### PR TITLE
fix(converters): keep a volume's pixel footprints two-dimensional

### DIFF
--- a/docs/coordinate-systems.md
+++ b/docs/coordinate-systems.md
@@ -113,29 +113,45 @@ meaningful frame is **physical micrometers of the imaged tissue**.
 
 Both elements resolve to the same micrometer extent at ``"global"``.
 
-For a **multi-slice volume** (``--handle-3d`` over more than one plane) that
-holds in z as well. The pixel polygons are ``POLYGON Z``: a flat square at the
-micrometre depth of the slice it was acquired on, taken from the same
-``obs["spatial_z"]`` the table stores. So the deepest footprint sits at
-``(n_z - 1) * z_spacing_um``, which is where the TIC volume's last plane lands
-under its own ``Scale``.
+For a **multi-slice volume** (``--handle-3d`` over more than one plane) the
+promise holds in x and y, and is **deliberately silent in z for the shapes
+element**. The TIC volume carries the depth on its ``Scale``, and every table
+row carries it in ``obs["spatial_z"]``; the pixel polygons stay
+two-dimensional and make no claim about depth at all.
 
-These are **footprints, not voxels**. A pixel is its square at one depth, not a
-solid spanning the slice thickness — shapely has no solid geometry. The extent
-in z is the slice spacing, carried by the image.
+So a volume's elements agree like this:
 
-!!! note "Reading 3D shapes"
-    ``spatialdata``'s shapes model is 2D, so it emits a ``UserWarning`` that
-    "2 is expected" whenever these are parsed, validated or transformed. The
-    geometry is nonetheless carried and transformed correctly, verified
-    through a zarr round trip and a ``Scale`` into ``"global"``. The warning
-    is left unsuppressed: it is upstream stating the limits of its model, and
-    silencing it would hide that from consumers.
+| Element | x, y at ``"global"`` | z at ``"global"`` |
+|---------|---------------------|-------------------|
+| TIC volume | ``Scale([pixel_size_um, pixel_size_um])`` | ``Scale([z_spacing_um])`` |
+| Table | ``spatial_x``, ``spatial_y`` | ``spatial_z`` |
+| Pixel shapes | micrometres, ``Identity`` | **absent** — join via ``spatial_z`` |
 
