### PR TITLE
feat(imzml): take spectrum representation explicitly, as SCiLS does

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -196,6 +196,42 @@ thyra input.imzML output.zarr --sparse-format csr
 
 ---
 
+## imzML-Specific
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--spectrum-type TYPE` | `auto` | `auto`, `profile`, or `centroid` -- declare the spectrum representation instead of detecting it |
+
+By default Thyra reads the representation the file declares (`MS:1000127`
+centroid / `MS:1000128` profile), wherever in the document it is written, and
+only guesses when the file declares neither. `--spectrum-type` overrides all of
+that.
+
+SCiLS Lab exposes the same control as `--rep_type PROFILE|CENTROID` (2026b User
+Guide, p.81).
+
+!!! warning "This changes stored values"
+    The representation is not just a label: it feeds instrument detection,
+    which picks the mass-axis type, which decides the bin spacing. Overriding
+    it changes the axis a dataset is resampled onto, and therefore the numbers
+    written to the store. It changes nothing for anyone who does not pass it.
+
+    Use it when a file declares the wrong thing -- that does happen. When the
+    override contradicts an explicit declaration Thyra logs a warning naming
+    both values; run with `-v INFO` to see it, and check the result.
+
+### Examples
+
+```bash
+# The file says centroid but it is really profile data
+thyra input.imzML output.zarr --spectrum-type profile
+
+# See what detection would have concluded before overriding it
+thyra input.imzML output.zarr -v INFO
+```
+
+---
+
 ## Bruker-Specific
 
 These options only apply when converting Bruker `.d` directories.

--- a/tests/unit/metadata/extractors/test_imzml_extractor.py
+++ b/tests/unit/metadata/extractors/test_imzml_extractor.py
@@ -426,3 +426,171 @@ class TestSpectrumTypeDetection:
             assert tree.select_strategy(metadata) == ResamplingMethod.NEAREST_NEIGHBOR
         finally:
             parser.m.close()
+
+
+def _capture(level, logger_name="thyra.metadata.extractors.imzml_extractor"):
+    """Collect (levelno, message) from a named logger.
+
+    ``caplog`` is unusable across this suite: ``setup_logging`` sets
+    ``propagate = False`` on the ``thyra`` logger and other tests leave that
+    state behind, so records never reach pytest's root handler.
+    """
+    records = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record):
+            records.append((record.levelno, record.getMessage()))
+
+    module_logger = logging.getLogger(logger_name)
+    handler = _Capture(level=level)
+    previous_level = module_logger.level
+    module_logger.addHandler(handler)
+    module_logger.setLevel(level)
+
+    class _Ctx:
+        def __enter__(self):
+            return records
+
+        def __exit__(self, *exc):
+            module_logger.removeHandler(handler)
+            module_logger.setLevel(previous_level)
+            return False
+
+    return _Ctx()
+
+
+class TestSpectrumTypeOverride:
+    """An explicit representation outranks the file, as SCiLS's --rep_type does.
+
+    Files do declare the wrong representation, so a user has to be able to say
+    what a file really is. That is also a good way to corrupt a conversion
+    silently, which is why contradicting a declaration is a warning and not a
+    debug line.
+    """
+
+    def _extractor(self, params, spectrum_type=None):
+        parser = Mock()
+        parser.metadata.file_description.param_by_name = params
+        return ImzMLMetadataExtractor(
+            parser, Path("/does/not/exist.imzML"), spectrum_type=spectrum_type
+        )
+
+    def test_override_beats_a_contradicting_declaration(self):
+        """The point of the feature: correct a file that declares wrongly."""
+        extractor = self._extractor(
+            {"profile spectrum": True, "processed": True}, spectrum_type="centroid"
+        )
+        assert extractor._detect_centroid_spectrum() == "centroid spectrum"
+
+    def test_override_beats_a_declaration_the_other_way(self):
+        extractor = self._extractor(
+            {"centroid spectrum": True, "processed": True}, spectrum_type="profile"
+        )
+        assert extractor._detect_centroid_spectrum() == "profile spectrum"
+
+    def test_override_replaces_the_storage_mode_guess(self):
+        """With nothing declared, the override stands in for the guess."""
+        extractor = self._extractor({"processed": True}, spectrum_type="profile")
+        assert extractor._detect_centroid_spectrum() == "profile spectrum"
+
+    def test_override_answers_where_detection_gives_up(self):
+        """Undeclared + continuous detects as None; the override still answers."""
+        assert self._extractor({"continuous": True})._detect_centroid_spectrum() is None
+        extractor = self._extractor({"continuous": True}, spectrum_type="centroid")
+        assert extractor._detect_centroid_spectrum() == "centroid spectrum"
+
+    def test_no_override_leaves_detection_untouched(self):
+        """The default must change nothing for anyone who does not opt in."""
+        extractor = self._extractor({"profile spectrum": True, "processed": True})
+        assert extractor.spectrum_type_override is None
+        assert extractor._detect_centroid_spectrum() == "profile spectrum"
+
+    def test_contradicting_the_file_warns_and_names_both(self):
+        with _capture(logging.WARNING) as records:
+            extractor = self._extractor(
+                {"profile spectrum": True, "processed": True},
+                spectrum_type="centroid",
+            )
+            extractor._detect_centroid_spectrum()
+        warnings = [m for level, m in records if level >= logging.WARNING]
+        assert warnings, "contradicting a declaration must warn"
+        assert any("CONTRADICTS" in m for m in warnings)
+        assert any(
+            "centroid spectrum" in m and "profile spectrum" in m for m in warnings
+        )
+
+    def test_agreeing_with_the_file_does_not_warn(self):
+        with _capture(logging.INFO) as records:
+            extractor = self._extractor(
+                {"profile spectrum": True, "processed": True},
+                spectrum_type="profile",
+            )
+            extractor._detect_centroid_spectrum()
+        assert not [m for level, m in records if level >= logging.WARNING]
+        assert any("agrees with the file" in m for _, m in records)
+
+    def test_overriding_an_undeclared_file_does_not_warn(self):
+        """There is nothing to contradict, so this is not the dangerous case."""
+        with _capture(logging.INFO) as records:
+            extractor = self._extractor({"processed": True}, spectrum_type="centroid")
+            extractor._detect_centroid_spectrum()
+        assert not [m for level, m in records if level >= logging.WARNING]
+        assert any("declares neither" in m for _, m in records)
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("profile", "profile spectrum"),
+            ("PROFILE", "profile spectrum"),
+            ("  Profile  ", "profile spectrum"),
+            ("profile spectrum", "profile spectrum"),
+            ("centroid", "centroid spectrum"),
+            ("CENTROID", "centroid spectrum"),
+            ("centroided", "centroid spectrum"),
+            ("centroid spectrum", "centroid spectrum"),
+        ],
+    )
+    def test_accepted_spellings(self, value, expected):
+        """SCiLS writes PROFILE/CENTROID; the CV names round-trip out of a store."""
+        extractor = self._extractor({"processed": True}, spectrum_type=value)
+        assert extractor.spectrum_type_override == expected
+
+    @pytest.mark.parametrize("value", ["profil", "prófile", "MS:1000128", "", "true"])
+    def test_a_typo_fails_loudly_at_construction(self, value):
+        """Silently ignoring a typo would hand the file back to auto-detection."""
+        with pytest.raises(ValueError, match="Unknown spectrum_type"):
+            self._extractor({"processed": True}, spectrum_type=value)
+
+    def test_a_non_string_is_rejected(self):
+        with pytest.raises(ValueError, match="must be a string or None"):
+            self._extractor({"processed": True}, spectrum_type=True)
+
+    @pytest.mark.parametrize(
+        "declared,override,expected",
+        [
+            ("profile", "centroid", "centroid spectrum"),
+            ("centroid", "profile", "profile spectrum"),
+        ],
+    )
+    def test_real_file_end_to_end(self, tmp_path, declared, override, expected):
+        """On a real imzML, the override is what gets stored."""
+        path = _write_imzml(tmp_path, f"ovr_{declared}", declared)
+        parser = ImzMLParser(str(path), parse_lib="ElementTree")
+        try:
+            extractor = ImzMLMetadataExtractor(parser, path, spectrum_type=override)
+            assert extractor._detect_centroid_spectrum() == expected
+            assert extractor.get_essential().spectrum_type == expected
+        finally:
+            parser.m.close()
+
+    def test_real_file_without_override_is_unchanged(self, tmp_path):
+        """The regression guard: opting out must behave exactly as before."""
+        path = _write_imzml(tmp_path, "no_ovr", "profile")
+        parser = ImzMLParser(str(path), parse_lib="ElementTree")
+        try:
+            assert (
+                ImzMLMetadataExtractor(parser, path).get_essential().spectrum_type
+                == "profile spectrum"
+            )
+        finally:
+            parser.m.close()

--- a/tests/unit/readers/test_imzml_reader.py
+++ b/tests/unit/readers/test_imzml_reader.py
@@ -329,3 +329,64 @@ class TestCrlfUnindentedImzML:
         reader.close()
 
         assert essential.n_spectra == 16000
+
+
+def _write_two_pixel_imzml(directory: Path, name: str, spec_type: str) -> Path:
+    """A minimal processed imzML declaring the given representation."""
+    path = directory / f"{name}.imzML"
+    mzs = np.linspace(100.0, 1000.0, 50)
+    intensities = np.zeros_like(mzs)
+    intensities[10] = 100.0
+    with ImzMLWriter(str(path), mode="processed", spec_type=spec_type) as writer:
+        writer.addSpectrum(mzs, intensities, (1, 1, 1))
+        writer.addSpectrum(mzs, intensities, (2, 1, 1))
+    return path
+
+
+class TestSpectrumTypeReaderOption:
+    """``reader_options={"spectrum_type": ...}`` has to reach the extractor.
+
+    The extractor is where the decision is made, but it is constructed by the
+    reader, so the value has to be threaded. This is the join that a unit test
+    on the extractor alone would not catch.
+    """
+
+    def test_absent_means_detect(self, tmp_path):
+        path = _write_two_pixel_imzml(tmp_path, "detect", "profile")
+        reader = ImzMLReader(path)
+        try:
+            assert reader.spectrum_type is None
+            assert reader.get_essential_metadata().spectrum_type == "profile spectrum"
+        finally:
+            reader.close()
+
+    @pytest.mark.parametrize(
+        "declared,override,expected",
+        [
+            ("profile", "centroid", "centroid spectrum"),
+            ("centroid", "profile", "profile spectrum"),
+        ],
+    )
+    def test_override_reaches_the_stored_metadata(
+        self, tmp_path, declared, override, expected
+    ):
+        path = _write_two_pixel_imzml(tmp_path, f"ovr_{declared}", declared)
+        reader = ImzMLReader(path, spectrum_type=override)
+        try:
+            assert reader.get_essential_metadata().spectrum_type == expected
+        finally:
+            reader.close()
+
+    def test_reader_normalises_before_storing(self, tmp_path):
+        path = _write_two_pixel_imzml(tmp_path, "norm", "profile")
+        reader = ImzMLReader(path, spectrum_type="CENTROID")
+        try:
+            assert reader.spectrum_type == "centroid spectrum"
+        finally:
+            reader.close()
+
+    def test_a_bad_value_fails_at_construction(self, tmp_path):
+        """Fail while the caller is still looking at its own arguments."""
+        path = _write_two_pixel_imzml(tmp_path, "bad", "profile")
+        with pytest.raises(ValueError, match="Unknown spectrum_type"):
+            ImzMLReader(path, spectrum_type="profil")

--- a/tests/unit/test_cli_spectrum_type.py
+++ b/tests/unit/test_cli_spectrum_type.py
@@ -1,0 +1,63 @@
+# tests/unit/test_cli_spectrum_type.py
+"""``--spectrum-type`` on the command line, the way SCiLS exposes ``--rep_type``.
+
+The flag is only a transport: it builds ``reader_options["spectrum_type"]``,
+which the imzML reader forwards to the metadata extractor. What is worth
+pinning here is the transport, and in particular that ``auto`` -- the CLI's
+spelling of "no override" -- is *omitted* rather than forwarded, because
+``"auto"`` is not a spectrum representation and the reader would reject it.
+"""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from thyra.__main__ import _build_reader_options, main
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+class TestBuildReaderOptions:
+    def test_auto_is_not_forwarded(self):
+        """Passing "auto" through would raise ValueError in the reader."""
+        options = _build_reader_options(True, None, "auto")
+        assert "spectrum_type" not in options
+
+    def test_default_is_auto(self):
+        """Callers that predate the flag must keep getting no override."""
+        assert "spectrum_type" not in _build_reader_options(True, None)
+
+    @pytest.mark.parametrize("value", ["profile", "centroid"])
+    def test_an_explicit_choice_is_forwarded_verbatim(self, value):
+        assert _build_reader_options(True, None, value)["spectrum_type"] == value
+
+    def test_it_does_not_disturb_the_other_options(self):
+        options = _build_reader_options(False, 12.5, "profile")
+        assert options["use_recalibrated_state"] is False
+        assert options["intensity_threshold"] == 12.5
+        assert options["spectrum_type"] == "profile"
+
+
+class TestFlagSurface:
+    def test_help_advertises_the_choices(self, runner):
+        result = runner.invoke(main, ["--help"])
+        assert result.exit_code == 0
+        assert "--spectrum-type" in result.output
+
+    def test_an_invalid_choice_is_rejected_by_click(self, runner, tmp_path):
+        """click.Choice rejects it before any file is touched."""
+        result = runner.invoke(
+            main,
+            [
+                str(tmp_path / "in.imzML"),
+                str(tmp_path / "out.zarr"),
+                "--spectrum-type",
+                "profil",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "profil" in result.output

--- a/thyra/__main__.py
+++ b/thyra/__main__.py
@@ -261,11 +261,21 @@ def _build_resampling_config(
 def _build_reader_options(
     use_recalibrated: bool,
     intensity_threshold: Optional[float],
-) -> dict[str, bool | float]:
-    """Build reader options dictionary from CLI parameters."""
-    options: dict[str, bool | float] = {"use_recalibrated_state": use_recalibrated}
+    spectrum_type: str = "auto",
+) -> dict[str, bool | float | str]:
+    """Build reader options dictionary from CLI parameters.
+
+    ``spectrum_type="auto"`` is the CLI's way of saying "no override", so it is
+    omitted entirely rather than forwarded -- readers take ``None``/absent to
+    mean detect, and ``"auto"`` is not a representation.
+    """
+    options: dict[str, bool | float | str] = {
+        "use_recalibrated_state": use_recalibrated
+    }
     if intensity_threshold is not None:
         options["intensity_threshold"] = intensity_threshold
+    if spectrum_type != "auto":
+        options["spectrum_type"] = spectrum_type
     return options
 
 
@@ -548,6 +558,17 @@ class GroupedCommand(click.Command):
         "(default: no limit)"
     ),
 )
+@click.option(
+    "--spectrum-type",
+    type=click.Choice(["auto", "profile", "centroid"]),
+    default="auto",
+    help=(
+        "Spectrum representation (default: auto-detect from the file). "
+        "Overrides what the imzML declares via MS:1000127/MS:1000128; "
+        "contradicting a declaration is logged as a warning. SCiLS Lab spells "
+        "this --rep_type. imzML only."
+    ),
+)
 # -- Bruker-specific --
 @click.option(
     "--use-recalibrated/--no-recalibrated",
@@ -597,6 +618,7 @@ def main(
     resample_reference_mz: float,
     resample_gap_tolerance: Optional[float],
     mass_axis_type: str,
+    spectrum_type: str,
     sparse_format: str,
     include_optical: bool,
     intensity_threshold: Optional[float],
@@ -664,7 +686,9 @@ def main(
     )
 
     # Build reader options for format-specific settings
-    reader_options = _build_reader_options(use_recalibrated, intensity_threshold)
+    reader_options = _build_reader_options(
+        use_recalibrated, intensity_threshold, spectrum_type
+    )
 
     # Perform conversion
     success = convert_msi(

--- a/thyra/convert.py
+++ b/thyra/convert.py
@@ -290,6 +290,17 @@ def convert_msi(
               which is the limit SCiLS Lab places on the same
               quantity (2026b User Guide, p.76). Pass None for
               no limit.
+            - spectrum_type: str - For imzML, declare the spectrum
+              representation explicitly: 'profile' or 'centroid'
+              (the full CV names are accepted too). Outranks the
+              file's own MS:1000127/MS:1000128, so it can correct a
+              file that declares the wrong thing; contradicting a
+              declaration is logged as a warning. SCiLS Lab spells
+              this --rep_type (2026b User Guide, p.81). Default:
+              None, meaning detect. **Changes stored values** for
+              files where it disagrees with what detection would
+              have chosen, because the representation feeds
+              instrument and axis-type selection.
         sparse_format: Sparse matrix format ('csc' or 'csr')
         include_optical: Include optical images (default: True)
         apply_optical_alignment: If True (default) and the MSI source

--- a/thyra/metadata/extractors/imzml_extractor.py
+++ b/thyra/metadata/extractors/imzml_extractor.py
@@ -9,7 +9,12 @@ from numpy.typing import NDArray
 from pyimzml.ImzMLParser import ImzMLParser
 
 from ...core.base_extractor import MetadataExtractor
-from ...resampling.constants import BinaryDataType, ImzMLAccessions, SpectrumType
+from ...resampling.constants import (
+    BinaryDataType,
+    ImzMLAccessions,
+    SpectrumType,
+    normalize_spectrum_type,
+)
 from ..types import ComprehensiveMetadata, EssentialMetadata
 
 logger = logging.getLogger(__name__)
@@ -18,16 +23,32 @@ logger = logging.getLogger(__name__)
 class ImzMLMetadataExtractor(MetadataExtractor):
     """ImzML-specific metadata extractor with optimized two-phase extraction."""
 
-    def __init__(self, parser: ImzMLParser, imzml_path: Path):
+    def __init__(
+        self,
+        parser: ImzMLParser,
+        imzml_path: Path,
+        spectrum_type: Optional[str] = None,
+    ):
         """Initialize ImzML metadata extractor.
 
         Args:
             parser: Initialized ImzML parser
             imzml_path: Path to the ImzML file
+            spectrum_type: Optional override for the spectrum representation,
+                ``"profile"`` or ``"centroid"`` (SCiLS Lab spells this
+                ``--rep_type``). When given, it wins over anything the file
+                says. ``None`` -- the default -- leaves detection alone.
+
+        Raises:
+            ValueError: If ``spectrum_type`` is not a recognised
+                representation.
         """
         super().__init__(parser)
         self.parser = parser
         self.imzml_path = imzml_path
+        # Normalised at construction so a typo fails here rather than silently
+        # falling through to auto-detection during extraction.
+        self.spectrum_type_override = normalize_spectrum_type(spectrum_type)
 
     def _extract_essential_impl(self) -> EssentialMetadata:
         """Extract essential metadata optimized for speed."""
@@ -524,12 +545,19 @@ class ImzMLMetadataExtractor(MetadataExtractor):
     def _detect_centroid_spectrum(self) -> Optional[str]:
         """Detect spectrum type by looking for MS:1000127 (centroid) or MS:1000128 (profile).
 
-        What the file *declares* wins, wherever it is written. Only when the
-        file declares nothing does Thyra guess -- see
+        An explicit ``spectrum_type`` override wins over everything, so a user
+        can correct a file that declares the wrong thing. Otherwise what the
+        file *declares* wins, wherever it is written, and only when the file
+        declares nothing does Thyra guess -- see
         :meth:`_guess_spectrum_type_from_storage_mode` for what that guess is
         worth.
         """
         try:
+            # 0. An explicit override outranks the file.
+            if self.spectrum_type_override is not None:
+                self._report_spectrum_type_override()
+                return self.spectrum_type_override
+
             # 1. The declaration, from metadata the parser already holds.
             result = self._check_parser_metadata_for_spectrum_type()
             if result:
@@ -546,6 +574,49 @@ class ImzMLMetadataExtractor(MetadataExtractor):
         except Exception as e:
             logger.debug(f"Could not detect spectrum type: {e}")
             return None
+
+    def _report_spectrum_type_override(self) -> None:
+        """Log an override, loudly when it contradicts the file's declaration.
+
+        Overriding a declared ``MS:1000127``/``MS:1000128`` is a legitimate
+        thing to want -- files do declare the wrong representation -- and it is
+        also a good way to corrupt a conversion silently. So the two cases are
+        not logged alike: agreeing with the file, or overriding a file that
+        declares nothing, is INFO; contradicting an explicit declaration is
+        WARNING and names both values.
+
+        This still reads the file's *declarations* (steps 1 and 2) in order to
+        compare, but never its guess -- there is nothing informative about
+        contradicting a guess. That costs at most the same bounded XML scan
+        detection would have done, and only on the opt-in path.
+        """
+        override = self.spectrum_type_override
+        declared = self._check_parser_metadata_for_spectrum_type()
+        if declared is None:
+            declared = self._check_xml_for_spectrum_type()
+
+        if declared is None:
+            logger.info(
+                "Using spectrum_type override %r; the file declares neither %s "
+                "(centroid) nor %s (profile).",
+                override,
+                ImzMLAccessions.CENTROID_SPECTRUM,
+                ImzMLAccessions.PROFILE_SPECTRUM,
+            )
+        elif declared == override:
+            logger.info(
+                "Using spectrum_type override %r, which agrees with the file.",
+                override,
+            )
+        else:
+            logger.warning(
+                "spectrum_type override %r CONTRADICTS the file, which declares "
+                "%r. Proceeding with the override -- the stored spectrum type, "
+                "and any decision Thyra makes from it, will not match what the "
+                "file says about itself. Remove the override to trust the file.",
+                override,
+                declared,
+            )
 
     def _check_xml_for_spectrum_type(self) -> Optional[str]:
         """Check XML for spectrum type markers using streaming parser.

--- a/thyra/readers/imzml/imzml_reader.py
+++ b/thyra/readers/imzml/imzml_reader.py
@@ -12,6 +12,7 @@ from ...core.base_extractor import MetadataExtractor
 from ...core.base_reader import BaseMSIReader
 from ...core.registry import register_reader
 from ...metadata.extractors.imzml_extractor import ImzMLMetadataExtractor
+from ...resampling.constants import normalize_spectrum_type
 
 logger = logging.getLogger(__name__)
 
@@ -351,6 +352,14 @@ class ImzMLReader(BaseMSIReader):
                 ``DEFAULT_MAX_MASS_AXIS_LENGTH`` (10 million, SCiLS Lab's own
                 limit); pass ``None`` explicitly for unlimited. See
                 ``_extract_continuous_mass_axis``.
+
+                ``spectrum_type`` declares the spectrum representation
+                explicitly -- ``"profile"`` or ``"centroid"`` -- instead of
+                letting Thyra read or guess it. SCiLS Lab spells the same thing
+                ``--rep_type``. Use it when a file declares the wrong
+                representation; it outranks the file's own ``MS:1000127`` /
+                ``MS:1000128``, and contradicting a declaration is logged as a
+                warning. Defaults to ``None`` (detect).
         """
         super().__init__(data_path, **kwargs)
         self.filepath: Optional[Union[str, Path]] = data_path
@@ -360,6 +369,11 @@ class ImzMLReader(BaseMSIReader):
         # so this cannot be a bare ``.get(...)`` with a None fallback.
         self.max_mass_axis_length: Optional[int] = kwargs.get(
             "max_mass_axis_length", DEFAULT_MAX_MASS_AXIS_LENGTH
+        )
+        # Validated here rather than at extraction time, so a bad value fails
+        # while the caller is still looking at its own arguments.
+        self.spectrum_type: Optional[str] = normalize_spectrum_type(
+            kwargs.get("spectrum_type")
         )
         self.parser: Optional[ImzMLParser] = None
         self.ibd_file: Optional[Any] = None
@@ -499,7 +513,9 @@ class ImzMLReader(BaseMSIReader):
         if not self.imzml_path:
             raise ValueError("ImzML path not available")
 
-        return ImzMLMetadataExtractor(self.parser, self.imzml_path)
+        return ImzMLMetadataExtractor(
+            self.parser, self.imzml_path, spectrum_type=self.spectrum_type
+        )
 
     @property
     def has_shared_mass_axis(self) -> bool:

--- a/thyra/resampling/constants.py
+++ b/thyra/resampling/constants.py
@@ -1,5 +1,7 @@
 """Constants for resampling and instrument detection."""
 
+from typing import Dict, Optional
+
 
 class ImzMLAccessions:
     """PSI-MS and imzML controlled vocabulary accession codes."""
@@ -35,6 +37,51 @@ class SpectrumType:
 
     CENTROID = "centroid spectrum"
     PROFILE = "profile spectrum"
+
+
+# What a caller may write for a spectrum representation, mapped to the CV name
+# Thyra stores. The bare words match SCiLS Lab's ``--rep_type PROFILE|CENTROID``
+# (2026b User Guide p.81); the full CV names are what MS:1000127 / MS:1000128
+# are called, and are what comes back out of the store, so both are accepted.
+SPECTRUM_TYPE_ALIASES: Dict[str, str] = {
+    "centroid": SpectrumType.CENTROID,
+    "centroided": SpectrumType.CENTROID,
+    "centroid spectrum": SpectrumType.CENTROID,
+    "profile": SpectrumType.PROFILE,
+    "profile spectrum": SpectrumType.PROFILE,
+}
+
+
+def normalize_spectrum_type(value: Optional[object]) -> Optional[str]:
+    """Map a user-supplied spectrum representation onto a :class:`SpectrumType`.
+
+    Args:
+        value: ``"profile"``, ``"centroid"``, either CV name, or ``None``.
+            Case and surrounding whitespace are ignored.
+
+    Returns:
+        The matching :class:`SpectrumType` constant, or ``None`` for ``None``.
+
+    Raises:
+        ValueError: If the value is not a recognised representation. A typo
+            here would otherwise be indistinguishable from "no override" and
+            would silently hand the file back to auto-detection, so this fails
+            loudly instead.
+    """
+    if value is None:
+        return None
+
+    if not isinstance(value, str):
+        raise ValueError(
+            f"spectrum_type must be a string or None, got {type(value).__name__}"
+        )
+
+    key = value.strip().lower()
+    if key in SPECTRUM_TYPE_ALIASES:
+        return SPECTRUM_TYPE_ALIASES[key]
+
+    accepted = ", ".join(repr(k) for k in sorted(SPECTRUM_TYPE_ALIASES))
+    raise ValueError(f"Unknown spectrum_type {value!r}. Accepted values: {accepted}.")
 
 
 class BinaryDataType:


### PR DESCRIPTION
Handout H item 4. **This adds user-facing API surface to a library with an external consumer, which the handout flags as the owner's call** -- so this is opened for a decision, not merged on green.

SCiLS Lab's importer takes the representation as an argument (2026b User Guide p.81):

```
--rep_type arg   spectra representation (PROFILE, CENTROID)
```

Thyra only ever inferred it. After #127 the inference is sound -- it reads what the file declares and guesses only when the file declares nothing -- but a file that declares the **wrong** representation still cannot be corrected, and files do.

```python
convert_msi(..., reader_options={"spectrum_type": "profile"})
```
```bash
thyra input.imzML out.zarr --spectrum-type profile
```

## The three open questions, answered

**1. CLI flag, or `reader_options` only? Both.**

`max_mass_axis_length` is Python-API-only, which argues for API-only. But that is a guard rail against runaway memory, not a scientific input. Spectrum representation sits with `--mass-axis-type` and `--resample-method`, which are already on the CLI and are the same kind of thing -- a statement about the physics that changes the output. `_build_reader_options` already exists as the CLI-to-reader bridge and already carries two options, so the flag costs one entry.

`--spectrum-type auto` is the CLI's spelling of "no override" and is **omitted** from `reader_options` rather than forwarded, because `"auto"` is not a representation and the reader would reject it. That is pinned by a test.

**2. Reader or extractor? Both, threaded.**

The extractor is where the decision is made, so it takes `spectrum_type` and honours it at step 0 of `_detect_centroid_spectrum`, ahead of the declaration checks. The reader is where `reader_options` land, so it takes the value, normalises it, and passes it into `_create_metadata_extractor`. A unit test on the extractor alone would not catch a broken join, so the threading has its own tests.

**3. Warn on contradiction? Yes -- and not uniformly.**

| Situation | Level | Message |
|---|---|---|
| File declares nothing | INFO | `the file declares neither MS:1000127 nor MS:1000128` |
| Override agrees with the file | INFO | `agrees with the file` |
| **Override contradicts a declaration** | **WARNING** | `CONTRADICTS the file, which declares ...` -- names both values |

The third is the one that corrupts a conversion quietly, so it is the only one that shouts. To tell the cases apart, the override path still reads the file's *declarations* -- but never its *guess*; there is nothing informative about contradicting a guess. That costs at most the bounded XML scan detection would have done anyway, and only when someone opts in.

A bad value raises `ValueError` **at construction**, not at extraction time, because a silently-dropped typo is indistinguishable from passing no override at all. Accepted spellings are SCiLS's bare words plus the CV names, case- and whitespace-insensitive: `profile`, `PROFILE`, `profile spectrum`, `centroid`, `centroided`, `centroid spectrum`.

## Stored values: yes, for anyone who uses it

By construction -- that is the point of the feature. Representation feeds instrument detection, which picks the axis type, which sets bin spacing. **It changes nothing for anyone who does not pass it**, which is pinned by two regression tests.

Measured end to end on real data, converting each file with and without the override that contradicts what it declares:

| | pea (declares centroid) | | bellini (declares profile) | |
|---|---|---|---|---|
| | detect | `--spectrum-type profile` | detect | `--spectrum-type centroid` |
| stored `spectrum_type` | `centroid spectrum` | **`profile spectrum`** | *(see note)* | *(see note)* |
| bins | 460,495 | **179,997** | 708,847 | **2,373,513** |
| median spacing | 1.58 mDa | **5.00 mDa** | 5.00 mDa | **0.047 mDa** |
| first-256-pixel sum | 98,644,892 | 98,644,892 | 766,734 | 766,734 |

Total intensity is preserved either way -- `nearest_neighbor` is a count accumulator. What moves is the axis: 2.6x fewer bins for pea, 3.3x more for bellini (106x finer spacing). That is the whole effect, and it is exactly what choosing the representation is supposed to control.

**`read_lazy` opened all four results** and returned real values from each.

> **Note on bellini's stored label.** Its `uns["essential_metadata"]` comes back **empty on both paths** -- with and without the override -- while pea's is fully populated. That is a **pre-existing gap on bellini's converter branch, not something this PR causes**: the override plainly took effect (the axis changed), and `ImzMLReader(bellini).get_essential_metadata().spectrum_type` returns `'profile spectrum'` correctly, so detection is fine and the loss is downstream in the writer. Filed separately rather than folded in here.

## Tests

**37 new**, and the suite went 1072 -> **1109 passed, 11 skipped, 18 deselected** on this base -- exactly +37, so nothing regressed.

- 25 on the extractor: override beats a contradicting declaration both ways, replaces the storage-mode guess, answers where detection returns `None`, the no-override path is untouched, each log level fires on the right case, every accepted spelling, five typos and a non-string rejected, and a real-imzML round trip both directions.
- 5 on the reader: the option reaches stored metadata, normalisation happens before storing, a bad value fails at construction.
- 7 on the CLI: `auto` is not forwarded, the default is `auto`, explicit choices pass through verbatim, other reader options undisturbed, `click.Choice` rejects a typo before any file is touched.

`caplog` is unusable in this suite -- `setup_logging` sets `propagate = False` on the `thyra` logger and other tests leave that behind -- so the log assertions attach a handler to the named module logger, following `tests/unit/readers/test_bruker_region_selection.py`.

## Gates

```
pytest    1109 passed, 11 skipped, 18 deselected
black     clean      isort clean      flake8 clean
mypy      clean on all four changed files (36 pre-existing errors elsewhere, untouched)
mkdocs build --strict   clean
```

Docs: a new **imzML-Specific** section in `docs/cli.md` with the flag, the SCiLS equivalence, and a warning that it changes stored values.