### PR TITLE
docs: correct the anndata claims in the comment, handout and pin

### DIFF
--- a/handouts/pandas-3-string-dtypes.md
+++ b/handouts/pandas-3-string-dtypes.md
@@ -101,9 +101,27 @@ Verified against anndata 0.12.2 with `infer_string=True`:
 | default | `IORegistryError` on `ArrowStringArrayNumpySemantics` |
 | `ad.settings.allow_write_nullable_strings = True` | still `IORegistryError` |
 | `pd.set_option("mode.string_storage", "python")` | still fails, now on `StringArrayNumpySemantics` |
+| both of the above together | still fails, on `StringArrayNumpySemantics` |
 
-So a Thyra-side fix is the only option short of raising the anndata ceiling
-past a release that does not exist yet.
+That last row is worth stating explicitly, because **on pandas 3 proper the
+combination does work.** Measured on pandas 3.0.5 + pyarrow 25.0.0 + anndata
+0.12.2: `mode.string_storage="python"` together with
+`allow_write_nullable_strings = True` writes cleanly, with values, index and
+categorical dtype all intact. Neither setting alone is enough there either --
+anndata 0.12.x has a `StringArray` writer gated behind that setting and no
+`ArrowStringArray` writer at all, so you have to leave Arrow storage *and*
+unlock nullable strings.
+
+It does not help under `infer_string` on pandas 2, which is what CI runs,
+because there the arrays are the `*NumpySemantics` subclasses that no writer
+matches.
+
+Either way it is the wrong tool for a library: both are global process state,
+and Thyra should not flip pandas and anndata settings on its users' behalf. A
+local coercion at the write chokepoint stays the right layer.
+
+So a Thyra-side fix is the right option until the `anndata` ceiling moves to
+`>= 0.13`.
 
 ### It is reachable today
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,10 +92,21 @@ zarr = ">=3.0.0, <3.2"              # tested 3.1.3
 imagecodecs = ">=2024.1.1"  # For reading compressed TIFF optical images
 # Moving this ceiling is the removal trigger for the pandas 3 string-dtype
 # coercion in base_spatialdata_converter.py: anndata 0.12.19 carries its own
-# `pandas<3` cap, so bumping to a release with pandas 3 support (#2221,
-# milestone 0.14.0) both opens the pandas 3 door and makes that coercion dead
-# code. Delete it in the same change.
-anndata = ">=0.11.0, <0.13"         # tested 0.12.2
+# `pandas<3` cap, so bumping to a release with pandas 3 support both opens the
+# pandas 3 door and makes that coercion dead code.
+#
+# That release is anndata 0.13.0 (anndata #2221, fixed by anndata #2133). Do
+# not trust #2221's milestone label, which still reads 0.14.0 even though the
+# fix shipped in 0.13.0.
+#
+# The bump is NOT mechanical -- see issue #117, where it was measured:
+#   - anndata 0.13.x requires Python >= 3.12, which this project does not.
+#   - anndata 0.13 moved `X` into `layers` under a None key, which spatialdata
+#     0.7.3's validate_table_attr_keys chokes on, breaking every write path.
+#     Fixed by spatialdata #1122, which is in v0.8.0 -- so this ceiling cannot
+#     move until the spatialdata ceiling does, despite 0.7.3 declaring only
+#     `anndata>=0.9.1`.
+anndata = ">=0.11.0, <0.13"         # tested 0.12.2; 0.13.2 fails, see #117
 psutil = ">=5.0.0"
 
 [tool.poetry.group.test.dependencies]

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -1836,9 +1836,13 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
     # anndata #2377 is this exact IORegistryError, closed as a duplicate of
     # it, and spatialdata-io #364 is the same failure in spatialdata's own
     # Xenium writer, so this is an ecosystem gap and not a Thyra bug.
-    # anndata's documented escape hatches do not help on the pinned 0.12.2:
-    # `ad.settings.allow_write_nullable_strings = True` and
-    # `pd.set_option("mode.string_storage", "python")` both still raise.
+    # anndata's documented escape hatches do not help individually on the
+    # pinned 0.12.2: `ad.settings.allow_write_nullable_strings = True` and
+    # `pd.set_option("mode.string_storage", "python")` each still raise. On
+    # pandas 3 the two together do write cleanly, but they are global process
+    # state that a library has no business setting for its users, and they do
+    # not help at all under future.infer_string on pandas 2, which is what CI
+    # runs. A local coercion here stays the right layer.
     #
     # Delete `_coerce_table_strings_to_object` and its call in `_save_output`
     # once the anndata ceiling in pyproject.toml moves to >= 0.13. Verified


### PR DESCRIPTION
Two comment/doc corrections, no behaviour change.

**1. The escape hatches work in combination on pandas 3.** #118 said both of anndata's documented hatches still raise, which reads as though no settings-only workaround exists. Each does still raise alone, but together they work. Measured on pandas 3.0.5 + pyarrow 25.0.0 + anndata 0.12.2:

| `mode.string_storage` | `allow_write_nullable_strings` | result |
|---|---|---|
| default (arrow) | False | `IORegistryError` on `ArrowStringArray` |
| default (arrow) | True | `IORegistryError` on `ArrowStringArray` |
| `python` | False | `RuntimeError` on `allow_write_nullable_strings` |
| `python` | True | wrote fine, values / index / categorical dtype intact |

Still the wrong tool here: both are global process state, and neither helps under `future.infer_string` on pandas 2, which is what CI runs. The coercion stays.

**2. The `anndata` pin comment cited the wrong prerequisites.** It named #2221's milestone as 0.14.0; the fix shipped in 0.13.0 and the label is wrong. Replaced with what #117 actually measured: the bump needs Python >= 3.12, and needs spatialdata >= 0.8.0 because anndata 0.13 moved `X` into `layers` under a `None` key that spatialdata 0.7.3's validation cannot handle. That coupling is invisible from metadata, since 0.7.3 declares `anndata>=0.9.1` with no cap.

Comments and docs only. 643 passed / 11 skipped / 1 xfailed; black, isort, flake8, mypy, bandit, pydocstyle clean.