-    Expressing the depth as a ``Translation`` on flat 2D geometry — the
-    obvious alternative — does **not** work. The transform silently drops z
-    and returns flat polygons, leaving a depth that exists only in the
-    metadata. ``tests/unit/converters/test_3d_pixel_shapes_z.py`` pins that.
+!!! note "Why the footprints carry no depth"
+    They briefly did. v3.2.0 made them ``POLYGON Z`` at the depth of their
+    slice, which is the geometrically honest representation, and it broke
+    ``spatialdata``'s spatial queries: a bounding box enclosing an entire test
+    volume returned 26 of 30 footprints and 26 of 30 table rows, silently. A
+    z-restricted query returned the same rows whether z was inside or far
+    outside the data.
+
+    Upstream asks for 2D here. ``ShapesModel.validate`` warns that a
+    3-dimensional geometry column "could led to unexpected behaviors" and
+    names ``force_2d()`` as the remedy — the query result above is that
+    behaviour. 3D shapes are not on the spatialdata roadmap
+    ([#109](https://github.com/scverse/spatialdata/issues/109), idle since
+    June 2023, covers images, labels and transformations), and the live 2.5D
+    discussion ([#961](https://github.com/scverse/spatialdata/issues/961))
+    scopes itself to points, images and labels. Serial-section MSI is 2.5D in
+    that taxonomy.
+
+    Expressing the depth as a ``Translation`` on flat geometry — the obvious
+    remaining alternative — does **not** work either: the transform silently
+    drops z, leaving a depth that exists only in metadata.
+
+    Both negative results are pinned by
+    ``tests/unit/converters/test_3d_pixel_shapes_z.py``. If either starts
+    passing, upstream has changed and this decision should be reopened.
 
 ### Mode B: with FlexImaging optical alignment
 

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -36,14 +36,13 @@ A converted dataset contains the following elements:
     slices are merged into a single table with `x`, `y`, `z` coordinates in
     `.obs`. The TIC image becomes a single **volume** of shape `(c, z, y, x)`
     rather than one 2D image per slice — see
-    [3D Data / Z-Slices](#3d-data--z-slices).
+    [3D Data / Z-Slices](#3d-data-z-slices).
 
-    The pixel shapes become `POLYGON Z`: each footprint is a flat square at the
-    micrometre depth of its own slice, so they meet the volume in z as well as
-    in x and y. They are footprints, not voxels — the extent in z is the slice
-    spacing and belongs to the image. See
-    [Coordinate systems](coordinate-systems.md) for why a `Translation` is not
-    used instead, and for the `UserWarning` spatialdata emits on 3D shapes.
+    The pixel shapes stay two-dimensional: one flat square per pixel per slice,
+    carrying no depth. Read a pixel's depth from the table's `spatial_z`
+    instead. See [Pixel footprints in a volume](#pixel-footprints-in-a-volume)
+    for why, and [Coordinate systems](coordinate-systems.md) for how the three
+    elements line up.
 
 !!! tip "Default dataset ID"
     The default `dataset_id` is `msi_dataset`, so typical keys look like
@@ -308,7 +307,7 @@ replaced by one **volume**:
 |---------|-----|--------------|
 | **Table** | `{dataset_id}` | pixels x m/z, with `x`, `y`, `z` and `spatial_x`, `spatial_y`, `spatial_z` in `.obs` |
 | **TIC volume** | `{dataset_id}_tic` | `(c, z, y, x)` — one channel, then the three spatial axes |
-| **Pixel Shapes** | `{dataset_id}_pixels` | GeoDataFrame of `POLYGON Z` footprints, each at its slice's depth |
+| **Pixel Shapes** | `{dataset_id}_pixels` | GeoDataFrame of 2D pixel boxes — one per pixel per slice, no z |
 
 ```python
 volume = sdata.images[f"{dataset_id}_tic"]
@@ -350,7 +349,7 @@ A `z_spacing_source` of `"assumed_isotropic"` means **nobody supplied a spacing
 and the in-plane pitch was reused** — treat the depth as unknown rather than as
 measured. Section thickness is set by the microtome, not by the raster, so the
 two agree only by coincidence. See
-[`--z-spacing`](cli.md#set---z-spacing-whenever-you-know-it).
+[`--z-spacing`](cli.md#set-z-spacing-whenever-you-know-it).
 
 !!! note "These keys only appear on volumes"
     `z_spacing_um` and `z_spacing_source` are written only when the store
@@ -361,33 +360,45 @@ two agree only by coincidence. See
 
 #### Pixel footprints in a volume
 
-The pixel polygons carry z too, so they meet the volume at `"global"` in all
-three axes. Each is a `POLYGON Z`: a flat square at the micrometre depth of the
-slice it was acquired on, the same value the table stores in `spatial_z`.
+The pixel polygons are **two-dimensional**, on every route including a volume.
+A slice's depth is not on the geometry; read it from the table's `spatial_z`,
+or from the volume's own `Scale`:
 
 ```python
 shapes = sdata.shapes[f"{dataset_id}_pixels"]
-geom = shapes.geometry.iloc[0]
-print(geom.has_z)                      # True on a multi-slice volume
-print(geom.exterior.coords[0][2])      # depth in um = z_index * z_spacing_um
+print(shapes.geometry.iloc[0].has_z)    # False, on 2D and 3D alike
+
+# Depth per pixel, in micrometres, from the table:
+obs = sdata.tables[dataset_id].obs
+print(obs.loc["0", "spatial_z"])        # z_index * z_spacing_um
 ```
 
-They are **footprints, not voxels**: a square at one depth, not a solid
-spanning the slice thickness — shapely has no solid geometry. The extent in z
-is the slice spacing, and it belongs to the image.
+Every footprint therefore resolves to the correct place in x and y, and carries
+no claim about z. Overlaying the shapes on the volume is exact in-plane and
+needs `spatial_z` to pick the slice.
 
-!!! note "spatialdata warns on 3D shapes"
-    `spatialdata`'s shapes model is 2D, so parsing, validating or transforming
-    these emits a `UserWarning` that "2 is expected". The geometry is carried
-    and scaled correctly regardless; the warning is left in place rather than
-    suppressed, because it is upstream describing the limits of its own model.
+!!! note "Why the footprints are flat"
+    They briefly were not. v3.2.0 made them `POLYGON Z` at the depth of their
+    slice, which is geometrically the more honest representation, and it broke
+    `spatialdata`'s spatial queries: a bounding box enclosing an entire test
+    volume returned 26 of 30 footprints and 26 of 30 table rows, with no
+    exception and no warning. A z-restricted query returned the same rows
+    whether z was inside or far outside the data.
 
-    Expressing the depth as a `Translation` on flat geometry instead does not
-    work — the transform silently drops z. See
-    [Coordinate systems](coordinate-systems.md).
+    `spatialdata` asks for 2D here: `ShapesModel.validate` warns that a
+    3-dimensional geometry column "could led to unexpected behaviors" and names
+    `force_2d()` as the remedy. 3D shapes are not on its roadmap
+    ([#109](https://github.com/scverse/spatialdata/issues/109) has been idle
+    since June 2023), and the live 2.5D discussion
+    ([#961](https://github.com/scverse/spatialdata/issues/961)) covers points,
+    images and labels only. Serial-section MSI is 2.5D in that sense.
 
-    Single-plane acquisitions and the per-slice 2D route keep flat geometry,
-    since neither has a z axis to place anything on.
+    So this is a deliberate trade: a documented gap in z, in exchange for
+    queries that return every pixel. Expressing the depth as a `Translation` on
+    flat geometry does not close the gap either — the transform silently drops
+    z. Both negative results are pinned by
+    `tests/unit/converters/test_3d_pixel_shapes_z.py`, which will fail if
+    upstream changes. See [Coordinate systems](coordinate-systems.md).
 
 ---
 

--- a/tests/unit/converters/test_3d_pixel_shapes_z.py
+++ b/tests/unit/converters/test_3d_pixel_shapes_z.py
@@ -1,30 +1,40 @@
 # tests/unit/converters/test_3d_pixel_shapes_z.py
-"""A volume's pixel footprints sit at the depth of the slice they came from.
+"""A volume's pixel footprints are flat, and its depth lives elsewhere.
 
-``_create_pixel_shapes`` took an ``is_3d`` argument and never read it. Every
-slice's footprints were built from ``spatial_x``/``spatial_y`` alone, so a
-volume's polygons all stacked flat at z=0 while its TIC image spanned
-``n_z * z_spacing_um`` in depth. ``docs/coordinate-systems.md`` promises that
-every element in a Thyra store resolves to the same physical frame at
-``"global"``; for a volume that promise was false in z, and PR #160 (which made
-the *image* honest) did not change it.
+The history here is worth keeping, because the obvious reading of it is
+wrong in both directions.
 
-Footprints now carry z, taken from ``obs["spatial_z"]`` -- already micrometres,
-and the same column the table stores, which is what makes the two elements
-agree rather than merely both look plausible.
+``_create_pixel_shapes`` originally took an ``is_3d`` argument and never
+read it, so a volume's polygons stacked at z=0 while its TIC image spanned
+``n_z * z_spacing_um``. 7317792 fixed that by making the footprints
+``POLYGON Z`` at the depth of their slice. Geometrically that was right,
+and it broke ``spatialdata``'s spatial queries: measured on this fixture,
+a bounding box enclosing the entire dataset with 1000um of margin returned
+26 of 30 footprints and 26 of 30 table rows, with no exception and no
+warning. ``shapely.force_2d`` on the same geometry returned 30 of 30.
 
-**Why not the obvious alternative.** spatialdata's shapes model is 2D, which
-invites keeping flat geometry and putting the depth in a transformation (one
-element per slice, each with a ``Translation`` in z). Measured, that silently
-loses: the element parses without complaint, coexists with a 3D image and
-survives a zarr round trip, but the transform **drops z** and every slice comes
-back at the same depth -- a depth recorded in the metadata that never reaches
-the geometry. ``test_a_translation_would_not_have_worked`` pins that, because
-it is the change someone will otherwise propose again.
+So the depth was moved back off the geometry, and this file pins the
+resulting arrangement:
 
-These are footprints, not voxels: a flat square at one depth, since shapely has
-no solid. The pixel's extent in z is the slice spacing and is carried by the
-image, not by the polygon.
+* the polygons are 2D -- one square per pixel, in x and y only;
+* the depth is on the TIC image's ``Scale`` and in ``obs["spatial_z"]``,
+  both of which 255c177 made honest and neither of which changed here;
+* spatial queries return every pixel again.
+
+**This is not a claim that flat is ideal.** It is a claim that a
+documented gap beats a silently truncated query. ``spatialdata`` asks for
+it too: ``ShapesModel.validate`` warns that a 3-dimensional geometry
+column "could led to unexpected behaviors" and names ``force_2d()`` as the
+remedy. 3D shapes are absent from the upstream roadmap
+(scverse/spatialdata#109, idle since June 2023, covers images, labels and
+transformations), and the live 2.5D discussion (#961) scopes itself to
+points, images and labels. Serial-section MSI is 2.5D in that taxonomy.
+
+Two tests here are tripwires rather than assertions about Thyra:
+``test_polygon_z_still_breaks_spatial_queries`` and
+``test_a_translation_would_not_have_worked``. If either fails, upstream
+has changed and this decision is worth reopening -- that is a signal, not
+a regression.
 """
 
 from __future__ import annotations
@@ -52,10 +62,14 @@ _DATASET_ID = "vol"
 # for another and make a wrong answer look right.
 _N_X, _N_Y, _N_Z = 5, 3, 2
 
-# 25x apart, so a footprint placed with the in-plane pitch instead of the slice
+# 25x apart, so a depth placed with the in-plane pitch instead of the slice
 # spacing is off by more than any rounding could explain.
 _PIXEL_SIZE_UM = 10.0
 _Z_SPACING_UM = 250.0
+
+# Margin on the query box, in micrometres. Far larger than the dataset, so a
+# footprint can only be missing because the query mishandled it.
+_GENEROUS_MARGIN_UM = 1000.0
 
 
 def _config(n_z: int = _N_Z) -> MockMSIConfig:
@@ -92,111 +106,110 @@ def volume(tmp_path_factory) -> Dict[str, Any]:
     store = _convert_volume(tmp_path_factory.mktemp("shapes_z"))
     sdata = spatialdata.read_zarr(str(store))
     return {
+        "sdata": sdata,
         "shapes": sdata.shapes[f"{_DATASET_ID}_pixels"],
         "obs": sdata.tables[_DATASET_ID].obs,
         "image": sdata.images[f"{_DATASET_ID}_tic"],
     }
 
 
-def _depth(geometry) -> float:
-    """The z ordinate of a footprint. Flat, so any vertex will do."""
-    return float(geometry.exterior.coords[0][2])
+def _enclosing_box(shapes):
+    """A box around every footprint, with room to spare, as (min, max)."""
+    bounds = shapes.geometry.bounds
+    return (
+        [
+            float(bounds.minx.min()) - _GENEROUS_MARGIN_UM,
+            float(bounds.miny.min()) - _GENEROUS_MARGIN_UM,
+        ],
+        [
+            float(bounds.maxx.max()) + _GENEROUS_MARGIN_UM,
+            float(bounds.maxy.max()) + _GENEROUS_MARGIN_UM,
+        ],
+    )
 
 
-def test_volume_footprints_carry_z(volume):
-    """The reproduction. Before, these were 2D and every depth was absent."""
+def test_volume_footprints_are_flat(volume):
+    """The decision, stated directly.
+
+    One footprint per pixel across every slice, none of them carrying a z
+    ordinate. The count matters as much as the flatness: dropping z must
+    not also drop a slice.
+    """
     shapes = volume["shapes"]
 
     assert len(shapes) == _N_X * _N_Y * _N_Z
-    assert all(geometry.has_z for geometry in shapes.geometry)
+    assert not any(geometry.has_z for geometry in shapes.geometry)
 
 
-def test_each_footprint_sits_at_its_own_slice_depth(volume):
-    """Depth must be the slice index times the spacing -- in closed form.
+def test_a_whole_dataset_query_returns_every_footprint(volume):
+    """The regression this arrangement exists for.
 
-    Checked against the arithmetic rather than against the store, so this
-    fails if the converter and the expectation drift apart. The set of depths
-    is compared too: a bug that put every footprint on plane 0 would satisfy a
-    per-row check that only ever looked at plane 0.
+    Under POLYGON Z this returned 26 of 30 shapes and 26 of 30 table rows
+    for a box enclosing everything, silently. No exception, no warning --
+    a user filtering a volume to a region simply got fewer pixels than
+    they asked for, with nothing to indicate it.
     """
-    shapes, obs = volume["shapes"], volume["obs"]
+    from spatialdata import bounding_box_query
 
-    expected_depths = [z * _Z_SPACING_UM for z in range(_N_Z)]
-    assert sorted({_depth(g) for g in shapes.geometry}) == expected_depths
+    sdata, shapes = volume["sdata"], volume["shapes"]
+    minimum, maximum = _enclosing_box(shapes)
 
-    for label, geometry in zip(shapes.index, shapes.geometry):
-        z_index = int(obs.loc[label, "z"])
-        assert _depth(geometry) == pytest.approx(z_index * _Z_SPACING_UM)
+    result = bounding_box_query(
+        sdata,
+        axes=("x", "y"),
+        min_coordinate=minimum,
+        max_coordinate=maximum,
+        target_coordinate_system="global",
+    )
 
-
-def test_footprints_and_table_agree_at_global(volume):
-    """The two elements a consumer overlays must land at the same depth.
-
-    obs["spatial_z"] and the polygons are built in different places. Either
-    alone can be self-consistent while the pair disagrees, which is the class
-    of defect this whole area keeps producing.
-    """
-    shapes, obs = volume["shapes"], volume["obs"]
-
-    for label, geometry in zip(shapes.index, shapes.geometry):
-        assert _depth(geometry) == pytest.approx(float(obs.loc[label, "spatial_z"]))
+    assert result is not None, "a box enclosing the data returned nothing"
+    assert len(result.shapes[f"{_DATASET_ID}_pixels"]) == len(shapes)
+    assert len(result.tables[_DATASET_ID]) == len(shapes)
 
 
-def test_footprints_and_image_span_the_same_depth(volume):
-    """The volume's depth extent and the footprints' must be the same range.
+def test_the_depth_is_still_recorded_on_the_table_and_the_image(volume):
+    """Flat geometry must not mean the depth is gone from the store.
 
-    The image spans n_z planes scaled by z_spacing; the deepest footprint sits
-    on the last plane. If either the Scale or the footprint depth used the
-    in-plane pitch, these part company.
+    ``obs["spatial_z"]`` and the image's ``Scale`` are where it lives now,
+    and they have to keep agreeing with each other: a consumer reads one
+    or the other and must land in the same place.
     """
     from spatialdata.transformations import get_transformation
 
-    shapes, image = volume["shapes"], volume["image"]
-
-    n_z_planes = np.asarray(image.data).shape[1]
-    assert n_z_planes == _N_Z
+    obs, image = volume["obs"], volume["image"]
 
     axes = ("c", "z", "y", "x")
     matrix = get_transformation(image, "global").to_affine_matrix(
         input_axes=axes, output_axes=axes
     )
     z_scale = float(matrix[1, 1])
-
     assert z_scale == pytest.approx(_Z_SPACING_UM)
-    assert max(_depth(g) for g in shapes.geometry) == pytest.approx(
-        (n_z_planes - 1) * z_scale
-    )
+
+    n_z_planes = np.asarray(image.data).shape[1]
+    assert n_z_planes == _N_Z
+
+    depths = sorted(set(float(v) for v in obs["spatial_z"]))
+    assert depths == [z * _Z_SPACING_UM for z in range(_N_Z)]
+
+    # The table's deepest pixel and the image's last plane are the same place.
+    assert max(depths) == pytest.approx((n_z_planes - 1) * z_scale)
+
+    # And each row's depth is its own slice index, not plane 0 for everyone.
+    for label in obs.index:
+        z_index = int(obs.loc[label, "z"])
+        assert float(obs.loc[label, "spatial_z"]) == pytest.approx(
+            z_index * _Z_SPACING_UM
+        )
 
 
 def test_the_footprint_is_still_pixel_sized(volume):
-    """Adding depth must not disturb the in-plane extent.
-
-    A footprint is the pixel's square at one depth; it is not a voxel, and its
-    x/y size is still the in-plane pitch.
-    """
+    """The in-plane extent is the pitch, unchanged by any of this."""
     geometry = volume["shapes"].geometry.iloc[0]
     xs = [c[0] for c in geometry.exterior.coords]
     ys = [c[1] for c in geometry.exterior.coords]
 
     assert max(xs) - min(xs) == pytest.approx(_PIXEL_SIZE_UM)
     assert max(ys) - min(ys) == pytest.approx(_PIXEL_SIZE_UM)
-
-
-def test_a_single_slice_volume_stays_flat(tmp_path):
-    """``handle_3d`` alone is not a volume, so it gets no z.
-
-    ``SpatialData3DConverter`` forces ``handle_3d=True`` regardless of the
-    data, and a one-plane acquisition through it takes the 2D branch
-    everywhere else. Footprints must follow, or a flat dataset acquires a
-    depth axis it has no planes for.
-    """
-    import spatialdata
-
-    store = _convert_volume(tmp_path, n_z=1)
-    sdata = spatialdata.read_zarr(str(store))
-    shapes = sdata.shapes[f"{_DATASET_ID}_pixels"]
-
-    assert not any(geometry.has_z for geometry in shapes.geometry)
 
 
 def test_the_2d_route_is_unchanged(tmp_path):
@@ -223,17 +236,80 @@ def test_the_2d_route_is_unchanged(tmp_path):
         ), f"{key} grew a z coordinate"
 
 
+def test_polygon_z_still_breaks_spatial_queries():
+    """Tripwire: the measured reason the footprints are flat.
+
+    Builds the geometry 7317792 shipped -- flat squares at two different
+    depths -- and queries a box that encloses all of them in x and y. Some
+    come back missing. ``spatialdata``'s own ``ShapesModel.validate`` warns
+    that a 3-dimensional geometry column "could led to unexpected
+    behaviors"; this is that behaviour, and it is silent.
+
+    If this test fails, upstream now handles ``POLYGON Z`` in queries and
+    the flat-footprint decision is worth reopening. That is the point of
+    the test: it is a signal, not a regression.
+    """
+    import geopandas as gpd
+    from shapely.geometry import Polygon
+    from spatialdata import SpatialData, bounding_box_query
+    from spatialdata.models import ShapesModel
+    from spatialdata.transformations import Identity
+
+    half = _PIXEL_SIZE_UM / 2
+    geometries = []
+    for z_index in range(_N_Z):
+        z = z_index * _Z_SPACING_UM
+        for y_index in range(_N_Y):
+            for x_index in range(_N_X):
+                x = x_index * _PIXEL_SIZE_UM
+                y = y_index * _PIXEL_SIZE_UM
+                geometries.append(
+                    Polygon(
+                        [
+                            (x - half, y - half, z),
+                            (x + half, y - half, z),
+                            (x + half, y + half, z),
+                            (x - half, y + half, z),
+                        ]
+                    )
+                )
+
+    gdf = gpd.GeoDataFrame(
+        geometry=geometries, index=[str(i) for i in range(len(geometries))]
+    )
+    with pytest.warns(UserWarning, match="dimensions"):
+        parsed = ShapesModel.parse(gdf, transformations={"global": Identity()})
+
+    sdata = SpatialData(shapes={"pixels": parsed})
+    minimum, maximum = _enclosing_box(parsed)
+
+    result = bounding_box_query(
+        sdata,
+        axes=("x", "y"),
+        min_coordinate=minimum,
+        max_coordinate=maximum,
+        target_coordinate_system="global",
+    )
+    returned = 0 if result is None else len(result.shapes["pixels"])
+
+    assert returned < len(geometries), (
+        "a POLYGON Z bounding-box query now returns every footprint; "
+        "spatialdata may have gained 3D shape support, so revisit whether "
+        "the pixel footprints should carry their slice depth again"
+    )
+
+
 def test_a_translation_would_not_have_worked():
-    """Pins the measured negative result behind the POLYGON Z choice.
+    """Tripwire: the other representation, also measured, also rejected.
 
-    Keeping flat 2D geometry and expressing the depth as a ``Translation`` is
-    the natural reading of spatialdata's 2D shapes model, and it is the change
-    someone will proposeagain on seeing the UserWarning that POLYGON Z
-    provokes. It does not work, and it fails *silently*: the transform drops z
-    and returns flat geometry, so the depth lives only in the metadata.
+    Keeping flat geometry and expressing the depth as a ``Translation`` is
+    the natural reading of spatialdata's 2D shapes model, and it is the
+    change someone will propose on seeing that the footprints are flat. It
+    does not work, and it fails *silently*: the transform drops z and
+    returns flat geometry, so the depth would live only in metadata.
 
-    If a future spatialdata makes this work, this test fails -- and that is the
-    signal to revisit the choice, not a regression.
+    If a future spatialdata makes this work, this test fails -- and that is
+    the signal to revisit, not a regression.
     """
     import geopandas as gpd
     import spatialdata
@@ -261,5 +337,5 @@ def test_a_translation_would_not_have_worked():
     assert max(c[0] for c in geometry.exterior.coords) == pytest.approx(_PIXEL_SIZE_UM)
     assert not geometry.has_z, (
         "spatialdata now carries z through a Translation on 2D shapes; "
-        "revisit whether POLYGON Z is still the right representation"
+        "revisit how a volume's footprints should record their depth"
     )

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -151,7 +151,7 @@ try:
     import xarray as xr
     import zarr
     from anndata import AnnData
-    from shapely.geometry import Polygon, box
+    from shapely.geometry import box
     from spatialdata import SpatialData
     from spatialdata.models import Image2DModel, ShapesModel, TableModel
     from spatialdata.transformations import Affine, Identity, Scale, Sequence
@@ -1509,48 +1509,63 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
 
         coo_arrays["current_idx"] = end_idx
 
-    def _create_pixel_shapes(
-        self, adata: AnnData, is_3d: bool = False
-    ) -> "ShapesModel":
+    def _create_pixel_shapes(self, adata: AnnData) -> "ShapesModel":
         """Create geometric shapes for pixels with proper transformations.
 
         When optical alignment is available (FlexImaging with Area definitions),
         shapes are created in optical image pixel coordinates for proper overlay.
         Otherwise, shapes use physical (micrometer) coordinates.
 
-        For a multi-slice volume the footprints are ``POLYGON Z``: a flat
-        square at the micrometre depth of the slice it was acquired on,
-        taken from ``obs["spatial_z"]``. They are footprints, not voxels --
-        shapely has no solid, so a pixel is its square at one depth rather
-        than a box spanning the slice thickness.
+        **Footprints are two-dimensional, including on a multi-slice
+        volume.** A slice's depth is carried by the TIC image's ``Scale``
+        and by ``obs["spatial_z"]``; it is deliberately not also put on
+        the polygon geometry.
 
-        Two alternatives were measured and rejected:
+        Three options were measured. All three are imperfect, so what
+        follows is the reasoning rather than a claim that this one is
+        free:
 
+        * **``POLYGON Z``** -- geometrically the most honest, and what
+          7317792 shipped in v3.2.0. It breaks ``spatialdata``'s spatial
+          queries: measured on a 5x3x2 volume, a bounding box enclosing
+          the whole dataset with 1000um of margin returned 26 of 30
+          footprints and 26 of 30 table rows, with no exception and no
+          warning. ``shapely.force_2d`` on the same geometry restored
+          30 of 30. A z-restricted query returned the same rows whether
+          z was inside or far outside the data, so z is ignored by the
+          query path rather than honoured.
         * **Flat 2D shapes carrying the depth in a transformation**
-          (one element per slice, each with a ``Translation`` in z). This
-          is what spatialdata's 2D shapes model invites, and it does not
-          work: the element parses without complaint, coexists with a 3D
-          image and round-trips, but the transform **silently drops z**
-          and every slice comes back at the same depth. It would put a
-          depth in the metadata that never reaches the geometry.
-        * **Leaving them flat** and documenting it. Honest, but then
-          ``docs/coordinate-systems.md``'s promise that every element
-          agrees at ``"global"`` stays false in z.
+          (one element per slice, each with a ``Translation`` in z).
+          The element parses, coexists with a 3D image and round-trips,
+          but the transform **silently drops z** and every slice comes
+          back at the same depth -- a depth in the metadata that never
+          reaches the geometry. ``test_3d_pixel_shapes_z.py`` pins this,
+          because it is the change someone will otherwise propose.
+        * **Flat, with the depth on the image and in ``obs`` only** --
+          what this does.
 
-        The cost of the choice: ``ShapesModel.parse``/``validate`` and
-        every downstream ``transform`` emit a ``UserWarning`` that 2
-        dimensions are expected. It is left unsuppressed deliberately --
-        it is upstream telling consumers this is outside the model, and
-        hiding it would be Thyra deciding that on their behalf. Only the
-        micrometre branch gains z; under optical alignment the frame is
-        optical pixels, which have no depth calibration to place a slice
-        in.
+        The deciding argument is that ``spatialdata`` itself asks for
+        this. ``ShapesModel.validate`` warns that a 3-dimensional
+        geometry column "could led to unexpected behaviors" and names
+        ``force_2d()`` as the remedy; the query result above is that
+        behaviour. 3D shapes are not on the upstream roadmap
+        (scverse/spatialdata#109 has been idle since June 2023 and
+        covers images, labels and transformations only), and the live
+        2.5D discussion (#961) scopes itself to points, images and
+        labels. Serial-section MSI is 2.5D in that taxonomy.
+
+        What this costs: ``docs/coordinate-systems.md``'s promise that
+        every element agrees at ``"global"`` is exact in x and y and
+        silent in z for the shapes element. That is a documented gap
+        rather than a wrong answer, which a truncated query is not. See
+        ``docs/output-format.md`` for the consumer-facing statement.
+
+        Reinstating z means restoring the ``is_3d`` parameter at all
+        three call sites as well; it was removed with the geometry so it
+        could not sit unread, which is how the original defect arose.
 
         Args:
             adata: AnnData object containing coordinates
-            is_3d: Whether this is the 3D volume route. Combined with
-                :attr:`_is_volume` (which also requires more than one
-                plane), decides whether footprints carry z.
 
         Returns:
             SpatialData shapes model
@@ -1628,29 +1643,15 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             y_coords: NDArray[np.float64] = adata.obs["spatial_y"].values
             half_pixel_um = self.pixel_size_um / 2
 
-            # A volume's footprints carry the depth of the slice they were
-            # acquired on, so they meet the TIC volume at "global" instead
-            # of stacking flat at z=0. spatial_z is already the micrometre
-            # depth (z index * z_spacing_um), so it needs no scaling here
-            # -- the same column the table stores, which is what keeps the
-            # two elements agreeing.
-            z_coords: Optional[NDArray[np.float64]] = None
-            if is_3d and self._is_volume:
-                z_coords = adata.obs["spatial_z"].values
-
+            # Footprints are flat, on every route including volumes. A
+            # slice's depth lives on the TIC image's Scale and in
+            # obs["spatial_z"]; see the docstring for why it is not also
+            # put on the geometry.
             for i in range(len(adata)):
                 x, y = x_coords[i], y_coords[i]
                 x0, y0 = x - half_pixel_um, y - half_pixel_um
                 x1, y1 = x + half_pixel_um, y + half_pixel_um
-
-                if z_coords is None:
-                    pixel_box = box(x0, y0, x1, y1)
-                else:
-                    z = float(z_coords[i])
-                    pixel_box = Polygon(
-                        [(x0, y0, z), (x1, y0, z), (x1, y1, z), (x0, y1, z)]
-                    )
-                geometries.append(pixel_box)
+                geometries.append(box(x0, y0, x1, y1))
 
         # Create GeoDataFrame with appropriate index
         if valid_indices is not None:

--- a/thyra/converters/spatialdata/spatialdata_2d_converter.py
+++ b/thyra/converters/spatialdata/spatialdata_2d_converter.py
@@ -328,9 +328,7 @@ class SpatialData2DConverter(BaseSpatialDataConverter):
 
                 # Add to tables and create shapes
                 data_structures["tables"][slice_id] = table
-                data_structures["shapes"][region_key] = self._create_pixel_shapes(
-                    adata, is_3d=False
-                )
+                data_structures["shapes"][region_key] = self._create_pixel_shapes(adata)
 
                 # Create TIC image for this slice
                 tic_values = slice_data["tic_values"]

--- a/thyra/converters/spatialdata/spatialdata_3d_converter.py
+++ b/thyra/converters/spatialdata/spatialdata_3d_converter.py
@@ -246,9 +246,7 @@ class SpatialData3DConverter(BaseSpatialDataConverter):
 
             # Add to tables and create shapes
             data_structures["tables"][self.dataset_id] = table
-            data_structures["shapes"][region_key] = self._create_pixel_shapes(
-                adata, is_3d=True
-            )
+            data_structures["shapes"][region_key] = self._create_pixel_shapes(adata)
 
             # Create TIC image
             self._create_tic_image(data_structures)

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -1004,9 +1004,7 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
 
                 # Add to tables and create shapes
                 data_structures["tables"][slice_id] = table
-                data_structures["shapes"][region_key] = self._create_pixel_shapes(
-                    adata, is_3d=False
-                )
+                data_structures["shapes"][region_key] = self._create_pixel_shapes(adata)
 
                 # Create TIC image for this slice
                 tic_values = slice_data["tic_values"]


### PR DESCRIPTION
## What

v3.2.0 (#162) made a volume's pixel footprints `POLYGON Z`, each at the depth
of its own slice. Geometrically that is the more honest representation. It
breaks `spatialdata`'s spatial queries.

Measured on a 5x3x2 volume, a bounding box enclosing the entire dataset with
1000 um of margin:

| geometry | footprints returned | table rows returned |
|---|---|---|
| `POLYGON Z` | **26 / 30** | **26 / 30** |
| after `force_2d` | 30 / 30 | 30 / 30 |

No exception and no warning in between. A z-restricted query returned the same
rows whether z sat inside the data or 250 um outside it -- z is ignored by the
query path rather than honoured. So filtering a volume to a region silently
returned fewer pixels than were asked for: the same class of quiet wrong answer
the whole v3.0.x series was spent removing.

## Why 2D rather than documenting the limitation

Upstream asks for it. `ShapesModel.validate` warns that a 3-dimensional
geometry column *"could led to unexpected behaviors"* and names `force_2d()` as
the remedy -- the query result above **is** that behaviour, and spatialdata
ships the remedy itself.

3D shapes are also not coming:

- [scverse/spatialdata#109](https://github.com/scverse/spatialdata/issues/109)
  "Roadmap for full 3D support" has been idle since June 2023 and covers io,
  images, labels and transformations. Shapes are not on it.
- The live 2.5D discussion,
  [#961](https://github.com/scverse/spatialdata/issues/961) (updated July 2025),
  scopes itself to points, images and labels. Shapes are not in it.

Serial-section MSI is 2.5D in that taxonomy, not a sampled volume.

## Nothing is lost from the store

Depth stays on the TIC image's `Scale` and in `obs["spatial_z"]` -- both from
#160, neither touched here. What goes is the claim on the polygon geometry.

`docs/coordinate-systems.md`'s promise that every element agrees at `"global"`
is now exact in x and y and **explicitly silent in z** for the shapes element,
with a table showing where each element's depth lives. A documented gap beats a
truncated query.

## Tripwires, not assertions

Two tests exist to fail if upstream changes:

- `test_polygon_z_still_breaks_spatial_queries` builds the v3.2.0 geometry and
  asserts the query still truncates. If it starts passing, spatialdata gained
  3D shape support and this decision should be reopened.
- `test_a_translation_would_not_have_worked` pins that expressing depth as a
  `Translation` on flat geometry silently drops z -- the alternative someone
  will otherwise propose.

## Also

- The `is_3d` parameter is removed rather than left unread at three call sites.
  That argument existing and being ignored is exactly how the original defect
  arose; reinstating z means restoring it deliberately.
- Fixes the two anchors #160 left broken in `docs/output-format.md`. mkdocs
  reports these at INFO, so `--strict` cannot catch them -- adding
  `validation: {links: {anchors: warn}}` to `mkdocs.yml` would, and belongs in
  the docs batch rather than here.

## Stored values

A volume's shapes element loses its z ordinate. Tables, images, `uns` and all
2D output are unchanged.

## Verification

- `pytest -q` -> 1384 passed, 13 skipped, 18 deselected
- `pytest -m integration` -> 18 passed
- whole-dataset query on real converter output -> 30/30 shapes, 30/30 rows
- `read_lazy` on a volume -> `(30, 64)`, `spatial_z` uniques `[0.0, 250.0]`
- `mkdocs build --strict` clean, no anchor warnings
- black, isort, flake8, mypy, bandit, pydocstyle all clean
