### PR TITLE
[test] throwaway: does an unfiltered pull_request trigger fire on a non-main base?

### DIFF
--- a/.github/workflows/complexity-monitoring.yml
+++ b/.github/workflows/complexity-monitoring.yml
@@ -3,8 +3,11 @@ name: Complexity Monitoring
 on:
   push:
     branches: [ main, develop ]
+  # Deliberately unfiltered, as in tests.yml: `branches:` here would match the
+  # PR's BASE branch, which silently excludes stacked PRs. The `push:` filter
+  # above is left narrow on purpose -- this should not start running on every
+  # push to every feature branch, only on the PRs those branches open.
   pull_request:
-    branches: [ main, develop ]
   schedule:
     # Run weekly on Sundays at 2 AM UTC
     - cron: '0 2 * * 0'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,13 @@
 name: Tests
 
 on:
+  # Deliberately unfiltered. `branches:` on a pull_request trigger matches the
+  # BASE branch, not the head, so `branches: [ main ]` skipped every stacked PR
+  # (one feature branch based on another) until its parent merged and GitHub
+  # retargeted it onto main -- i.e. the tests only ran after review, never
+  # before. There is no `push:` trigger in this workflow, so accepting every
+  # base branch cannot double up with anything.
   pull_request:
-    branches: [ main ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Throwaway draft opened to empirically verify the trigger change in #132 before recommending a merge. Base is a feature branch, not main. If checks appear here, an unfiltered `pull_request` trigger does fire on a non-main base, and GitHub resolves the workflow from the PR merge ref. Closing as soon as the answer is in -- do not review or merge.