### PR TITLE
ci(release): make the release guard report what actually happened

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,22 +54,38 @@ jobs:
       - name: Create Release
         id: release
         run: |
-          # Check if a new version is pending
+          # `--print` reports the version semantic-release WOULD release. When
+          # nothing on main is releasable -- a ci:/chore:/docs:/test: commit --
+          # it prints the CURRENT version, not an empty string. So an emptiness
+          # test can never fire, and what actually stopped the no-op release was
+          # the already-tagged guard below, reporting a concurrent run that
+          # never happened. Compare against the last released version instead,
+          # which is the thing "is there a release to cut?" really asks.
           NEXT=$(semantic-release version --print 2>/dev/null || true)
+          LAST=$(semantic-release version --print-last-released 2>/dev/null || true)
+          echo "next=${NEXT:-<none>} last-released=${LAST:-<none>}"
+
           if [ -z "$NEXT" ]; then
-            echo "No release needed"
+            echo "No release: semantic-release could not determine a version."
             echo "released=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          # Guard: skip if this version is already tagged (race condition)
-          if git tag -l "v$NEXT" | grep -q "v$NEXT"; then
-            echo "Tag v$NEXT already exists -- skipping (concurrent run)"
+          if [ "$NEXT" = "$LAST" ]; then
+            echo "No release: nothing releasable since v$LAST (no feat/fix/perf commits)."
             echo "released=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          echo "Creating release: $NEXT"
+          # Past this point $NEXT is a genuine bump, so an existing tag really
+          # does mean another run got there first.
+          if git rev-parse -q --verify "refs/tags/v$NEXT" >/dev/null; then
+            echo "No release: v$NEXT is a new version but is already tagged -- a concurrent run created it."
+            echo "released=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Creating release: v${LAST:-<none>} -> v$NEXT"
 
           # Run semantic-release (creates commit, tag, and GitHub release)
           semantic-release version


### PR DESCRIPTION
## The defect

`release.yml`'s first guard has never run:

```bash
NEXT=$(semantic-release version --print 2>/dev/null || true)
if [ -z "$NEXT" ]; then
  echo "No release needed"
```

`semantic-release version --print` returns the **current** version when nothing
is releasable, not an empty string. `$NEXT` is never empty on this workflow's
trigger, so `-z` never fires. What actually stops a non-releasable merge is the
*tag* guard immediately below: the current version is already tagged, so it
takes the "already exists" path -- and logs `skipping (concurrent run)` for the
ordinary case of a `ci:`/`chore:`/`docs:` merge.

The harm is diagnostic, not functional. A quiet release run reads as
"semantic-release decided not to bump" when it actually means "we tried to
re-release the current version and the tag guard caught it" -- misleading in
exactly the situation where you are working out why a release did not happen.

## Evidence

**Measured on a real job log**, not inferred. PR #134 (`c47e3b2`) merged a
`ci:`-typed commit, which is not releasable. Its release run
([30704006695](https://github.com/M4i-Imaging-Mass-Spectrometry/thyra/actions/runs/30704006695))
logged:

```
Tag v2.2.3 already exists -- skipping (concurrent run)
```

Not "No release needed". No concurrent run existed.

Reproduced locally against semantic-release 10.6.1 (what the unpinned
`pip install python-semantic-release` in this workflow resolves to today), on
`main` at `c47e3b2`:

```
NEXT = 2.2.3   <- --print, non-empty, so -z cannot fire
LAST = 2.2.3   <- --print-last-released
```

## The fix

Compare `$NEXT` against `--print-last-released`, which is what "is there a
release to cut?" actually asks. The tag guard stays, for the thing it was meant
to catch: a genuine bump that another run already tagged.

Three distinct, honest outcomes:

| Situation | Log line |
|---|---|
| `ci:`/`chore:` merge, nothing releasable | `No release: nothing releasable since v2.2.3 (no feat/fix/perf commits).` |
| Real bump, tag already exists | `No release: v2.3.0 is a new version but is already tagged -- a concurrent run created it.` |
| Real bump, no tag | `Creating release: v2.2.3 -> v2.3.0` |

The empty-`$NEXT` branch is kept but relabelled to what it means. It is
reachable only when semantic-release itself errors -- e.g. on a branch outside
the configured release groups, where it exits non-zero with
`branch '<name>' isn't in any release groups` and `2>/dev/null || true`
flattens that to an empty string. That cannot happen on this workflow's
push-to-`main` trigger, which is why the branch was dead rather than merely
rare.

Also swaps `git tag -l "v$NEXT" | grep -q "v$NEXT"` -- a substring match over a
tag listing -- for `git rev-parse -q --verify "refs/tags/v$NEXT"`, an exact ref
lookup.

## Verification

The five branches were exercised against the real repository with the
`semantic-release version` call stubbed:

```
REAL HEAD (ci: merge)                  -> next=2.2.3 last=2.2.3  -> nothing releasable, released=false
FORCED bump to already-tagged 2.2.3    -> concurrent run,          released=false
FORCED untagged bump 2.2.3 -> 2.3.0    -> Creating release,        released=true version=2.3.0
FORCED semantic-release produced nothing-> could not determine,     released=false
FORCED first ever release (LAST empty) -> Creating release,        released=true version=9.9.9
```

## Stored values

**No change.** This is CI-only and touches no library code. No release-behaviour
change either: every path that released before still releases, every path that
skipped still skips -- only the reported reason changes.

This commit is `ci:`-typed and therefore not itself releasable, so merging it
will exercise the new "nothing releasable" branch on its own release run.