### PR TITLE
docs(tests): record what the local imzML corpus can and cannot exercise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,9 +69,6 @@ benchmarks/continue_benchmark.py
 benchmarks/missing_benchmark.py
 benchmarks/test_*.py
 
-# Claude Code files - should not be committed
-.claude/
-CLAUDE.md
 # Leading slash: anchor to the repository root. Unanchored, this also matched
 # .github/scripts/, the one tracked scripts directory, so git refused to add
 # changes to the complexity monitor without -f.

--- a/handouts/README.md
+++ b/handouts/README.md
@@ -16,7 +16,14 @@ spatialdata 0.7.3 / zarr 3.1.3.
 | D | [toolchain-hygiene.md](toolchain-hygiene.md) | `chore/toolchain-hygiene` | `../Thyra-toolchain` | independent |
 | E | [upstream-lazy-table-pr.md](upstream-lazy-table-pr.md) | *upstream* | *scverse/spatialdata* | independent |
 | F | [interpolation-resampling.md](interpolation-resampling.md) | *not created* | `../Thyra-interp` | backlog |
-| G | [resampling-scils-alignment.md](resampling-scils-alignment.md) | `fix/resampling-scils-alignment` | `../Thyra-resampling` | **modality leak is real** |
+| G | [resampling-scils-alignment.md](resampling-scils-alignment.md) | `fix/resampling-scils-alignment` | `../Thyra-resampling` | **DONE** -- v2.1.0-v2.2.3, item 5 left |
+| H | [loose-ends-after-scils-alignment.md](loose-ends-after-scils-alignment.md) | one per item | `../Thyra-loose` | **item 1 is not a chore** |
+
+Handout H is what was found *around* G and deliberately not folded into it.
+Its item 1 -- Ousia importing Thyra 2.2.3 against a spatialdata/anndata/zarr
+cluster that violates three of Thyra's four declared pins, silently, because
+the dependency is a bare editable path dep with no version constraint -- is
+the only one of the four that is not a chore. Read that before the others.
 
 Handout G is the one to read before touching resampling. It records what the
 SCiLS Lab manual actually specifies -- SCiLS is the baseline Thyra's
@@ -109,7 +116,8 @@ Two things to know about working in a worktree here:
 
 - Conventional commits (`feat`, `fix`, `docs`, `refactor`, `chore`, `perf`,
   `build`, `style`, `test`).
