### PR TITLE
docs(changelog): backfill the v3.0.0 entry the generator dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,67 @@
 
 ## v3.0.0 (2026-08-02)
 
+<!-- Hand-written. The generator rendered this section empty; the six commits
+     below are `git log --no-merges v2.3.1..v3.0.0`. -->
+
+### Bug Fixes
+
+- **converters**: Drop the PCS path's phantom pixel rows, and refuse depth
+  ([`87f287c`](https://github.com/M4i-Imaging-Mass-Spectrometry/thyra/commit/87f287c4b10b78ab3acea1a91d0bd2959a7be25b))
+
+- **converters**: Give the PCS store the root attrs and obs column it skipped
+  ([`2c719d4`](https://github.com/M4i-Imaging-Mass-Spectrometry/thyra/commit/2c719d4fbbd8d12416d16bf67b0fc488a79f9441))
+
+- **imzml**: Read file_mode and uuid from the file instead of by luck
+  ([`d61a09f`](https://github.com/M4i-Imaging-Mass-Spectrometry/thyra/commit/d61a09fa0e6324fd26e0f2cc382e433dfe5d1e7e))
+
+- **imzml**: Rebase z on the file instead of clamping z-1 at zero
+  ([`76c18b8`](https://github.com/M4i-Imaging-Mass-Spectrometry/thyra/commit/76c18b88eb9945cda58e4c749260e54f1525101e))
+
+- **metadata**: Refuse a dataset with no mass range instead of inventing one
+  ([`3cae48b`](https://github.com/M4i-Imaging-Mass-Spectrometry/thyra/commit/3cae48bceab94dceeadc50acb58e638447930f8f))
+
+- **resampling**: Drop out-of-range peaks instead of folding them into edge bins
+  ([`ef59115`](https://github.com/M4i-Imaging-Mass-Spectrometry/thyra/commit/ef591158e0f44d9370bee3f1759e58270f65d090))
+
+### Breaking Changes
+
+- A PCS store's row indices change. Nothing migrates an existing one.
+
+  The streaming-PCS path wrote one row per grid position where the other three
+  write one per acquired spectrum. Acquisitions are polygon-shaped and the grid
+  is their bounding box, so the corners came out as all-zero rows. On real
+  `pea.imzML` that is 17,423 rows against 12,737 spectra, 4,686 of them empty,
+  with a shapes polygon for each phantom. All four paths now agree at 12,737.
+
+  This affects any store written by the streaming path with `use_csc=True`,
+  which is chosen automatically for large datasets. Kept rows keep their *grid*
+  index as `instance_id`, gaps and all -- only the row offsets compact. The TIC
+  image stays full-grid, deliberately: it is a dense raster, not a per-pixel
+  table, which is why `sum(TIC) == sum(X)` still holds.
+
+  **Migration: reconvert.** Nothing rewrites an existing store in place, and
+  code that indexes rows positionally will read the wrong pixel. Index by
+  `instance_id` rather than by row offset and the change is invisible to you.
+
+  To tell the two layouts apart on disk, count the root attrs: a store written
+  before v3.0.0 by this path has 7, missing `coordinate_systems`,
+  `format_specific_metadata` and `msi_dataset_info` (see the second commit
+  above), and has no `obs/region_number` column. A v3.0.0 store has 10 and the
+  column, on every path.
+
+- `n_z > 1` is now refused on the streaming path rather than silently
+  flattened. The PCS scatter indexes rows by `y * n_x + x` with no z term, so a
+  multi-plane acquisition summed both planes onto one and returned success.
+  Use the 2D or 3D converter, which the refusal message names.
+
+- Stored values also change, without a row-layout change, for two inputs:
+  resampling with a narrowed mass range (`--resample-min-mz` /
+  `--resample-max-mz`) no longer piles the discarded part of every spectrum
+  onto the first and last bins, and a dataset from which no spectrum yields a
+  peak is now refused instead of being given an invented `(0.0, 1000.0)` mass
+  range that also sized the common axis.
+
 
 ## v2.3.1 (2026-08-02)
 

--- a/docs/coordinate-systems.md
+++ b/docs/coordinate-systems.md
@@ -259,10 +259,24 @@ for their respective zarrs.
 
 ## What if I open a zarr that doesn't have this attr?
 
-Older Thyra outputs (pre-schema) do not carry the
-``coordinate_systems`` attr. They are still readable, but you have
-to infer the convention from element layouts and accept some
-risk that two elements disagree silently.
+Two kinds of Thyra output lack the ``coordinate_systems`` attr, and
+the second is more recent than it looks:
+
+- **Anything written before v1.22.0**, which introduced the schema.
+- **Any store written by the streaming path with ``use_csc=True``,
+  up to and including v2.3.1.** That path hand-writes its Zarr root
+  attributes and its copy was short: 7 attrs against the 10 the
+  other three paths produce, missing ``coordinate_systems``,
+  ``format_specific_metadata`` and ``msi_dataset_info``. Fixed in
+  v3.0.0. This is the awkward one, because in those versions the
+  route was chosen by estimated size -- so the biggest datasets are
+  exactly the ones that lost it. (Since v3.1.1 that threshold is
+  gone and PCS is the streaming default, but by then the attr was
+  already being written.)
+
+Either way the store is still readable, but you have to infer the
+convention from element layouts and accept some risk that two
+elements disagree silently.
 
 If you control the data: **regenerate**. The schema is cheap to
 write and the resulting zarrs are self-describing forever after.


### PR DESCRIPTION
## What

The `## v3.0.0` section is a heading with nothing under it. The six fixes that
shipped in it -- and the `BREAKING CHANGE` that caused the major -- are
documented nowhere a user reads. The breaking footer exists only in `87f287c`'s
commit body.

Written from `git log --no-merges v2.3.1..v3.0.0`, in the format
semantic-release would have produced, plus a `### Breaking Changes` section
carrying:

- the row-layout change and how to migrate (reconvert; index by `instance_id`,
  never by row offset)
- how to tell the two layouts apart on disk (7 root attrs vs 10)
- the `n_z > 1` refusal
- the two other commits that change stored values without changing the layout
  (`ef59115` out-of-range peaks, `3cae48b` the invented mass range)

Also corrects `docs/coordinate-systems.md`, which attributed a missing
`coordinate_systems` attr to "older Thyra outputs (pre-schema)". That is half
of it: the schema arrived in v1.22.0, but the streaming-PCS path skipped the
attr until v3.0.0, so the newest large stores lack it too. Both cases are now
named.

## Why it matters

The affected path is the one chosen automatically for large datasets, so the
stores whose row indices changed are the big ones. A consumer pinned below 3
currently has no way to find out what changed before deciding whether to move.

## Stored values

No. Documentation only.

## What is deliberately not in here

Why the render was empty is **not** established, and this PR does not guess.
`template_dir` is not the cause: v2.3.1 released the same day under
byte-identical config and rendered eleven entries. v1.24.0 is empty the same
way, so it recurs. Every release since (v3.0.1 through v3.2.0) has rendered
correctly, which narrows it further. Worth a separate look; a release-job
assertion that a bump's rendered section is non-empty would turn a silent empty
render into a failure.

## Verification

- `poetry run mkdocs build --strict` clean (needs `poetry install --with docs`
  first; the docs group is not installed by default)
- `PYTHONPATH=$(pwd) poetry run pytest -q` -> 1382 passed, 13 skipped, 18 deselected
