### PR TITLE
fix(converters): stop the streaming-PCS path inventing its own provenance

### DIFF
--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -318,6 +318,39 @@ Instrument info, acquisition parameters, and resampling config are in
 print("uns keys:", list(msi_table.uns.keys()))
 ```
 
+### Provenance
+
+`uns["essential_metadata"]` records what the store was made from, and how
+the source was interpreted. It is the only place a converted dataset says
+where it came from, so it is written the same way by every converter path:
+
+```python
+provenance = msi_table.uns["essential_metadata"]
+
+print(provenance["source_path"])     # the file this was converted from
+print(provenance["dimensions"])      # source grid, [x, y, z]
+print(provenance["mass_range"])      # SOURCE m/z range, not the target axis
+print(provenance["spectrum_type"])   # "centroid spectrum" / "profile spectrum"
+print(provenance["thyra_version"])   # the Thyra that wrote the store
+```
+
+`mass_range` describes the source, not the resampled axis -- for the axis
+the data actually sits on, read `msi_table.var["mz"]`.
+
+Beside it, when the source format provides them:
+
+| Key | Contents |
+|-----|----------|
+| `format_specific` | Vendor metadata (imzML file mode and UUID, FlexImaging areas, teaching points) |
+| `acquisition_params` | Polarity, scan range, laser settings |
+| `instrument_info` | Instrument model, serial, software version |
+| `raw_metadata` | Source metadata as read, for round-trip fidelity |
+| `regions` | Acquisition region summary, as a JSON string (see [Regions](#regions)) |
+
+A section the source format has nothing for is omitted rather than written
+empty, so `"instrument_info" not in uns` means "this format does not carry
+it" rather than "it was carried and lost".
+
 ---
 
 ## Recipes

--- a/tests/fixtures/mock_msi_generator.py
+++ b/tests/fixtures/mock_msi_generator.py
@@ -89,7 +89,14 @@ class _MockMetadataExtractor(MetadataExtractor):
             total_peaks=self._n_spectra * avg_peaks,
             estimated_memory_gb=n_pixels * 150 * 8 / (1024**3),
             source_path="mock_msi_data",
-            spectrum_type="processed",
+            # Deliberately a value from the vocabulary the real extractors
+            # produce ("centroid spectrum" / "profile spectrum"), and
+            # deliberately NOT "processed".  The streaming-PCS writer used
+            # to hardcode "processed" into the stored provenance, and this
+            # fixture used to say "processed" too -- so every test agreed
+            # with the bug and none of them could see it.  Keep these two
+            # different.
+            spectrum_type="centroid spectrum",
         )
 
     def _extract_comprehensive_impl(self) -> ComprehensiveMetadata:

--- a/tests/unit/converters/test_uns_provenance_parity.py
+++ b/tests/unit/converters/test_uns_provenance_parity.py
@@ -1,0 +1,274 @@
+"""The provenance block in ``uns`` must survive, and agree, on every path.
+
+A converted store is supposed to be able to say where it came from and how
+it was interpreted: ``uns["essential_metadata"]`` carries ``source_path``,
+``dimensions``, ``mass_range``, ``spectrum_type`` and the ``thyra_version``
+that wrote it, and the sections beside it carry the vendor metadata.  Ousia
+reads those back out of the store; nothing else records them.
+
+There are three write paths and they had drifted:
+
+* the in-memory converter and the streaming-COO path hand the table to
+  anndata's writer, which serialises ``adata.uns`` as-is, and
+* the streaming-PCS path hand-writes the Zarr layout, and used to compose
+  its own, much smaller block -- ``spectrum_type`` hardcoded to
+  ``"processed"``, ``mass_range`` taken from the *resampled target axis*
+  rather than the source, ``source_path`` from a different attribute, and
+  ``format_specific`` / ``instrument_info`` / ``raw_metadata`` / ``regions``
+  dropped entirely.
+
+Which path a dataset takes is decided by size, in
+``StreamingSpatialDataConverter._should_use_pcs`` -- so two acquisitions
+off the same instrument landed on opposite sides of the split and came out
+described differently.  On ``test_data/``: ``pea.imzML`` estimates 29.9 GB
+(COO, complete provenance) and ``bellini.imzML`` 43.3 GB (PCS, wrong
+``spectrum_type``, everything else missing).  Ousia's import wizard forces
+``use_csc=True``, so *every* wizard conversion took the PCS path.
+
+Nothing caught it because ``MockMSIReader`` reported
+``spectrum_type="processed"`` too -- the fixture agreed with the hardcoded
+literal, so a test could compare them and pass.  The fixture now reports a
+value from the vocabulary the real extractors produce; see the comment on
+it.
+
+These tests convert the same mock dataset down all three paths and compare
+what each one stored.
+"""
+
+from typing import Any, Callable, Dict
+
+import numpy as np
+import pytest
+
+from tests.fixtures.mock_msi_generator import MockMSIConfig, MockMSIReader
+from thyra.converters.spatialdata.base_spatialdata_converter import (
+    SPATIALDATA_AVAILABLE,
+)
+from thyra.converters.spatialdata.spatialdata_2d_converter import SpatialData2DConverter
+from thyra.converters.spatialdata.streaming_converter import (
+    StreamingSpatialDataConverter,
+)
+
+pytestmark = pytest.mark.skipif(
+    not SPATIALDATA_AVAILABLE,
+    reason="SpatialData dependencies not available",
+)
+
+_DATASET_ID = "mock"
+_TABLE_NAME = f"{_DATASET_ID}_z0"
+_N_X = 6
+_N_Y = 6
+_N_MZ_BINS = 500
+
+# What the mock reader reports, and therefore what must come back out of
+# every store. Kept as literals rather than read off the fixture: the point
+# is that the stored value tracks the source, and a test that derives the
+# expectation from the same place the writer does cannot show that.
+_EXPECTED_SPECTRUM_TYPE = "centroid spectrum"
+_EXPECTED_SOURCE_PATH = "mock_msi_data"
+_EXPECTED_ESSENTIAL_KEYS = {
+    "source_path",
+    "dimensions",
+    "mass_range",
+    "spectrum_type",
+    "thyra_version",
+}
+
+
+def _config() -> MockMSIConfig:
+    return MockMSIConfig(
+        n_x=_N_X, n_y=_N_Y, n_mz_bins=_N_MZ_BINS, peaks_per_spectrum=(20, 40)
+    )
+
+
+def _in_memory(output_path):
+    """The default converter -- anything under the streaming threshold."""
+    return SpatialData2DConverter(
+        reader=MockMSIReader(_config()),
+        output_path=output_path,
+        dataset_id=_DATASET_ID,
+        pixel_size_um=10.0,
+    )
+
+
+def _streaming_coo(output_path):
+    """``streaming=True, use_csc=False`` -- writes via ``SpatialData.write()``."""
+    return StreamingSpatialDataConverter(
+        reader=MockMSIReader(_config()),
+        output_path=output_path,
+        dataset_id=_DATASET_ID,
+        pixel_size_um=10.0,
+        use_csc=False,
+    )
+
+
+def _streaming_pcs(output_path):
+    """``streaming=True, use_csc=True`` -- the hand-written Zarr layout."""
+    return StreamingSpatialDataConverter(
+        reader=MockMSIReader(_config()),
+        output_path=output_path,
+        dataset_id=_DATASET_ID,
+        pixel_size_um=10.0,
+        use_csc=True,
+    )
+
+
+WRITE_PATHS: Dict[str, Callable] = {
+    "in_memory": _in_memory,
+    "streaming_coo": _streaming_coo,
+    "streaming_pcs": _streaming_pcs,
+}
+
+
+def _convert(tmp_path_factory, path_name: str):
+    """Convert once through one write path; hand back the table group path."""
+    output_path = tmp_path_factory.mktemp(f"prov_{path_name}") / "out.zarr"
+    converter = WRITE_PATHS[path_name](output_path)
+    assert converter.convert() is True, f"{path_name} conversion failed"
+    return output_path / "tables" / _TABLE_NAME
+
+
+@pytest.fixture(scope="module")
+def stores(tmp_path_factory) -> Dict[str, Any]:
+    """One conversion per write path. Module-scoped: converting is the slow part."""
+    return {name: _convert(tmp_path_factory, name) for name in WRITE_PATHS}
+
+
+def _read_uns(table_path) -> Dict[str, Any]:
+    """Read ``uns`` back eagerly, as a plain dict."""
+    import anndata as ad
+    import zarr
+
+    return ad.io.read_elem(zarr.open_group(str(table_path), mode="r")["uns"])
+
+
+def _plain(value: Any) -> Any:
+    """Normalise for comparison across paths.
+
+    A list written by one path and an ndarray by another are the same
+    stored value; ``==`` on ndarrays is not a bool. Recurse so nested
+    sections compare too.
+    """
+    if isinstance(value, dict):
+        return {k: _plain(v) for k, v in value.items()}
+    if isinstance(value, np.ndarray):
+        return [_plain(v) for v in value.tolist()]
+    if isinstance(value, (list, tuple)):
+        return [_plain(v) for v in value]
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
+@pytest.mark.parametrize("path_name", list(WRITE_PATHS))
+def test_essential_metadata_is_not_empty(stores, path_name):
+    """The reported symptom: the block present but with nothing in it.
+
+    Deliberately the weakest assertion here, and deliberately first --
+    a store whose provenance is empty cannot say what it came from at
+    all, which is worse than one that says something inaccurate.
+    """
+    uns = _read_uns(stores[path_name])
+
+    assert "essential_metadata" in uns, f"{path_name} wrote no essential_metadata"
+    essential = uns["essential_metadata"]
+    assert essential, f"{path_name} wrote an EMPTY essential_metadata block"
+    assert set(essential) == _EXPECTED_ESSENTIAL_KEYS
+
+
+@pytest.mark.parametrize("path_name", list(WRITE_PATHS))
+def test_stored_spectrum_type_is_the_readers(stores, path_name):
+    """``spectrum_type`` must come from the data, not from a literal.
+
+    The PCS path wrote ``"processed"`` for everything. That is not a
+    value any extractor produces, so a consumer could neither trust it
+    nor tell it apart from a real reading -- which is the whole failure:
+    losing provenance *silently*.
+    """
+    essential = _read_uns(stores[path_name])["essential_metadata"]
+
+    assert essential["spectrum_type"] == _EXPECTED_SPECTRUM_TYPE, (
+        f"{path_name} stored spectrum_type={essential['spectrum_type']!r}; "
+        f"the reader reports {_EXPECTED_SPECTRUM_TYPE!r}"
+    )
+    assert essential["spectrum_type"] != "processed"
+
+
+@pytest.mark.parametrize("path_name", list(WRITE_PATHS))
+def test_essential_metadata_values_track_the_source(stores, path_name):
+    """The rest of the block must describe the source, not the output."""
+    essential = _read_uns(stores[path_name])["essential_metadata"]
+    cfg = _config()
+
+    assert essential["source_path"] == _EXPECTED_SOURCE_PATH
+    assert _plain(essential["dimensions"]) == [cfg.n_x, cfg.n_y, cfg.n_z]
+    # mass_range is the SOURCE range. The PCS path used to take it from
+    # the resampled target axis, which is a different quantity whenever
+    # resampling clips or extends the range.
+    assert _plain(essential["mass_range"]) == pytest.approx([cfg.mz_min, cfg.mz_max])
+    assert essential["thyra_version"]
+
+
+@pytest.mark.parametrize("path_name", list(WRITE_PATHS))
+def test_vendor_sections_are_stored(stores, path_name):
+    """The sections beside essential_metadata, which PCS dropped entirely.
+
+    ``acquisition_params`` is deliberately not asserted: the mock leaves
+    it empty and empty sections are omitted, so that a consumer can tell
+    "this format has none" from "this one has none recorded".
+    """
+    uns = _read_uns(stores[path_name])
+
+    assert uns.get("format_specific") == {"format": "mock"}
+    assert uns.get("instrument_info") == {"instrument": "mock"}
+    assert uns.get("raw_metadata") == {"source": "mock"}
+    assert "acquisition_params" not in uns
+    assert uns.get("regions"), f"{path_name} stored no region summary"
+
+
+def test_every_path_stores_the_same_provenance(stores):
+    """The invariant the individual assertions above are instances of.
+
+    Compares whole blocks rather than named keys, so a section added to
+    one path and forgotten on another fails here without anyone having
+    to remember to extend this file.
+    """
+    provenance_keys = (
+        "essential_metadata",
+        "format_specific",
+        "acquisition_params",
+        "instrument_info",
+        "raw_metadata",
+        "regions",
+    )
+    blocks = {
+        name: {k: _plain(v) for k, v in _read_uns(path).items() if k in provenance_keys}
+        for name, path in stores.items()
+    }
+
+    reference_name = "in_memory"
+    reference = blocks[reference_name]
+    for name, block in blocks.items():
+        if name == reference_name:
+            continue
+        assert (
+            block == reference
+        ), f"{name} stored different provenance from {reference_name}"
+
+
+@pytest.mark.parametrize("path_name", list(WRITE_PATHS))
+def test_read_lazy_sees_the_block(stores, path_name):
+    """The access mode a consumer actually uses.
+
+    ``read_lazy`` is how Ousia opens a converted store without pulling
+    the matrix into memory, and it is where the loss was noticed. Array
+    entries come back as dask, so this checks the keys are reachable --
+    the values are covered eagerly above.
+    """
+    anndata = pytest.importorskip("anndata")
+
+    lazy = anndata.experimental.read_lazy(str(stores[path_name]))
+    essential = lazy.uns["essential_metadata"]
+
+    assert set(essential) == _EXPECTED_ESSENTIAL_KEYS
+    assert essential["spectrum_type"] == _EXPECTED_SPECTRUM_TYPE

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -494,56 +494,72 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         except Exception as e:
             logger.debug(f"Could not extract spectrum metadata: {e}")
 
-    def _add_metadata_to_uns(self, adata) -> None:
-        """Add MSI metadata to AnnData .uns for preservation in SpatialData.
+    def build_uns_metadata(self) -> Dict[str, Any]:
+        """The provenance block every write path must persist, identically.
 
-        This stores comprehensive metadata including:
-        - Essential metadata (dimensions, mass range, source)
-        - Format-specific metadata (FlexImaging areas, teaching points, etc.)
-        - Acquisition parameters
-        - Instrument information
-        - Raw metadata (complete original metadata for future use)
+        Single source of truth for what lands in the table's ``uns``:
+
+        - ``essential_metadata`` -- dimensions, mass range, source path,
+          spectrum type and the Thyra version that wrote the store.
+        - ``format_specific`` -- vendor metadata (FlexImaging areas,
+          teaching points, imzML file mode, ...).
+        - ``acquisition_params`` / ``instrument_info`` -- when the reader
+          has them.
+        - ``raw_metadata`` -- the source metadata as read.
+        - ``regions`` -- the acquisition region summary, as JSON.
+
+        This exists because the converters have two write paths and they
+        drifted. The in-memory and streaming-COO paths hand the table to
+        ``anndata``'s writer, which serialises whatever is in
+        ``adata.uns``; the streaming-PCS path hand-writes the Zarr layout
+        and used to compose its own, much smaller block -- with
+        ``spectrum_type`` hardcoded to ``"processed"``, which is not even
+        a value the extractors produce. A dataset that crossed
+        ``StreamingSpatialDataConverter.PCS_SIZE_THRESHOLD_GB`` therefore
+        came out claiming a spectrum representation it did not have, and
+        without any of the other sections, while a slightly smaller one
+        from the same instrument came out complete. Both paths now render
+        this mapping, so a section added here reaches every store.
+
+        Sections the reader has nothing for are omitted rather than
+        written empty, so consumers can tell "not available from this
+        format" from "available and empty".
+
+        Returns:
+            Mapping of ``uns`` key to the value to store. Empty if the
+            reader cannot produce comprehensive metadata at all.
         """
         try:
             comp_meta = self.reader.get_comprehensive_metadata()
-
-            self._store_format_specific(adata, comp_meta)
-            self._store_acquisition_params(adata, comp_meta)
-            self._store_instrument_info(adata, comp_meta)
-            self._store_essential_metadata(adata, comp_meta)
-            self._store_raw_metadata(adata, comp_meta)
-            self._store_region_info(adata)
-
-            logger.debug("Added MSI metadata to AnnData .uns")
         except Exception as e:
-            logger.debug(f"Could not add metadata to .uns: {e}")
+            # Non-fatal: a store without provenance still holds the
+            # spectra. But it is not a debug-level event -- the whole
+            # point of the block is that a consumer can say where the
+            # data came from, so losing it has to be visible in the log.
+            logger.warning("Could not read metadata for uns provenance: %s", e)
+            return {}
 
-    def _store_format_specific(self, adata, comp_meta) -> None:
-        """Store format-specific metadata (FlexImaging areas, teaching points)."""
-        if hasattr(comp_meta, "format_specific") and comp_meta.format_specific:
-            adata.uns["format_specific"] = comp_meta.format_specific
+        uns: Dict[str, Any] = {}
+        try:
+            self._collect_essential_metadata(uns, comp_meta)
+            self._collect_optional_sections(uns, comp_meta)
+            self._collect_region_info(uns)
+        except Exception as e:
+            logger.warning("Could not build the full uns provenance block: %s", e)
 
-    def _store_acquisition_params(self, adata, comp_meta) -> None:
-        """Store acquisition parameters."""
-        if hasattr(comp_meta, "acquisition_params") and comp_meta.acquisition_params:
-            adata.uns["acquisition_params"] = comp_meta.acquisition_params
+        return uns
 
-    def _store_instrument_info(self, adata, comp_meta) -> None:
-        """Store instrument information."""
-        if hasattr(comp_meta, "instrument_info") and comp_meta.instrument_info:
-            adata.uns["instrument_info"] = comp_meta.instrument_info
-
-    def _store_essential_metadata(self, adata, comp_meta) -> None:
-        """Store essential metadata (convert tuples to lists for Zarr)."""
-        if not hasattr(comp_meta, "essential"):
+    def _collect_essential_metadata(self, uns: Dict[str, Any], comp_meta: Any) -> None:
+        """Add ``essential_metadata`` (tuples become lists for Zarr)."""
+        essential = getattr(comp_meta, "essential", None)
+        if essential is None:
             return
 
-        essential = comp_meta.essential
         dims = essential.dimensions
         mrange = essential.mass_range
         from thyra import __version__
 
-        adata.uns["essential_metadata"] = {
+        uns["essential_metadata"] = {
             "source_path": str(essential.source_path),
             "dimensions": list(dims) if dims else None,
             "mass_range": list(mrange) if mrange else None,
@@ -551,13 +567,19 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             "thyra_version": __version__,
         }
 
-    def _store_raw_metadata(self, adata, comp_meta) -> None:
-        """Store raw metadata (complete original data for future use)."""
-        if hasattr(comp_meta, "raw_metadata") and comp_meta.raw_metadata:
-            adata.uns["raw_metadata"] = self._serialize_for_zarr(comp_meta.raw_metadata)
+    def _collect_optional_sections(self, uns: Dict[str, Any], comp_meta: Any) -> None:
+        """Add the vendor sections the reader actually populated."""
+        for key in ("format_specific", "acquisition_params", "instrument_info"):
+            value = getattr(comp_meta, key, None)
+            if value:
+                uns[key] = self._serialize_for_zarr(value)
 
-    def _store_region_info(self, adata) -> None:
-        """Store acquisition region summary in uns as JSON.
+        raw_metadata = getattr(comp_meta, "raw_metadata", None)
+        if raw_metadata:
+            uns["raw_metadata"] = self._serialize_for_zarr(raw_metadata)
+
+    def _collect_region_info(self, uns: Dict[str, Any]) -> None:
+        """Add the acquisition region summary as JSON.
 
         Stored as a JSON string because AnnData/zarr cannot round-trip
         a list of dicts (they get stringified individually). JSON
@@ -568,7 +590,13 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         """
         region_info = getattr(self, "_region_info", None)
         if region_info:
-            adata.uns["regions"] = json.dumps(self._serialize_for_zarr(region_info))
+            uns["regions"] = json.dumps(self._serialize_for_zarr(region_info))
+
+    def _add_metadata_to_uns(self, adata) -> None:
+        """Apply :meth:`build_uns_metadata` to an AnnData about to be written."""
+        uns = self.build_uns_metadata()
+        adata.uns.update(uns)
+        logger.debug("Added MSI metadata to AnnData .uns: %s", sorted(uns))
 
     def _serialize_for_zarr(self, obj):
         """Recursively convert tuples to lists for Zarr serialization."""

--- a/thyra/converters/spatialdata/spatialdata_3d_converter.py
+++ b/thyra/converters/spatialdata/spatialdata_3d_converter.py
@@ -221,6 +221,11 @@ class SpatialData3DConverter(BaseSpatialDataConverter):
                     per_region[str(r)] = total / max(count, 1)
                 adata.uns["average_spectrum_per_region"] = per_region
 
+            # Add MSI metadata to .uns. The 2D and streaming paths have
+            # always done this; the 3D one never did, so a volume came
+            # out with no record of where it came from at all.
+            self._add_metadata_to_uns(adata)
+
             # Make sure region column exists and is correct
             region_key = f"{self.dataset_id}_pixels"
             if "region" not in adata.obs.columns:

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -1296,6 +1296,27 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
 
         return mm_indices, mm_data
 
+    def _write_uns_provenance(self, uns_group: "zarr.Group") -> None:
+        """Write the shared provenance block into a hand-written ``uns`` group.
+
+        This path composes the Zarr layout itself, so it cannot reach
+        ``adata.uns`` the way ``_save_output`` does. It renders the same
+        mapping through anndata's own element writer instead, which is
+        what produces the ``encoding-type`` / ``encoding-version`` pairs
+        ``read_lazy`` needs -- getting those right by hand is exactly
+        what this path used to have to do, and exactly where it drifted
+        from the other one.
+
+        Only ``uns`` goes through anndata here. ``obs``/``var`` stay
+        hand-written: they carry the pandas string dtypes this path
+        exists to sidestep, whereas the provenance block is plain dicts,
+        strings, lists and numbers.
+        """
+        from anndata.io import write_elem
+
+        for key, value in self.build_uns_metadata().items():
+            write_elem(uns_group, key, value)
+
     def _write_csc_arrays_to_zarr(
         self,
         mm_indices: np.memmap,
@@ -1540,40 +1561,7 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         a.attrs["encoding-type"] = "string"
         a.attrs["encoding-version"] = "0.2.0"
 
-        em_group = uns_group.create_group("essential_metadata")
-        em_group.attrs["encoding-type"] = "dict"
-        em_group.attrs["encoding-version"] = "0.1.0"
-        a = em_group.create_array(
-            "dimensions", data=np.asarray(np.array(self._dimensions))
-        )
-        a.attrs["encoding-type"] = "array"
-        a.attrs["encoding-version"] = "0.2.0"
-        a = em_group.create_array(
-            "mass_range",
-            data=np.array([mz_values.min(), mz_values.max()]),
-        )
-        a.attrs["encoding-type"] = "array"
-        a.attrs["encoding-version"] = "0.2.0"
-        a = em_group.create_array(
-            "source_path",
-            data=np.array(str(self.reader.data_path), dtype=str_dtype),
-        )
-        a.attrs["encoding-type"] = "string"
-        a.attrs["encoding-version"] = "0.2.0"
-        a = em_group.create_array(
-            "spectrum_type",
-            data=np.array("processed", dtype=str_dtype),
-        )
-        a.attrs["encoding-type"] = "string"
-        a.attrs["encoding-version"] = "0.2.0"
-        from thyra import __version__
-
-        a = em_group.create_array(
-            "thyra_version",
-            data=np.array(__version__, dtype=str_dtype),
-        )
-        a.attrs["encoding-type"] = "string"
-        a.attrs["encoding-version"] = "0.2.0"
+        self._write_uns_provenance(uns_group)
 
         a = uns_group.create_array("average_spectrum", data=avg_spectrum)
         a.attrs["encoding-type"] = "array"


### PR DESCRIPTION
## What was wrong

`uns["essential_metadata"]` is the only place a converted store records what
it was made from. Three write paths produce it, and they had drifted:

| | in-memory / streaming-COO | streaming-PCS |
|---|---|---|
| how `uns` is written | `adata.uns` -> anndata's writer | hand-written Zarr |
| `spectrum_type` | from the reader | **hardcoded `"processed"`** |
| `mass_range` | source range | resampled **target axis** |
| `source_path` | `essential.source_path` | `reader.data_path` |
| `format_specific` / `instrument_info` / `raw_metadata` / `regions` | written | **dropped** |

`"processed"` is not a value any extractor produces -- they emit
`"centroid spectrum"` / `"profile spectrum"` -- so a consumer could neither
trust it nor tell it apart from a real reading.

## Why it looked dataset-specific

Which path a dataset takes is decided purely by size, in
`StreamingSpatialDataConverter._should_use_pcs()`. Measured on `test_data/`
with `resampling_config={}`:

| file | axis | dense estimate | branch | stored `spectrum_type` |
|---|---|---|---|---|
| `pea.imzML` | 460,495 bins | 29.9 GB | COO (under 30 GB) | `centroid spectrum` (correct) |
| `bellini.imzML` | 708,847 bins | **43.3 GB** | **PCS** (over 30 GB) | `processed` (wrong; it is `profile spectrum`) |

Two acquisitions land either side of `PCS_SIZE_THRESHOLD_GB = 30.0` and come
out described differently. Ousia's import wizard passes `use_csc=True`, so
**every** wizard conversion takes the PCS path regardless of size.

## The fix

`BaseSpatialDataConverter.build_uns_metadata()` is now the single source of
truth for the whole block. The PCS path renders that same mapping through
`anndata.io.write_elem` rather than composing its own -- which also stops it
hand-maintaining the `encoding-type` / `encoding-version` pairs `read_lazy`
depends on. `obs`/`var` stay hand-written; only `uns` goes through anndata.

Also here:

- The 3D converter never called `_add_metadata_to_uns` at all, so a volume
  came out with no provenance whatsoever. It now writes the same block.
- A failure to build the block is logged at `warning`, not `debug`. Losing
  provenance *silently* is the harm being fixed.
- Empty sections stay omitted, so a consumer can distinguish "this format
  does not carry it" from "it was carried and lost".
- `docs/output-format.md` now documents the block; it previously covered
  `uns["average_spectrum"]` and `uns["regions"]` but not this.

## Verification

Real data, `bellini.imzML` forced down the PCS branch:

```
before:  uns = [essential_metadata, spatialdata_attrs]      spectrum_type='processed'
after:   uns = [essential_metadata, format_specific,        spectrum_type='profile spectrum'
                raw_metadata, regions, spatialdata_attrs]
```

which matches `ImzMLReader(bellini).get_essential_metadata().spectrum_type`.

New `tests/unit/converters/test_uns_provenance_parity.py` converts the same
mock dataset down all three paths and asserts the block is non-empty, that
`spectrum_type` tracks the reader, and that all three paths store *identical*
provenance -- so a section added to one path and forgotten on another fails
without anyone remembering to extend the test.

**Why no test caught this before:** `MockMSIReader` reported
`spectrum_type="processed"` too. The fixture agreed with the hardcoded
literal, so every test could compare them and pass. It now reports a value
from the real vocabulary; that one-line change is what makes the new tests
fail on `main`:

```
streaming_pcs stored spectrum_type='processed'; the reader reports 'centroid spectrum'
streaming_pcs stored different provenance from in_memory
  Right contains 4 more items: format_specific, instrument_info, raw_metadata, regions
```

Full suite: 1088 passed, 11 skipped. All pre-commit hooks pass.