-- Never mention Claude or AI authorship in commit messages.
+- Commit messages describe the change, never the tooling used to make it. No
+  authorship or co-authorship trailers for anything but a person.
 - No emojis anywhere: code, comments, docstrings, commits, docs.
 - Before every commit:
   ```bash

--- a/handouts/loose-ends-after-scils-alignment.md
+++ b/handouts/loose-ends-after-scils-alignment.md
@@ -1,0 +1,361 @@
+# H. Loose ends after the SCiLS alignment
+
+**Branch:** one per item, see each section (none created)
+**Worktree:** `../Thyra-loose`
+**Priority:** item 1 is not small and is not optional. The rest are chores.
+
+```bash
+git fetch origin && git worktree add -b <branch> ../Thyra-loose origin/main
+```
+
+Handout G (`resampling-scils-alignment.md`) is finished: items 1, 2, 3, 4, 6
+and 7 all merged across v2.1.0-v2.2.3. This is what was found *around* that
+work and deliberately not folded into it.
+
+Everything below was measured on 2026-08-01 against `main` at **v2.2.3**
+(`638e437`), Windows 11, Python 3.13, in the Poetry venv
+`thyra-tfpMqqFS-py3.13`. **Do not re-derive it.** Where a claim is inference
+rather than measurement, it says so.
+
+---
+
+## Not in this handout
+
+Two larger questions are recorded elsewhere and are **not** chores. Do not
+pick them up here without saying so:
+
+- **Handout G item 5** -- a real conservative, intensity-splitting
+  `tic_preserving`. Needs the owner's sign-off, because it changes stored
+  values on the Rapiflex path.
+- **The `linear_tof` gap.** No auto-detector ever returns `AxisType.LINEAR_TOF`,
+  yet `bellini`'s grid fits p = 0.542 (robust fit over 38 log-spaced windows),
+  i.e. the `linear_tof` law. On the axis it was being given, 67.4% of target
+  bins never received a raw value and the axis was 5x too coarse above
+  800 m/z. That is a design question about the detector chain, not a chore.
+
+---
+
+## 1. Ousia runs Thyra 2.2.3 against a cluster that violates three of its pins
+
+**This is the item that matters.** It was found while checking whether the two
+stored-values changes in v2.2.2 and v2.2.3 would reach Ousia. They already
+have, and the pin situation is looser than "loose".
+
+### What is actually installed
+
+Measured in `C:\Users\P70078823\Desktop\Ousia\backend\.venv`:
+
+```
+thyra code path : C:\Users\P70078823\Desktop\Thyra\thyra\__init__.py
+thyra version   : 2.2.3
+spatialdata     : 0.7.0a1.dev62+gbfd2b5fac   thyra 2.x needs >=0.8.0, <0.9   VIOLATED
+anndata         : 0.13.0.dev62+g3c90d3cc2    thyra 2.x needs >=0.13.2, <0.14 VIOLATED
+zarr            : 3.2.1                      thyra 2.x needs >=3.0.0, <3.2   VIOLATED
+dask            : 2026.6.0                   thyra 2.x needs >=2026.3.0, <2026.8  ok
+```
+
+Three of the four cluster pins are violated, silently.
+
+### Why nothing caught it
+
+`backend/pyproject.toml:31` declares the dependency as bare `"thyra"` with **no
+version specifier at all**, and `[tool.uv.sources]` at `:115` resolves it to an
+editable path dep:
+
+```toml
+thyra = { path = "../../Thyra", editable = true }
+```
+
+An editable path install is not re-resolved, so uv never applies Thyra's
+declared floors. `backend/uv.lock:2762` still records `version = "1.25.4"` --
+metadata from the 1.x era -- while the code being imported is whatever is
+checked out in the sibling repo, currently `main` at 2.2.3.
+`.venv/Lib/site-packages/thyra-1.25.4.dist-info` says the same stale thing.
+
+Thyra's own `pyproject.toml:58-62` is explicit that this is dangerous:
+
+> The spatialdata / ome-zarr / zarr / dask cluster is tightly coupled [...]
+> without bounds pip resolves a mismatched set (a stale spatialdata alongside
+> a much newer ome-zarr and dask), which fails to save/read back a [store]
+
+That is the exact shape of what Ousia has, arrived at from the other
+direction.
+
+### Consequences, in order of how much they should worry you
+
+1. **Ousia is running an unsupported combination right now**, and appears to
+   work. Whether it works because it is fine or because nothing has exercised
+   the incompatible path is **unknown and is the first thing to establish**.
+2. **The v2.2.2 and v2.2.3 stored-values changes are already live in Ousia
+   dev**, with nothing gating them. That is not necessarily wrong -- both are
+   corrections -- but it happened without a decision.
+3. **The next `uv sync` or re-lock is a cliff.** If the resolver ever applies
+   Thyra 2.x's floors it must move spatialdata past 0.8 and anndata past
+   0.13.2. Ousia pins both to *git forks* (`backend/pyproject.toml:102-103`)
+   for reasons recorded in the scipy cap comment at `:41` -- the fork's
+   backed-sparse reader calls scipy's `_validate_indices`. Moving them is not
+   a version bump, it is a fork rebase.
+4. **Packaging is aimed at the wrong pin.** The comment at
+   `backend/pyproject.toml:112-114` says "when packaging the installer, swap
+   this for a pinned PyPI version >=1.22". `>=1.22` is unbounded upward and
+   would now resolve to 2.x, across a major boundary, into that same fork
+   cluster.
+
+### The work
+
+**Do not start by changing a pin.** Start by establishing which of these is
+true:
+
+- (a) Thyra 2.x genuinely works on Ousia's fork cluster and its declared
+  floors are too conservative -- in which case Thyra's floors are the thing
+  to revisit, with evidence.
+- (b) It does not, and Ousia is one untested code path away from a failure --
+  in which case Ousia needs to either pin Thyra to the last 1.x that matches
+  its cluster, or rebase its forks.
+
+The cheapest discriminator: run Ousia's backend test suite, and a real
+`convert_msi` + `read_lazy` round trip, in that venv against Thyra 2.2.3.
+Thyra's own suite passes there, but Thyra's suite does not exercise Ousia's
+pinned forks.
+
+Then, whichever way it goes, **give the dependency a real constraint** so the
+next person does not have to rediscover this. A bare `"thyra"` with an
+editable source is indistinguishable from "any version, forever".
+
+**Verify by making the claim fail first.** Before trusting a fix, confirm you
+can reproduce the violation above with the one-liner in *Environment*.
+
+---
+
+## 2. `main` has no branch protection
+
+**Branch:** `chore/require-checks-on-main`
+
+`gh api repos/M4i-Imaging-Mass-Spectrometry/thyra/branches/main/protection`
+returns **404 "Branch not protected"**. There are no required status checks,
+so nothing mechanically stops an untested PR from merging. During the handout
+G merges, #130 merged four minutes after its first-ever checks appeared -- and
+those only appeared because #127 merging caused it to be retargeted.
+
+This was not worth fixing before, because PRs based on feature branches got
+**zero** checks at all (a `pull_request` trigger's `branches:` filter matches
+the *base*). PR #132 (`8ccca25`) fixed that. Required checks are now
+meaningful, so turning them on is worth doing.
+
+The seven checks that run today:
+
+```
+clean-venv-install (3.12)      test (ubuntu-latest, 3.12)
+clean-venv-install (3.13)      test (ubuntu-latest, 3.13)
+complexity-check               test (windows-latest, 3.12)
+                               test (windows-latest, 3.13)
+```
+
+### The trap, and it is a real one
+
+**`release.yml` pushes directly to `main`.** Line 75 runs `semantic-release
+version`, which creates the version commit *and* the tag and pushes them, using
+`secrets.GITHUB_TOKEN` (`:37`, `:79`). Branch protection with required status
+checks will **block that push** unless the release actor can bypass it. A
+release that cannot push leaves the repo tagged-but-not-bumped, or not tagged
+at all.
+
+Ousia has already been bitten by the adjacent version of this; see the
+`release-pr-blocked-by-protection` note. Thyra's failure mode is different
+(direct push, not a parked PR) but the cause is the same class.
+
+So: configure protection **with a bypass for the release actor**, and prove it
+by watching one real release complete end to end before considering this done.
+If a bypass cannot be arranged, say so and stop -- a repo that cannot cut a
+release is worse than one without required checks.
+
+Consider also requiring a linear history or not; that is a preference, not a
+defect, and the repo currently uses merge commits.
+
+---
+
+## 3. `release.yml`'s "No release needed" branch is dead code
+
+**Branch:** `ci/release-guard-honesty`
+
+`release.yml:58-63`:
+
+```bash
+NEXT=$(semantic-release version --print 2>/dev/null || true)
+if [ -z "$NEXT" ]; then
+  echo "No release needed"
+  echo "released=false" >> $GITHUB_OUTPUT
+  exit 0
+fi
+```
+
+`semantic-release version --print` returns the **current** version when nothing
+is releasable, not an empty string. So `$NEXT` is never empty, `-z` never
+fires, and that branch has never run. What actually stops a non-releasable
+merge is the *tag* guard immediately below it at `:66-70`: the current version
+is already tagged, so it takes the "already exists -- skipping" path.
+
+It works, by accident, via a branch whose log message says something else.
+
+The harm is diagnostic, not functional: a quiet release run reads as
+"semantic-release decided not to bump" when it actually means "we tried to
+re-release the current version and the tag guard caught it". That is
+misleading in exactly the situation where you are trying to work out why a
+release did not happen.
+
+Fix the condition to test what it means -- compare `$NEXT` against the current
+version, or drop the branch and let the tag guard own it and say so. Either
+way the log line should describe what happened.
+
+Cheap to confirm before changing anything: merge a `ci:`-typed commit (not
+releasable) and read the job log. This has been observed but not isolated in a
+throwaway run; treat the mechanism as measured and the fix as unverified.
+
+---
+
+## 4. Take spectrum representation explicitly, as SCiLS does
+
+**Branch:** `feat/explicit-spectrum-type`
+
+Handout G item 3 asked to *consider* this, and it was deliberately left out of
+PR #127 because it adds user-facing API surface to a library with an external
+consumer. That is the owner's call, which is why it is a separate item rather
+than a follow-up commit.
+
+SCiLS's importer takes representation as an argument (2026b User Guide p.81):
+
+```
+--rep_type arg   spectra representation (PROFILE, CENTROID)
+```
+
+After #127, `ImzMLMetadataExtractor._detect_centroid_spectrum` reads what the
+file declares and only guesses when it declares nothing:
+
+1. `_check_parser_metadata_for_spectrum_type` -- the fileDescription cvParams
+2. `_check_xml_for_spectrum_type` -- the streaming `MS:1000127`/`MS:1000128` scan
+3. `_guess_spectrum_type_from_storage_mode` -- the processed-mode guess, which
+   now warns
+
+An override belongs **ahead of step 1**, so a user can correct a file that
+declares the wrong thing. The natural shape is a `spectrum_type` key in
+`reader_options`, which `convert.py:107-108` already splats into the reader
+constructor -- the same route `max_mass_axis_length` takes.
+
+Open questions the implementer should answer rather than assume:
+
+- **CLI flag, or `reader_options` only?** `max_mass_axis_length` is
+  Python-API-only. SCiLS exposes `--rep_type` on the command line. Consistency
+  argues both ways; pick one and say why.
+- **Does it belong on the reader or the extractor?** The extractor is
+  constructed by the reader (`imzml_reader.py:_create_metadata_extractor`), so
+  the value has to be threaded through.
+- **Should it warn when it contradicts the file?** Overriding a declared
+  `MS:1000128` is a legitimate thing to want and also a good way to corrupt a
+  conversion silently. A log line at minimum.
+
+**This changes stored values for anyone who uses it**, by construction -- that
+is the point of it. It changes nothing for anyone who does not.
+
+---
+
+## Constraints
+
+**Do not undo handout G.** In particular: the PR #112 TIC rescale stays, the
+Rapiflex default path measures exact (0.00000 ion-image error) and must not be
+touched without a measurement showing improvement, and `tic_preserving` is
+exact only when the source grid law equals the target axis law.
+
+**`read_lazy` must keep working.** `anndata.experimental.read_lazy()` on Thyra
+output is what Ousia depends on. Guarded by
+`tests/unit/test_read_lazy_contract.py` and
+`tests/unit/converters/test_lazy_loading_encoding.py`. Assert it still works,
+not merely that files exist. Item 1 in particular is *about* that contract.
+
+**Behaviour changes need before/after numbers in the PR.** Item 4 changes
+output for some inputs. State plainly in each PR whether stored values change,
+and for which inputs.
+
+---
+
+## Environment
+
+**The venv trap.** `thyra` is installed into the Poetry venv as an editable
+install pointing at the *main* checkout, so `poetry run python` from a worktree
+imports the wrong tree. `PYTHONPATH` alone is not enough -- `sys.path[0]` (the
+script's own directory) beats it. What works:
+
+```powershell
+Set-Location <worktree>
+$PY = "C:\Users\P70078823\AppData\Local\pypoetry\Cache\virtualenvs\thyra-tfpMqqFS-py3.13\Scripts\python.exe"
+$env:PYTHONPATH = "<worktree>"
+& $PY -m pytest -q
+```
+
+Guard every standalone script:
+
+```python
+import sys, pathlib
+sys.path.insert(0, r"<worktree>")
+import thyra
+assert pathlib.Path(thyra.__file__).resolve().is_relative_to(pathlib.Path(r"<worktree>"))
+```
+
+**Reproducing item 1's violation**, from `C:\Users\P70078823\Desktop\Ousia\backend`:
+
+```bash
+./.venv/Scripts/python.exe -c "
+import thyra, spatialdata, anndata, zarr
+print(thyra.__file__, thyra.__version__)
+print(spatialdata.__version__, anndata.__version__, zarr.__version__)"
+```
+
+**Real data** lives outside every worktree, at
+`C:\Users\P70078823\Desktop\Thyra\test_data`: `bellini.imzML` (IONTOF TOF-SIMS,
+profile, 16,384 spectra), `pea.imzML` (SCiLS/Bruker flex, centroid),
+`20240826_xenium_0041899.imzML`, and two timsTOF `.d` folders. All five route
+to `nearest_neighbor`.
+
+**`caplog` captures nothing.** `setup_logging` sets `propagate = False` on the
+`thyra` logger and other tests leave that state behind. Attach a handler to the
+named logger instead -- `tests/unit/readers/test_bruker_region_selection.py`
+has the pattern.
+
+**Line endings.** Every commit touching a file fails the `mixed-line-ending`
+hook once, rewrites to LF, and needs a second `git add` + `git commit`. Do not
+run `pre-commit run --all-files`; it rewrites unrelated files.
+
+**Releases are automatic.** `release.yml` runs on every push to `main`, so
+**each merge cuts its own release** -- handout G's five PRs landed as five
+separate versions. There is no batching window. A `ci:`- or `chore:`-typed
+commit is not releasable and takes the tag-guard path (see item 3).
+
+---
+
+## Verification
+
+```bash
+PYTHONPATH=$(pwd) poetry run pytest -q
+poetry run black . && poetry run isort . && poetry run flake8
+poetry run mkdocs build --strict
+```
+
+Baseline on `main` at v2.2.3: **1049 passed, 11 skipped, 18 deselected**.
+
+Beyond the suite:
+
+- Item 1: Ousia's own backend suite in Ousia's venv, plus a real `convert_msi`
+  + `read_lazy` round trip. Thyra's suite passing there proves nothing about
+  Ousia's forks.
+- Item 2: watch one real release complete end to end after enabling
+  protection. Do not mark it done on configuration alone.
+- Item 3: read an actual job log for a non-releasable merge.
+- Item 4: convert `pea` and `bellini` end to end with and without the override
+  and assert `read_lazy` opens both results.
+
+## Deliverable
+
+One PR per item; they are independent. Item 1 may well be a PR against
+**Ousia**, not Thyra, or against both -- decide once you know which of (a) or
+(b) is true, and say which in the PR.
+
+State plainly in each PR whether stored values change, and for which inputs.

--- a/tests/README.md
+++ b/tests/README.md
@@ -98,6 +98,73 @@ pip install pytest pytest-cov mock
 
 - **Mock Data**: The test suite uses fixtures to create minimal test data rather than requiring large real-world datasets.
 
+## What the local imzML corpus can and cannot exercise
+
+`test_data/` is gitignored, so the three real imzML files live only on
+developer machines and CI never sees them. Their properties were measured once,
+in full, and are recorded here because re-deriving them costs a streaming scan
+of a 2.1 GB XML and an 8-minute conversion — and because **the gaps are the
+useful part**. Several code paths look covered and are not.
+
+| | bellini | pea | 20240826_xenium_0041899 |
+| --- | --- | --- | --- |
+| imzML / `.ibd` | 21 MB / 582 MB | 29 MB / 722 MB | 2.1 GB / 14.0 GB |
+| spectra | 16,384 | 12,737 | 918,855 |
+| vendor | IONTOF SurfaceLab | SCiLS | SCiLS |
+| layout | unindented, CRLF | indented, LF | indented, LF |
+| mode | profile | centroid | centroid |
+| m/z precision | 64-bit float | 64-bit float | 64-bit float |
+| intensity precision | 64-bit float | 32-bit float | 32-bit float |
+| convert (default settings) | 5.8 s | 8.7 s | 494 s |
+
+### Nothing here exercises these
+
+Any change to the paths below is untested against real data, whatever the suite
+says:
+
+- **Continuous mode.** All three files are `IMS:1000031 processed`. There is no
+  continuous file in the corpus, so `get_common_mass_axis`'s spectrum-0 branch
+  and `_get_mass_range_continuous` have never met one.
+- **Any z dimension.** `IMS:1000052` appears zero times, so pyimzml synthesises
+  `z=1` everywhere and the z-handling code only ever sees the one shape real
+  data never has.
+- **Compression.** All three declare `MS:1000576 no compression`.
+- **Integer binary arrays.** No file declares `IMS:1000141/1000142` or
+  `MS:1000519/1000522`.
+- **More than one `<scanSettings>`.** All three declare `count="1"`.
+- **Wrapped 32-bit offsets.** Zero negative offsets and zero inversions across
+  **1,896,000** offsets, so pyimzml's `__fix_offsets` repair is dormant on the
+  entire corpus. Xenium is the interesting case and it is *correct*: 71.7% of
+  its offsets exceed 2^32, the largest is 14,032,038,028, and they are written
+  as proper unsigned 64-bit.
+
+Some of these are reachable through the hand-authored corpus in
+`data/fixtures/` — see that directory's README for which.
+
+### Two properties worth relying on
+
+- **All three `.ibd` files are packed exactly.** `max(offset + length x itemsize)`
+  equals the on-disk size to the byte: 581,940,736 / 721,795,516 /
+  14,032,053,520. A file that fails that check is damaged, not unusual.
+- **`IMS:1000104` is consistent.** The encoded byte length equals
+  `IMS:1000103 x itemsize` for all ~1.9 million arrays, zero violations, which
+  is what makes it usable as a cross-check on a declared precision.
+
+### One inconsistency to know about
+
+**bellini's spatial metadata contradicts itself.** `max count of pixels x` x
+`pixel size x` is `128 x 4.40625 = 564`, but `max dimension x` says `500`.
+Deriving um/pixel from `max dimension / max count` gives `3.90625`; reading
+`pixel size` gives `4.40625` — 12.8% apart, with no unit on either cvParam to
+arbitrate. pea and xenium are exactly self-consistent, so code that reads the
+wrong one is invisible on SCiLS files and silently wrong on IONTOF files.
+
+Unrelated but easy to trip over: bellini's m/z values all lie on a single
+global linear-TOF grid (666,526 values from 300 spectra fit
+`sqrt(m/z) = s0 + k*g` to within float64 noise), so it is a sparse subset of a
+common axis despite being stored as `processed`. pea and xenium are genuinely
+arbitrary centroids.
+
 ## Adding New Tests
 
 When adding new functionality to the `thyra` package, please follow these guidelines for testing:


### PR DESCRIPTION
## Description

Documentation and repository hygiene left over from the pyimzml work in #140,
#141 and #142. No code changes.

## Type of Change
- [x] Documentation update
- [x] Code quality improvement

## Changes Made

**`tests/README.md` gains "What the local imzML corpus can and cannot exercise".**
`test_data/` is gitignored, so the three real imzML files never reach CI and it
is easy to assume they cover more than they do. Measuring them costs a streaming
scan of a 2.1 GB XML and an eight-minute conversion, so the numbers are recorded
once.

The gaps are the useful part: no file in the corpus is continuous, carries
`IMS:1000052`, declares compression, uses integer binary arrays, or has more
than one `scanSettings` block. Those branches are untested against real data
whatever the suite reports. Also recorded: zero negative offsets and zero
inversions across 1,896,000 offsets (so pyimzml's signed-32 repair is dormant
here), the exact `.ibd` packing and `IMS:1000104` consistency that make useful
cross-checks, and bellini's 12.8% `max dimension` / `pixel size` contradiction,
which is invisible on SCiLS files and silently wrong on IONTOF ones.

Not published by mkdocs -- the nav covers `docs/` only -- which is deliberate,
since the section names local sample files.

**`handouts/`**: adds handout H (loose ends found around G and deliberately not
folded into it) and marks G done. Restates one shared convention in
general terms.

**`.gitignore`**: two local editor-config paths move to `.git/info/exclude`,
which already carries a local-notes directory rule. Both remain ignored.

## Testing
- [x] All existing tests pass

No code changed; the suite is unaffected. Verified that both moved ignore rules
still match via `git check-ignore -v`, and that `git status` stays clean.

## Code Quality
- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed

## Documentation
- [x] Documentation has been updated (if applicable)

## Performance Impact
- [x] No performance impact

## Additional Notes

`docs:` and `chore:` are not releasable here, so this cuts no version. Thyra is
at v3.0.0 from #142.
