### PR TITLE
feat(readers): read PHI SmartSoft-TOF ToF-SIMS .raw data

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ for a full walkthrough, including the published example dataset
 
 ## Features
 
-- **Multiple Input Formats**: ImzML, Bruker (.d directories), Waters (.raw directories)
+- **Multiple Input Formats**: ImzML, Bruker (.d directories), Waters (.raw directories), PHI SmartSoft-TOF ToF-SIMS (.raw files)
 - **SpatialData Output**: Modern, cloud-ready format with Zarr backend
 - **Memory Efficient**: Handles large datasets (100+ GB) through streaming processing
 - **Optical Alignment**: Automatic MSI-to-optical image registration for Bruker data
@@ -53,9 +53,16 @@ thyra input.imzML output.zarr
 # Bruker data with verbose logging
 thyra data.d output.zarr -v DEBUG
 
+# PHI SmartSoft-TOF ToF-SIMS (a .raw file, not a directory)
+thyra tofsims_run.raw output.zarr
+
 # Disable resampling
 thyra input.imzML output.zarr --no-resample
 ```
+
+Thyra auto-detects the input format. Note that `.raw` is claimed by two
+vendors and resolved by shape: Waters writes a directory, PHI writes a single
+file. See [Supported Formats](https://M4i-Imaging-Mass-Spectrometry.github.io/thyra/supported-formats/).
 
 ### Python API
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -221,9 +221,11 @@ with ImzMLReader("sample.imzML") as reader:
 
 ## Reader Base Class
 
-All format readers (ImzML, Bruker, Waters) inherit from this base class. If
-you are writing a custom reader for a new format, subclass `BaseMSIReader`
-and implement the abstract methods below.
+All format readers (ImzML, Bruker, Waters, PHI) inherit from this base class.
+If you are writing a custom reader for a new format, subclass `BaseMSIReader`
+and implement the abstract methods below. See
+[Supported Formats](supported-formats.md) for which optional methods are worth
+implementing and what each one buys you.
 
 ::: thyra.core.base_reader.BaseMSIReader
     options:
@@ -231,7 +233,9 @@ and implement the abstract methods below.
         - get_essential_metadata
         - get_comprehensive_metadata
         - get_common_mass_axis
+        - get_mass_axis_annotations
         - get_optical_image_paths
+        - get_peak_counts_per_pixel
         - iter_spectra
         - get_region_map
         - get_region_info

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,10 +32,19 @@ thyra input.imzML output.zarr
 
 # Bruker .d folder
 thyra data.d output.zarr
+
+# Waters .raw folder
+thyra data.raw output.zarr
+
+# PHI SmartSoft-TOF ToF-SIMS .raw file
+thyra tofsims_run.raw output.zarr
 ```
 
 That's it -- Thyra auto-detects the format, reads the pixel size from metadata,
 resamples onto a common mass axis, and writes a SpatialData/Zarr directory.
+
+See [Supported Formats](supported-formats.md) for the full list, how each one
+is detected, and what metadata each can supply.
 
 ### Python API
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ The output is a single SpatialData/Zarr directory containing intensity matrices,
 
 | | Feature | Description |
 |---|---------|-------------|
-| **Formats** | Multiple inputs | ImzML, Bruker (.d timsTOF + Rapiflex), Waters (.raw) |
+| **Formats** | Multiple inputs | ImzML, Bruker (.d timsTOF + Rapiflex), Waters (.raw directory), PHI SmartSoft-TOF (.raw file) |
 | **Output** | SpatialData/Zarr | Cloud-ready, chunked, standardised |
 | **Scale** | Memory efficient | Streaming mode for 100+ GB datasets |
 | **Optics** | Optical alignment | Automatic MSI-to-microscopy registration (Bruker) |
@@ -90,11 +90,16 @@ tic = np.asarray(sdata.images["msi_dataset_z0_tic"])[0]
 
 ### Input
 
-| Format | Extension | Instruments |
-|--------|-----------|-------------|
-| ImzML  | `.imzML`  | Any vendor exporting to open standard |
-| Bruker | `.d`      | timsTOF fleX, Rapiflex MALDI-TOF |
-| Waters | `.raw`    | MassLynx imaging (DESI, MALDI) |
+| Format | Path | Instruments |
+|--------|------|-------------|
+| ImzML  | `.imzML` file | Any vendor exporting to the open standard |
+| Bruker | `.d` directory | timsTOF fleX, Rapiflex MALDI-TOF |
+| Waters | `.raw` directory | MassLynx imaging (DESI, MALDI) |
+| PHI    | `.raw` file | SmartSoft-TOF nanoTOF (ToF-SIMS) |
+
+`.raw` is claimed by two vendors and resolved by shape: Waters writes a
+directory, PHI writes a single file. See
+[Supported Formats](supported-formats.md).
 
 ### Output
 
@@ -108,6 +113,7 @@ tic = np.asarray(sdata.images["msi_dataset_z0_tic"])[0]
 
 - **[Getting Started](getting-started.md)** -- installation, first conversion, common workflows
 - **[Tutorial](tutorial.md)** -- step-by-step walkthrough, from an example dataset to ion images
+- **[Supported Formats](supported-formats.md)** -- every input format, how it is detected, what metadata it supplies
 - **[CLI Reference](cli.md)** -- every command-line option explained
 - **[Resampling](resampling.md)** -- how the common mass axis is chosen, and how to control it
 - **[Output Format](output-format.md)** -- what the .zarr contains and how to use it

--- a/docs/phi-tofsims-notes.md
+++ b/docs/phi-tofsims-notes.md
@@ -226,8 +226,9 @@ Some properties of this format are worth knowing before analysis:
 
 ## Not yet exercised on real data
 
-Implemented from the format and covered by tests against synthetic files, but
-never run against a real acquisition:
+These paths are implemented from the format and covered by tests, but those
+tests build **synthetic** `.raw` files. No real acquisition using them has been
+through the reader, so treat them as untested rather than working:
 
 - **Mosaic acquisitions** (block 6 tile origins). The reference file declares
   `Number Of Tiles X=8, Y=2` but has mosaic mode off and contains no block 6,
@@ -236,6 +237,19 @@ never run against a real acquisition:
 - **MS/MS acquisitions**, where events move to block id 8.
 - **Depth profiling / 3D.** The reference file has `NoSputCycles: 0`. Thyra
   treats PHI data as 2D.
+
+The gap is data, not effort: each was straightforward to write and is
+impossible to confirm without a file that exercises it. Everything Thyra *is*
+verified on was verified the same way — against the instrument's own exports —
+and the same would be done here.
+
+!!! tip "Have one of these acquisitions?"
+    Please [open an issue](https://github.com/M4i-Imaging-Mass-Spectrometry/thyra/issues)
+    if you need one of these supported. A single representative file is enough
+    to turn any of them from untested into verified, and a `.bif6` export
+    alongside it makes the check exact. Say which acquisition mode you used and
+    roughly how large the file is; the data itself does not have to be attached
+    to the issue.
 
 ## Related exports
 

--- a/docs/phi-tofsims-notes.md
+++ b/docs/phi-tofsims-notes.md
@@ -1,0 +1,246 @@
+# PHI ToF-SIMS Notes
+
+Thyra reads PHI (Physical Electronics) SmartSoft-TOF `.raw` files from nanoTOF
+instruments directly -- there is no vendor SDK for this format, so the layout
+below was established by reverse engineering and verified against the
+instrument software's own exports.
+
+Everything on this page was measured on a 512x512 negative-mode acquisition,
+148 MB, 18.4 million ion events. The verification is not incidental: PHI's
+software can export a total-ion image and peak images as `.bif6` files, and
+reconstructing the total ion image from Thyra's parse reproduces the vendor's
+export **bit-exactly** -- 262,144 of 262,144 pixels identical.
+
+---
+
+## File layout
+
+```
+[0, HeaderSize)   ASCII key/value header, CRLF lines, SOFH ... EOFH,
+                  zero-padded out to the size it declares itself
+[HeaderSize, EOF) block-structured stream
+```
+
+The header is plain text. Top-level entries are `Key: value`; entries under a
+`[Section]` marker are `Key=value`. `HeaderSize` (20000 in the reference file)
+says where the binary begins.
+
+### Blocks
+
+Everything after the header is a chain of blocks, each introduced by a 16-byte
+header:
+
+| offset | type | meaning |
+|---|---|---|
+| 0 | uint16 | block id |
+| 2 | 10 bytes | not interpreted |
+| 12 | uint32 | record size |
+
+| id | meaning |
+|---|---|
+| 1 | ion events (8 bytes each); `8` instead when MS/MS is active |
+| 2 | end of frame, no payload |
+| 6 | mosaic tile origin: two uint32 tile indices |
+| 14 | appended ASCII info block, e.g. a post-hoc recalibration |
+| 0 | end of stream |
+
+Any other id is skipped using its record size. The chain tiles the payload
+exactly, which is what makes it trustworthy: a parse that ends anywhere other
+than end-of-file has gone wrong. In the reference file the walk covers 32,179
+blocks and lands precisely on the final byte, and the 100 end-of-frame blocks
+match the header's `NoFrames: 100`.
+
+### Events
+
+Each event is a little-endian uint64:
+
+| bits | meaning |
+|---|---|
+| 31 | set on a valid event |
+| 0-30 | flight time in picoseconds (27 bits used) |
+| 32-42 | X pixel index |
+| 43-53 | Y pixel index |
+| 58-63 | clear on a valid event |
+
+Records failing that test are dropped. The reference file carries 64,493 of
+them among 18.5 million (0.35%), many holding the `0xADADADAD` uninitialised
+-heap fill. Excluding them is what makes the reconstruction exact.
+
+!!! warning "Do not parse the payload as a flat event array"
+    Because block headers happen to be 16 bytes -- exactly two event slots --
+    and fail the validity test, a naive flat parse *appears* to work on
+    single-tile data. It silently collapses every mosaic tile onto the same
+    grid, because it never sees the block 6 tile origins.
+
+---
+
+## Mass calibration
+
+The relation is the standard time-of-flight one:
+
+```
+sqrt(m/z) = (Mass/Time) * t_us + MassOffset
+```
+
+### The header calibration may be stale
+
+The acquisition header carries `Mass/Time` and `MassOffset`, and often
+`Calibrated: no` alongside them. In the reference file those coefficients are
+left over from a positive-mode session -- its `Calibration:` line lists C+H,
+C₂, C₃, C₄ although the acquisition is negative-mode -- and they place known
+ions about **+3 mDa** high:
+
+| ion | theoretical | header calibration | error |
+|---|---|---|---|
+| CH₂⁻ | 14.01565 | 14.01851 | +2.86 mDa |
+| CN⁻ | 26.00307 | 26.00676 | +3.69 mDa |
+| CNO⁻ | 41.99799 | 42.00144 | +3.45 mDa |
+| PO₂⁻ | 62.96343 | 62.96569 | +2.26 mDa |
+| PO₃⁻ | 78.95834 | 78.96093 | +2.59 mDa |
+
+Mean +3.02 mDa, standard deviation 0.46 -- a consistent bias, not scatter.
+
+### The real calibration is appended to the file
+
+A recalibration performed after acquisition is **not** written back into the
+header. It is appended near the end of the file as a block 14
+`AsciiInfoBlock01`:
+
+```
+AppendedBlockType: AsciiInfoBlock01
+BlockAppendedDate: 07/27/2026 17:29:40
+Calibration: 4  (26.003016, C+N, 26.003099)  (41.998143, C+N+O, 41.998001) ...
+Mass/Time: 0.382674
+MassOffset: -1.598302
+```
+
+Thyra prefers it automatically. The difference is not cosmetic -- measured
+against the instrument's own peak-image exports:
+
+| calibration | peak count recovery | mean correlation |
+|---|---|---|
+| header | 83.4% | 0.852 |
+| appended | **99.7%** | **0.985** |
+
+Pass `use_appended_calibration=False` to reproduce a legacy conversion that
+ignored it. Whichever is used, `uns["raw_metadata"]["calibration"]` records
+both sets of coefficients, which one was applied, and the appended block
+verbatim.
+
+---
+
+## The time axis, and why it is binned
+
+The instrument measures **flight time**; m/z is derived. Thyra therefore keeps
+the flight time in `var["tof_us"]` next to `var["mz"]`, so the calibration is
+reversible without re-reading the raw file:
+
+```python
+import spatialdata as sd
+
+table = next(iter(sd.read_zarr("out.zarr").tables.values()))
+cal = table.uns["raw_metadata"]["calibration"]
+
+tof = table.var["tof_us"].to_numpy()
+mz = (cal["mass_slope_used"] * tof + cal["mass_offset_used"]) ** 2   # == var["mz"]
+
+# a corrected calibration needs only the stored times
+better = (0.382674 * tof - 1.598302) ** 2
+```
+
+### What binning costs
+
+Events are binned onto the detector's time-channel grid, whose width the header
+gives as `SpecBinSize` (0.128 ns = 128 ps). Individual flight times are
+recorded more finely than that -- `SpecBinIncr` is 1 ps -- and in a
+mass-shift-corrected file they are scattered off the native grid entirely (only
+0.77% of times are multiples of 128 ps).
+
+So it is fair to ask what binning to 128 ps throws away. Measured across bin
+widths on the reference file, against the vendor's peak images:
+
+| bin (ps) | channels | non-zeros | axis size | peak recovery | correlation |
+|---|---|---|---|---|---|
+| 1 | 116,578,841 | 16,712,840 | 932.6 MB | 99.7% | 0.9846 |
+| 8 | 14,572,356 | 16,712,840 | 116.6 MB | 99.7% | 0.9851 |
+| 32 | 3,643,089 | 16,712,840 | 29.1 MB | 99.8% | 0.9869 |
+| **128** | **910,773** | **16,712,608** | **7.3 MB** | **100.4%** | **0.9937** |
+| 512 | 227,694 | 14,453,296 | 1.8 MB | 100.8% | 0.9820 |
+| 2048 | 56,924 | 11,935,480 | 0.5 MB | 76.3% | -- |
+
+Going from 1 ps to 128 ps merges **232 cells out of 16.7 million** and shrinks
+the mass axis 128-fold. The data is so sparse that events essentially never
+share a bin: 18.4 million events occupy 16.7 million distinct (pixel, channel)
+cells regardless of how fine the bins are.
+
+Agreement with the vendor does not merely survive the coarsening, it *improves*
+-- 0.9846 to 0.9937 -- because 128 ps is the grid the instrument software
+itself works on. Finer bins place events at positions that then fall
+differently against peak-window edges.
+
+Below 128 ps you pay 128x the storage for nothing. Above it you start
+destroying data: at 512 ps a fifth of the cells merge, and at 2048 ps a quarter
+of all counts fall outside their peak windows and some peaks vanish entirely.
+
+The rounding itself is small against any real peak. Events sit a mean 32 ps
+from their bin centre, worst case 64 ps, which at m/z 79 is 4.7 ppm or
+0.37 mDa -- against a vendor integration window for PO₃⁻ that is 49.3 mDa wide.
+
+!!! note "What is not stored"
+    The output holds the binned axis, not the 18.4 million individual events.
+    Per-event data -- for instance the exact arrival time of one ion, or
+    re-binning at a width Thyra did not choose -- requires the original `.raw`.
+    Keep it.
+
+---
+
+## Pixel size
+
+Derived as `Raster Size (um) / ImagePixels`, which for the reference file is
+512 µm over 512 pixels: **1.00 µm**, matching what the operator selected.
+
+The header also carries `Raster Size Calibration` (1.550 here). Thyra
+deliberately does **not** apply it: it trims the scan generator so the raster
+achieves the requested pitch, rather than scaling the field of view.
+Multiplying by it would inflate every coordinate by 55%. Override with
+`pixel_size_um=` if a future instrument configuration needs it; the source is
+recorded in `uns["format_specific"]["pixel_size_source"]`.
+
+---
+
+## Acquisition characteristics
+
+Some properties of this format are worth knowing before analysis:
+
+- **Extremely sparse.** 18.4 million events over 262,144 pixels and 863,670
+  mass channels is 64 occupied channels per pixel on average -- 0.007% density.
+  Counts are low: the mean pixel holds 70 ions, the maximum 491.
+- **Frames are summed.** `NoFrames: 100` means 100 passes over the raster,
+  concatenated in the stream and summed into one image. Thyra does not separate
+  them; there is no per-frame counter in the event record.
+- **Scatter raster.** `Raster Pattern=Scatter` means pixels are not acquired in
+  raster order, which is why every event carries its own coordinates.
+- **Empty pixels are possible.** The reference file has 2 pixels that recorded
+  no ions at all. These are skipped by `iter_spectra` rather than emitted as
+  empty spectra.
+
+## Not yet exercised on real data
+
+Implemented from the format and covered by tests against synthetic files, but
+never run against a real acquisition:
+
+- **Mosaic acquisitions** (block 6 tile origins). The reference file declares
+  `Number Of Tiles X=8, Y=2` but has mosaic mode off and contains no block 6,
+  so the grid is sized from the tile origins actually encountered, not from the
+  declared counts.
+- **MS/MS acquisitions**, where events move to block id 8.
+- **Depth profiling / 3D.** The reference file has `NoSputCycles: 0`. Thyra
+  treats PHI data as 2D.
+
+## Related exports
+
+PHI's software writes `.bif6` sidecar files -- a total-ion image, and a peak
+list of operator-selected mass windows. Thyra does **not** read these, because
+they are derived products: the total ion image is reproducible bit-exactly from
+the `.raw`, and the peak images to 99.7%. They remain useful as ground truth
+when validating a change to the reader.

--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -1,0 +1,151 @@
+# Supported Formats
+
+Thyra reads five MSI formats and writes all of them into the same
+SpatialData/Zarr layout. The input format is detected from the path -- there is
+no format flag on the CLI, and `format_type` in the Python API selects the
+*output* format, not the input.
+
+| Format | Path shape | Detected by | Vendor SDK |
+|---|---|---|---|
+| **imzML** | `.imzML` file + `.ibd` | extension, `.ibd` must exist | none |
+| **Bruker timsTOF** | `.d` directory | `analysis.tsf` or `analysis.tdf` | bundled DLL |
+| **Bruker Rapiflex** | directory | `*.dat` + `*_poslog.txt` | none |
+| **Waters MassLynx** | `.raw` **directory** | `_FUNC*.DAT` files inside | bundled DLL |
+| **PHI SmartSoft-TOF** | `.raw` **file** | `SOFH` magic in first 4 bytes | none |
+
+```bash
+thyra sample.imzML       out.zarr   # imzML
+thyra sample.d           out.zarr   # Bruker timsTOF
+thyra rapiflex_folder/   out.zarr   # Bruker Rapiflex
+thyra waters_run.raw/    out.zarr   # Waters (a directory)
+thyra tofsims_run.raw    out.zarr   # PHI (a file)
+```
+
+---
+
+## The `.raw` collision
+
+Two vendors claim `.raw`, and they are told apart by **shape, not extension**:
+
+- **Waters** `.raw` is a *directory* containing `_FUNC001.DAT`, `_FUNC002.DAT`, …
+- **PHI** `.raw` is a *single file* whose header begins with the ASCII magic
+  `SOFH`
+
+Detection checks the directory case first, then the file magic. A `.raw` path
+that is neither raises an error naming both possibilities, rather than a
+confusing Waters-specific complaint:
+
+```
+Unrecognised .raw file: <path>. Expected either a Waters directory containing
+_FUNC*.DAT files, or a PHI SmartSoft-TOF file beginning with the SOFH magic.
+```
+
+---
+
+## What each format provides
+
+Not every source carries every kind of metadata. This is what Thyra can
+actually populate from each.
+
+| | imzML | timsTOF | Rapiflex | Waters | PHI |
+|---|---|---|---|---|---|
+| Pixel size from metadata | yes | yes | yes | yes | yes |
+| Optical image | -- | yes | yes | -- | -- |
+| Optical alignment | -- | yes (`.mis`) | -- | -- | -- |
+| Multi-region | -- | yes | -- | -- | mosaic tiles |
+| 3D / multi-slice | yes | yes | -- | -- | -- |
+| Native non-m/z axis kept | -- | -- | -- | -- | flight time |
+
+Anything a format does not supply is simply absent from the output rather than
+guessed at. Pixel size is the one exception worth knowing about: when a source
+cannot report it, the CLI falls back to a default and records that it did so in
+`uns` (see [Output Format](output-format.md)).
+
+---
+
+## imzML
+
+The open interchange format, read through
+[pyimzML](https://github.com/alexandrovteam/pyimzML). Both storage modes work:
+
+- **continuous** -- every spectrum shares one m/z array, so the common mass
+  axis is read once
+- **processed** -- each spectrum carries its own m/z values, so building the
+  common axis requires a pass over every spectrum
+
+An `.imzML` without its `.ibd` beside it is rejected up front, because the XML
+holds only offsets and the binary holds the data.
+
+See [imzML Parser Notes](imzml-parser-notes.md) for the hazards Thyra works
+around in the underlying library.
+
+## Bruker timsTOF
+
+`.d` directories containing `analysis.tsf` (TOF) or `analysis.tdf` (with ion
+mobility). Reading goes through Bruker's `timsdata` library, which is bundled
+for Windows and Linux. This is the richest source Thyra handles: it carries
+optical microscopy images, FlexImaging `.mis` teaching points for MSI-to-optical
+registration, and per-pixel region annotations for multi-region slides.
+
+## Bruker Rapiflex
+
+A folder of `*.dat` files with `*_poslog.txt` and `*_info.txt` alongside. The
+position log supplies the pixel grid. No SDK required.
+
+## Waters MassLynx
+
+A `.raw` **directory** of `_FUNC*.DAT` files, read through the MassLynxRaw and
+MLReader native libraries (bundled for Windows and Linux). The pixel grid is
+reconstructed from the laser X/Y position recorded on each scan, and only MS
+functions are converted -- lockmass, MRM and ion-mobility functions are
+classified and skipped.
+
+## PHI SmartSoft-TOF (ToF-SIMS)
+
+A single `.raw` **file** from PHI (Physical Electronics) nanoTOF instruments.
+Unlike Waters and Bruker this needs **no vendor SDK** -- the format is parsed
+directly, so it behaves identically on every platform.
+
+It differs from the other formats in one important way: it records **individual
+ion arrivals**, not per-pixel spectra. Thyra aggregates those events into sparse
+spectra on the detector's time-channel grid. Because flight time is what the
+instrument actually measures, Thyra also stores it as `var["tof_us"]` so the
+mass calibration stays reversible.
+
+```bash
+thyra tofsims_run.raw out.zarr
+```
+
+```python
+from thyra.readers.phi import PhiReader
+
+with PhiReader("tofsims_run.raw") as reader:
+    print(reader.dimensions)          # (512, 512, 1)
+    print(reader.pixel_size_um)       # 1.0
+    print(reader.calibration_source)  # 'appended' or 'header'
+```
+
+See [PHI ToF-SIMS Notes](phi-tofsims-notes.md) for the file layout, the
+calibration behaviour, and why the time axis is binned the way it is.
+
+---
+
+## Adding another format
+
+A reader subclasses `BaseMSIReader` and implements four methods --
+`_create_metadata_extractor`, `get_common_mass_axis`, `iter_spectra` and
+`close` -- then registers itself with `@register_reader("name")`. The converter
+is format-agnostic, so 2D/3D handling, resampling, chunking and the whole
+SpatialData output path come for free.
+
+Optional overrides that are worth implementing when the format allows it:
+
+| Method | Buys you |
+|---|---|
+| `has_shared_mass_axis` | skips a full pass when the axis is fixed |
+| `get_peak_counts_per_pixel` | single-pass CSR build instead of two passes |
+| `get_mass_axis_annotations` | keeps a native non-m/z axis in `var` |
+| `get_region_map` / `get_region_info` | per-pixel region annotation |
+| `get_optical_image_paths` | optical images carried into the output |
+
+See [Contributing](contributing.md).

--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -125,6 +125,12 @@ with PhiReader("tofsims_run.raw") as reader:
     print(reader.calibration_source)  # 'appended' or 'header'
 ```
 
+Verified against the instrument software's own exports: the total ion image is
+reconstructed bit-exactly, and the exported peak images to 99.7%. Mosaic,
+MS/MS and depth-profiling acquisitions are implemented but have only been
+tested against synthetic files -- if you have real data in one of those modes,
+please [open an issue](https://github.com/M4i-Imaging-Mass-Spectrometry/thyra/issues).
+
 See [PHI ToF-SIMS Notes](phi-tofsims-notes.md) for the file layout, the
 calibration behaviour, and why the time axis is binned the way it is.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,11 +79,13 @@ nav:
   - Getting Started: getting-started.md
   - Tutorial: tutorial.md
   - Explore the Output: explore-the-output.ipynb
+  - Supported Formats: supported-formats.md
   - CLI Reference: cli.md
   - Resampling: resampling.md
   - Output Format: output-format.md
   - Coordinate Systems: coordinate-systems.md
   - imzML Parser Notes: imzml-parser-notes.md
+  - PHI ToF-SIMS Notes: phi-tofsims-notes.md
   - API Reference: api.md
   - Contributing: contributing.md
   - Code of Conduct: code-of-conduct.md

--- a/tests/unit/readers/test_phi_reader.py
+++ b/tests/unit/readers/test_phi_reader.py
@@ -1,0 +1,494 @@
+"""Tests for the PHI SmartSoft-TOF .raw reader.
+
+Builds synthetic .raw files matching the documented layout so the reader can
+be exercised without a multi-hundred-megabyte vendor file.
+"""
+
+import struct
+
+import numpy as np
+import pytest
+
+from thyra.core.registry import detect_format
+from thyra.readers.phi import PhiReader, build_mass_axis, parse_phi_header, scan_blocks
+from thyra.readers.phi.event_stream import decode_events
+
+HEADER_SIZE = 2048
+
+# slope 1.0 / offset 0.0 makes m/z == (t_us)**2, and a 1000 ns channel makes
+# one channel exactly one microsecond, so masses land on 1, 4, 9, ... 100.
+_HEADER_TEMPLATE = """SOFH\r
+Platform: PC\r
+SoftwareVersion: SmartSoft-TOF V3.2.0.35\r
+Technique: -TofSIMS\r
+SecIonPolarity: -\r
+DataType: unsigned long\r
+SpecBinSize: {bin_size_ns}\r
+SpecBinIncr: 0.00100\r
+StartFlightTime: {start_us}\r
+StopFlightTime: {stop_us}\r
+Mass/Time: {slope}\r
+MassOffset: {offset}\r
+ImagePixels: {pixels}\r
+ScanWidthX: 512.00000\r
+NoFrames: {frames}\r
+Calibrated: no\r
+Calibration: 2  (26.003016, C+N, 26.003099)  (41.998143, C+N+O, 41.998001)\r
+HeaderSize: {header_size}\r
+[Acq Base]\r
+Start Mass (amu)={start_mz}\r
+End Mass (amu)={stop_mz}\r
+Frames={frames}\r
+MSMS Active={msms}\r
+Raster Pattern=Scatter\r
+Raster Resolution={pixels}\r
+[PHI LMIG]\r
+Gun Particle=Bi3 +\r
+Raster Size (um)={raster_um}\r
+Raster Size Calibration=1.550, 1.550\r
+[Mosaic Area]\r
+Number Of Tiles X={tiles_x}\r
+Number Of Tiles Y={tiles_y}\r
+[Polarity]\r
+Polarity=Negative (-) Ions\r
+[Main]\r
+Project Name=SmartSoft-TOF\r
+EOFH\r
+"""
+
+
+def make_header(**overrides) -> bytes:
+    """Render an ASCII header, zero-padded to HeaderSize."""
+    fields = {
+        "bin_size_ns": "1000.00000",
+        "start_us": "0.00000",
+        "stop_us": "10.00000",
+        "slope": "1.0000000",
+        "offset": "0.0000000",
+        "pixels": 4,
+        "frames": 2,
+        "header_size": HEADER_SIZE,
+        "start_mz": "1.0",
+        "stop_mz": "100.0",
+        "msms": "Inactive",
+        "raster_um": "8.0",
+        "tiles_x": 1,
+        "tiles_y": 1,
+    }
+    fields.update(overrides)
+    text = _HEADER_TEMPLATE.format(**fields).encode("latin-1")
+    if len(text) > HEADER_SIZE:  # pragma: no cover - guards the fixture itself
+        raise AssertionError("synthetic header exceeds HeaderSize")
+    return text.ljust(HEADER_SIZE, b"\x00")
+
+
+def event(x: int, y: int, tof_ps: int) -> int:
+    """Encode one ion event as its uint64 record."""
+    return (1 << 31) | (tof_ps & 0x7FFFFFFF) | (x << 32) | (y << 43)
+
+
+def block(block_id: int, payload: bytes = b"", record_size: int = None) -> bytes:
+    """Render one block header plus payload."""
+    size = len(payload) if record_size is None else record_size
+    return (
+        struct.pack("<H", block_id) + b"\x00" * 10 + struct.pack("<I", size) + payload
+    )
+
+
+def events_block(words, block_id: int = 1) -> bytes:
+    """Render a block of ion events."""
+    return block(block_id, np.array(words, dtype="<u8").tobytes())
+
+
+def write_raw(path, blocks: bytes, **header_overrides):
+    """Write a complete synthetic .raw file."""
+    path.write_bytes(make_header(**header_overrides) + blocks + block(0))
+    return path
+
+
+@pytest.fixture
+def simple_raw(tmp_path):
+    """Two pixels with a handful of events, split across two frames."""
+    blocks = (
+        events_block([event(0, 0, 3_000_000), event(0, 0, 3_000_000)])
+        + events_block([event(1, 2, 5_000_000)])
+        + block(2)
+        + events_block([event(0, 0, 3_000_000), event(1, 2, 10_000_000)])
+        + block(2)
+    )
+    return write_raw(tmp_path / "simple.raw", blocks)
+
+
+class TestHeaderParsing:
+    def test_parses_core_fields(self, simple_raw):
+        header = parse_phi_header(simple_raw)
+        assert header.header_size == HEADER_SIZE
+        assert header.image_pixels == 4
+        assert header.mass_slope == 1.0
+        assert header.mass_offset == 0.0
+        assert header.bin_size_ns == 1000.0
+        assert header.polarity == "negative"
+        assert header.n_frames == 2
+        assert header.msms_active is False
+        assert header.data_block_id == 1
+
+    def test_parses_sections_and_calibrants(self, simple_raw):
+        header = parse_phi_header(simple_raw)
+        assert header.sections["PHI LMIG"]["Gun Particle"] == "Bi3 +"
+        assert header.sections["Acq Base"]["Raster Pattern"] == "Scatter"
+        assert [c.species for c in header.calibrants] == ["C+N", "C+N+O"]
+        assert header.calibrants[0].theoretical_mz == pytest.approx(26.003099)
+
+    def test_pixel_size_ignores_raster_calibration(self, simple_raw):
+        """Raster Size Calibration trims the scan generator, it is not a scale.
+
+        Applying it would inflate every coordinate by 55%.
+        """
+        header = parse_phi_header(simple_raw)
+        assert header.raster_size_calibration == pytest.approx(1.55)
+        # 8 um raster over 4 pixels
+        assert header.pixel_size_um == pytest.approx(2.0)
+
+    def test_msms_selects_block_id_eight(self, tmp_path):
+        path = write_raw(tmp_path / "msms.raw", b"", msms="Active")
+        assert parse_phi_header(path).data_block_id == 8
+
+    def test_rejects_non_phi_file(self, tmp_path):
+        path = tmp_path / "other.raw"
+        path.write_bytes(b"NOTPHI" + b"\x00" * 100)
+        with pytest.raises(ValueError, match="SOFH"):
+            parse_phi_header(path)
+
+    def test_rejects_unterminated_header(self, tmp_path):
+        path = tmp_path / "trunc.raw"
+        path.write_bytes(b"SOFH\r\nImagePixels: 4\r\n")
+        with pytest.raises(ValueError, match="EOFH"):
+            parse_phi_header(path)
+
+    def test_rejects_empty_flight_time_range(self, tmp_path):
+        path = write_raw(tmp_path / "bad.raw", b"", start_us="9.0", stop_us="1.0")
+        with pytest.raises(ValueError, match="flight-time range"):
+            parse_phi_header(path)
+
+
+class TestBlockScan:
+    def test_indexes_blocks_and_terminates_cleanly(self, simple_raw):
+        header = parse_phi_header(simple_raw)
+        index = scan_blocks(simple_raw, header)
+        assert index.clean is True
+        assert index.end_offset == simple_raw.stat().st_size
+        assert len(index.data_spans) == 3
+        assert index.n_records == 5
+        assert index.n_frames == 2
+        assert index.tile_grid == (1, 1)
+
+    def test_unknown_blocks_are_skipped_by_record_size(self, tmp_path):
+        blocks = (
+            block(99, b"\xde\xad\xbe\xef" * 4)
+            + events_block([event(1, 1, 4_000_000)])
+            + block(2)
+        )
+        path = write_raw(tmp_path / "unknown.raw", blocks)
+        index = scan_blocks(path, parse_phi_header(path))
+        assert index.clean is True
+        assert index.n_records == 1
+        assert index.block_counts[99] == 1
+
+    def test_raises_when_no_event_blocks(self, tmp_path):
+        path = write_raw(tmp_path / "empty.raw", block(2))
+        with pytest.raises(ValueError, match="No event blocks"):
+            scan_blocks(path, parse_phi_header(path))
+
+    def test_appended_calibration_is_recovered(self, tmp_path):
+        appended = (
+            b"AppendedBlockType: AsciiInfoBlock01\r\n"
+            b"BlockAppendedDate: 07/27/2026 17:29:40\r\n"
+            b"Mass/Time: 2.0\r\n"
+            b"MassOffset: -0.5\r\n"
+        )
+        blocks = events_block([event(0, 0, 3_000_000)]) + block(14, appended)
+        path = write_raw(tmp_path / "appended.raw", blocks)
+        index = scan_blocks(path, parse_phi_header(path))
+        assert index.appended_calibration() == (2.0, -0.5)
+
+    def test_no_appended_block_returns_none(self, simple_raw):
+        header = parse_phi_header(simple_raw)
+        assert scan_blocks(simple_raw, header).appended_calibration() is None
+
+
+class TestEventDecoding:
+    def test_round_trips_coordinates_and_flight_time(self):
+        words = np.array([event(511, 300, 21_113_342)], dtype=np.uint64)
+        x, y, tof = decode_events(words)
+        assert (x[0], y[0], tof[0]) == (511, 300, 21_113_342)
+
+    def test_supports_eleven_bit_coordinates(self):
+        words = np.array([event(2047, 2047, 1)], dtype=np.uint64)
+        x, y, _ = decode_events(words)
+        assert (x[0], y[0]) == (2047, 2047)
+
+    def test_drops_records_failing_the_validity_test(self):
+        words = np.array(
+            [
+                event(1, 1, 1000),
+                0xADADADADADADADAD,  # uninitialised-heap fill
+                event(2, 2, 2000) & ~(1 << 31),  # tag bit clear
+            ],
+            dtype=np.uint64,
+        )
+        x, _, _ = decode_events(words)
+        assert x.size == 1
+
+
+class TestMassAxis:
+    def test_axis_is_clipped_to_declared_mass_range(self):
+        axis = build_mass_axis(1.0, 0.0, 0.0, 10.0, 1000.0, 1.0, 100.0)
+        assert len(axis) == 10
+        assert axis.channel_offset == 1
+        np.testing.assert_allclose(axis.mz, [1, 4, 9, 16, 25, 36, 49, 64, 81, 100])
+
+    def test_channels_map_back_to_the_axis(self):
+        axis = build_mass_axis(1.0, 0.0, 0.0, 10.0, 1000.0, 1.0, 100.0)
+        idx, ok = axis.to_channel(np.array([3_000_000, 10_000_000], dtype=np.int64))
+        assert ok.all()
+        np.testing.assert_array_equal(idx, [2, 9])
+        np.testing.assert_allclose(axis.mz[idx], [9.0, 100.0])
+
+    def test_out_of_range_flight_times_are_masked(self):
+        axis = build_mass_axis(1.0, 0.0, 0.0, 10.0, 1000.0, 1.0, 100.0)
+        _, ok = axis.to_channel(np.array([0, 500_000_000], dtype=np.int64))
+        assert not ok.any()
+
+    def test_tof_axis_matches_the_mz_axis(self):
+        axis = build_mass_axis(1.0, 0.0, 0.0, 10.0, 1000.0, 1.0, 100.0)
+        # slope 1, offset 0 -> m/z is exactly t**2
+        np.testing.assert_allclose(axis.tof_us, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        np.testing.assert_allclose(axis.tof_us**2, axis.mz)
+
+    def test_calibration_round_trips(self):
+        axis = build_mass_axis(0.382674, -1.598302, 0.0, 120.0, 0.128, 0.5, 1850.0)
+        np.testing.assert_allclose(axis.mz_to_tof_us(axis.mz), axis.tof_us, rtol=1e-9)
+
+    def test_recalibration_from_stored_times(self):
+        """A corrected axis follows from the stored times, without the file.
+
+        The time axis does not depend on the calibration, so two axes over
+        the same channels share it exactly and differ only in m/z.
+        """
+        stale = build_mass_axis(0.3826529, -1.5976032, 0.0, 120.0, 0.128)
+        good = build_mass_axis(0.382674, -1.598302, 0.0, 120.0, 0.128)
+
+        # The axes begin at different channels -- the offset moves where the
+        # root turns positive -- but both run to the same stop time on the
+        # same grid, so they align from the tail.
+        n = min(stale.tof_us.size, good.tof_us.size)
+        np.testing.assert_allclose(stale.tof_us[-n:], good.tof_us[-n:], rtol=1e-12)
+
+        # Applying the corrected coefficients to the stored times recovers
+        # the corrected masses, so nothing is lost by storing the stale ones.
+        recomputed = (0.382674 * stale.tof_us[-n:] - 1.598302) ** 2
+        np.testing.assert_allclose(recomputed, good.mz[-n:], rtol=1e-9)
+
+    def test_rejects_non_positive_bin_size(self):
+        with pytest.raises(ValueError, match="SpecBinSize"):
+            build_mass_axis(1.0, 0.0, 0.0, 10.0, 0.0)
+
+    def test_rejects_empty_mass_window(self):
+        with pytest.raises(ValueError, match="No time channel"):
+            build_mass_axis(1.0, 0.0, 0.0, 10.0, 1000.0, 500.0, 900.0)
+
+
+class TestPhiReader:
+    def test_dimensions_and_axis(self, simple_raw):
+        with PhiReader(simple_raw) as reader:
+            assert reader.dimensions == (4, 4, 1)
+            np.testing.assert_allclose(
+                reader.get_common_mass_axis(),
+                [1, 4, 9, 16, 25, 36, 49, 64, 81, 100],
+            )
+
+    def test_aggregates_events_per_pixel(self, simple_raw):
+        with PhiReader(simple_raw) as reader:
+            spectra = {
+                (x, y): (mz, inten) for (x, y, _), mz, inten in reader.iter_spectra()
+            }
+        assert set(spectra) == {(0, 0), (1, 2)}
+        # (0,0) saw three events all at 3 us -> m/z 9, summed
+        np.testing.assert_allclose(spectra[(0, 0)][0], [9.0])
+        np.testing.assert_allclose(spectra[(0, 0)][1], [3.0])
+        # (1,2) saw one at 5 us (m/z 25) and one at 10 us (m/z 100)
+        np.testing.assert_allclose(spectra[(1, 2)][0], [25.0, 100.0])
+        np.testing.assert_allclose(spectra[(1, 2)][1], [1.0, 1.0])
+
+    def test_spectra_are_sorted_by_mz(self, simple_raw):
+        with PhiReader(simple_raw) as reader:
+            for _, mzs, _ in reader.iter_spectra():
+                assert np.all(np.diff(mzs) > 0)
+
+    def test_peak_counts_match_iterated_spectra(self, simple_raw):
+        with PhiReader(simple_raw) as reader:
+            counts = reader.get_peak_counts_per_pixel()
+            n_x = reader.dimensions[0]
+            expected = np.zeros_like(counts)
+            for (x, y, _), mzs, _ in reader.iter_spectra():
+                expected[y * n_x + x] = mzs.size
+        np.testing.assert_array_equal(counts, expected)
+        # (0,0) holds one occupied channel, (1,2) holds two
+        assert counts.sum() == 3
+
+    def test_essential_metadata(self, simple_raw):
+        with PhiReader(simple_raw) as reader:
+            meta = reader.get_essential_metadata()
+        assert meta.dimensions == (4, 4, 1)
+        assert meta.n_spectra == 2
+        assert meta.total_peaks == 3
+        assert meta.pixel_size == pytest.approx((2.0, 2.0))
+        assert meta.spectrum_type == "profile spectrum"
+        assert meta.coordinate_bounds == (0.0, 3.0, 0.0, 3.0)
+
+    def test_comprehensive_metadata_records_calibration_source(self, simple_raw):
+        with PhiReader(simple_raw) as reader:
+            meta = reader.get_comprehensive_metadata()
+        cal = meta.raw_metadata["calibration"]
+        assert cal["source"] == "header"
+        assert cal["mass_slope_used"] == 1.0
+        assert cal["header_calibrated_flag"] == "no"
+        assert meta.instrument_info["vendor"] == "Physical Electronics (PHI)"
+        assert meta.format_specific["block_chain_complete"] is True
+
+    def test_iteration_is_repeatable(self, simple_raw):
+        with PhiReader(simple_raw) as reader:
+            first = [(c, m.tolist()) for c, m, _ in reader.iter_spectra()]
+            reader.reset()
+            second = [(c, m.tolist()) for c, m, _ in reader.iter_spectra()]
+        assert first == second
+
+    def test_pixel_size_override(self, simple_raw):
+        with PhiReader(simple_raw, pixel_size_um=1.55) as reader:
+            assert reader.pixel_size_um == pytest.approx(1.55)
+            meta = reader.get_essential_metadata()
+        assert meta.pixel_size == pytest.approx((1.55, 1.55))
+
+    def test_intensity_threshold_filters_low_counts(self, simple_raw):
+        with PhiReader(simple_raw, intensity_threshold=2.0) as reader:
+            coords = [c for c, _, _ in reader.iter_spectra()]
+        # only pixel (0,0), with three summed counts, clears the threshold
+        assert coords == [(0, 0, 0)]
+
+    def test_appended_calibration_is_preferred(self, tmp_path):
+        appended = b"AppendedBlockType: AsciiInfoBlock01\r\nMass/Time: 2.0\r\nMassOffset: 0.0\r\n"
+        blocks = events_block([event(0, 0, 1_000_000)]) + block(14, appended)
+        path = write_raw(tmp_path / "recal.raw", blocks)
+        with PhiReader(path) as reader:
+            assert reader.calibration_source == "appended"
+            assert reader.mass_axis.slope == 2.0
+            # 1 us at slope 2 -> sqrt(m) = 2 -> m/z 4
+            ((_, mzs, _),) = list(reader.iter_spectra())
+            np.testing.assert_allclose(mzs, [4.0])
+
+    def test_appended_calibration_can_be_disabled(self, tmp_path):
+        appended = b"AppendedBlockType: AsciiInfoBlock01\r\nMass/Time: 2.0\r\nMassOffset: 0.0\r\n"
+        blocks = events_block([event(0, 0, 1_000_000)]) + block(14, appended)
+        path = write_raw(tmp_path / "recal.raw", blocks)
+        with PhiReader(path, use_appended_calibration=False) as reader:
+            assert reader.calibration_source == "header"
+            assert reader.mass_axis.slope == 1.0
+
+    def test_mosaic_tiles_offset_coordinates(self, tmp_path):
+        blocks = (
+            events_block([event(1, 1, 3_000_000)])
+            + block(6, struct.pack("<II", 1, 0))
+            + events_block([event(1, 1, 3_000_000)])
+        )
+        path = write_raw(tmp_path / "mosaic.raw", blocks, tiles_x=2, tiles_y=1)
+        with PhiReader(path) as reader:
+            assert reader.dimensions == (8, 4, 1)
+            coords = sorted(c for c, _, _ in reader.iter_spectra())
+        # second tile is offset by one raster width in x
+        assert coords == [(1, 1, 0), (5, 1, 0)]
+
+    def test_declared_tiles_do_not_inflate_the_grid(self, simple_raw):
+        """Tile counts are declared even when mosaic mode is off."""
+        path = write_raw(
+            simple_raw.parent / "declared.raw",
+            events_block([event(0, 0, 3_000_000)]),
+            tiles_x=8,
+            tiles_y=2,
+        )
+        with PhiReader(path) as reader:
+            assert reader.header.declared_tiles == (8, 2)
+            assert reader.dimensions == (4, 4, 1)
+
+    def test_exposes_flight_time_as_a_mass_axis_annotation(self, simple_raw):
+        with PhiReader(simple_raw) as reader:
+            ann = reader.get_mass_axis_annotations()
+            axis = reader.get_common_mass_axis()
+        assert set(ann) == {"tof_us"}
+        assert len(ann["tof_us"]) == len(axis)
+        np.testing.assert_allclose(ann["tof_us"], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+
+    def test_rejects_directory(self, tmp_path):
+        directory = tmp_path / "waters.raw"
+        directory.mkdir()
+        with pytest.raises(ValueError, match="must be a file"):
+            PhiReader(directory)
+
+
+class TestFlightTimeSurvivesConversion:
+    """The measured flight time must reach the store on both write routes.
+
+    The streaming route writes ``var`` to Zarr by hand rather than through a
+    dataframe, so the two paths have to be checked separately.
+    """
+
+    @pytest.fixture
+    def raw_with_events(self, tmp_path):
+        words = [
+            event(x, y, tof * 1_000_000)
+            for x in range(4)
+            for y in range(4)
+            for tof in (3, 5, 9)
+        ]
+        return write_raw(tmp_path / "conv.raw", events_block(words) + block(2))
+
+    @pytest.mark.parametrize("streaming", [False, True])
+    def test_tof_axis_is_written(self, raw_with_events, tmp_path, streaming):
+        sd = pytest.importorskip("spatialdata")
+        from thyra.convert import convert_msi
+
+        out = tmp_path / f"out_{int(streaming)}.zarr"
+        assert convert_msi(raw_with_events, out, dataset_id="d", streaming=streaming)
+
+        table = next(iter(sd.read_zarr(out).tables.values()))
+        assert "tof_us" in table.var.columns
+
+        # The stored times reproduce the stored m/z under the same calibration.
+        cal = table.uns["raw_metadata"]["calibration"]
+        recomputed = (
+            cal["mass_slope_used"] * table.var["tof_us"].to_numpy()
+            + cal["mass_offset_used"]
+        ) ** 2
+        np.testing.assert_allclose(recomputed, table.var["mz"].to_numpy(), rtol=1e-9)
+
+
+class TestRegistryDetection:
+    def test_detects_phi_raw_file(self, simple_raw):
+        assert detect_format(simple_raw) == "phi"
+
+    def test_detects_waters_raw_directory(self, tmp_path):
+        directory = tmp_path / "waters.raw"
+        directory.mkdir()
+        (directory / "_FUNC001.DAT").write_bytes(b"\x00")
+        assert detect_format(directory) == "waters"
+
+    def test_waters_directory_without_func_files_still_errors(self, tmp_path):
+        directory = tmp_path / "empty.raw"
+        directory.mkdir()
+        with pytest.raises(ValueError, match="_FUNC"):
+            detect_format(directory)
+
+    def test_unrecognised_raw_file_is_reported(self, tmp_path):
+        path = tmp_path / "mystery.raw"
+        path.write_bytes(b"XXXX" + b"\x00" * 64)
+        with pytest.raises(ValueError, match="Unrecognised .raw file"):
+            detect_format(path)

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -169,13 +169,24 @@ class TestRegistry:
 
         assert detect_format(raw_dir) == "waters"
 
-    def test_waters_not_directory(self, tmp_path):
-        """Test error for .raw file instead of directory."""
+    def test_raw_file_without_phi_magic_is_rejected(self, tmp_path):
+        """A .raw file is a PHI candidate, so the error names both vendors.
+
+        Waters .raw is a directory and PHI .raw is a file, so a plain file
+        that lacks the PHI SOFH magic belongs to neither.
+        """
         fake_raw = tmp_path / "test.raw"
         fake_raw.touch()
 
-        with pytest.raises(ValueError, match="requires .raw directory"):
+        with pytest.raises(ValueError, match="Unrecognised .raw file"):
             detect_format(fake_raw)
+
+    def test_detect_format_phi(self, tmp_path):
+        """Test PHI format detection via .raw file with SOFH magic."""
+        phi_raw = tmp_path / "test.raw"
+        phi_raw.write_bytes(b"SOFH\r\nImagePixels: 4\r\nEOFH\r\n")
+
+        assert detect_format(phi_raw) == "phi"
 
     def test_waters_missing_func_files(self, tmp_path):
         """Test error for .raw directory without _FUNC*.DAT files."""

--- a/tests/unit/utils/test_windows_paths.py
+++ b/tests/unit/utils/test_windows_paths.py
@@ -21,11 +21,73 @@ from thyra.utils.windows_paths import (
     DEEPEST_KEY_RESERVE,
     WINDOWS_MAX_PATH,
     prepare_zarr_output_path,
+    prepare_zarr_read_path,
     projected_deepest_key_length,
     to_extended_length_path,
 )
 
 EXTENDED_PREFIX = "\\\\?\\"
+
+
+class TestPrepareZarrReadPath:
+    """Reading a store back is subject to the same limit as writing it.
+
+    A store written through an extended-length path is intact, but its deep
+    keys are invisible to a plain read, which makes it look corrupt.
+    """
+
+    @pytest.fixture
+    def on_windows(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(windows_paths, "_long_paths_enabled", lambda: False)
+
+    @staticmethod
+    def _store_with_key_length(monkeypatch, total: int) -> Path:
+        """A store whose longest key is ``total`` characters.
+
+        The walk is faked rather than written to disk: creating a key past
+        the limit is exactly the thing that needs the prefix, so a real file
+        cannot be used to test the code that decides to apply it.
+        """
+        store = Path("C:\\stores\\store.zarr")
+        name = "k" * max(1, total - len(str(store)) - 1)
+        monkeypatch.setattr(
+            windows_paths.os, "walk", lambda p: [(str(store), [], [name])]
+        )
+        return store
+
+    def test_shallow_store_is_untouched(self, on_windows, monkeypatch):
+        store = self._store_with_key_length(monkeypatch, 120)
+
+        assert prepare_zarr_read_path(store) == store
+
+    def test_deep_store_is_extended(self, on_windows, monkeypatch):
+        store = self._store_with_key_length(monkeypatch, WINDOWS_MAX_PATH + 20)
+
+        result = prepare_zarr_read_path(store)
+
+        assert str(result).startswith(EXTENDED_PREFIX)
+        assert str(result).endswith(str(store))
+
+    def test_no_op_off_windows(self, monkeypatch):
+        store = self._store_with_key_length(monkeypatch, WINDOWS_MAX_PATH + 20)
+        monkeypatch.setattr(sys, "platform", "linux")
+
+        assert prepare_zarr_read_path(store) == store
+
+    def test_no_op_when_long_paths_are_enabled(self, monkeypatch):
+        store = self._store_with_key_length(monkeypatch, WINDOWS_MAX_PATH + 20)
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(windows_paths, "_long_paths_enabled", lambda: True)
+
+        assert prepare_zarr_read_path(store) == store
+
+    def test_missing_store_is_left_alone(self, on_windows, tmp_path):
+        """os.walk yields nothing for a missing store, so there is nothing
+        to protect and the caller should see its own path in the error."""
+        missing = tmp_path / "does_not_exist.zarr"
+
+        assert prepare_zarr_read_path(missing) == missing
 
 
 class TestToExtendedLengthPath:

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -1461,10 +1461,23 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             return {}
         n_channels = len(self._common_mass_axis)
 
+        # getattr rather than a bare call: readers predating this hook, and
+        # test doubles that do not subclass BaseMSIReader, simply have nothing
+        # to contribute and should not have to raise to say so.
+        getter = getattr(self.reader, "get_mass_axis_annotations", None)
+        if getter is None:
+            return {}
+
         try:
-            annotations = self.reader.get_mass_axis_annotations()
+            annotations = getter()
         except Exception as exc:  # pragma: no cover - reader-defined
-            logger.warning("Reader failed to supply mass axis annotations: %s", exc)
+            # Format eagerly. Passing the exception itself to the logger keeps
+            # it alive inside the log record, and with it its traceback, the
+            # caller frames reachable through tb_frame.f_back, and any memmap
+            # those frames hold -- which on Windows leaves the backing file
+            # locked long after the conversion has finished.
+            detail = f"{type(exc).__name__}: {exc}"
+            logger.warning("Reader failed to supply mass axis annotations: %s", detail)
             return {}
 
         validated: Dict[str, Any] = {}

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -614,9 +614,14 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         logger.debug("Added MSI metadata to AnnData .uns: %s", sorted(uns))
 
     def _serialize_for_zarr(self, obj):
-        """Recursively convert tuples to lists for Zarr serialization."""
+        """Recursively convert tuples to lists for Zarr serialization.
+
+        Dict keys are coerced to strings: Zarr group members must be named,
+        and a non-string key otherwise fails at write time, after the whole
+        conversion has already been done.
+        """
         if isinstance(obj, dict):
-            return {k: self._serialize_for_zarr(v) for k, v in obj.items()}
+            return {str(k): self._serialize_for_zarr(v) for k, v in obj.items()}
         elif isinstance(obj, (list, tuple)):
             return [self._serialize_for_zarr(item) for item in obj]
         elif hasattr(obj, "__dict__"):
@@ -1434,10 +1439,50 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         if self._common_mass_axis is None:
             raise ValueError("Common mass axis is not initialized")
 
+        n_channels = len(self._common_mass_axis)
+        columns: Dict[str, Any] = {"mz": self._common_mass_axis}
+        columns.update(self._validated_mass_axis_annotations())
+
         return pd.DataFrame(
-            {"mz": self._common_mass_axis},
-            index=[f"mz_{i}" for i in range(len(self._common_mass_axis))],
+            columns,
+            index=[f"mz_{i}" for i in range(n_channels)],
         )
+
+    def _validated_mass_axis_annotations(self) -> Dict[str, Any]:
+        """Reader-supplied per-channel columns that fit the axis being written.
+
+        A reader whose native axis is not m/z (flight time, drift time) can
+        keep that axis alongside ``mz`` so the conversion stays reversible.
+        Annotations whose length does not match are dropped rather than
+        raising: that is the expected outcome when resampling rebuilds the
+        axis, and it must not fail an otherwise good conversion.
+        """
+        if self._common_mass_axis is None:
+            return {}
+        n_channels = len(self._common_mass_axis)
+
+        try:
+            annotations = self.reader.get_mass_axis_annotations()
+        except Exception as exc:  # pragma: no cover - reader-defined
+            logger.warning("Reader failed to supply mass axis annotations: %s", exc)
+            return {}
+
+        validated: Dict[str, Any] = {}
+        for name, values in (annotations or {}).items():
+            if name == "mz":
+                logger.warning("Ignoring mass axis annotation named 'mz'")
+                continue
+            if len(values) != n_channels:
+                logger.info(
+                    "Dropping mass axis annotation %r: %d values for a "
+                    "%d channel axis (expected when resampling rebuilds it)",
+                    name,
+                    len(values),
+                    n_channels,
+                )
+                continue
+            validated[name] = values
+        return validated
 
     def _get_pixel_index(self, x: int, y: int, z: int) -> int:
         """Calculate linear pixel index from 3D coordinates.

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -1700,7 +1700,10 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         var_group.attrs["encoding-type"] = "dataframe"
         var_group.attrs["encoding-version"] = "0.2.0"
         var_group.attrs["_index"] = "_index"
-        var_group.attrs["column-order"] = ["mz"]
+        # A reader whose native axis is not m/z keeps that axis here too, so
+        # this route stores the same columns as the dataframe-based ones.
+        annotations = self._validated_mass_axis_annotations()
+        var_group.attrs["column-order"] = ["mz"] + sorted(annotations)
 
         mz_values = self._common_mass_axis
         if mz_values is None:
@@ -1722,6 +1725,11 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         a = var_group.create_array("mz", data=mz_values)
         a.attrs["encoding-type"] = "array"
         a.attrs["encoding-version"] = "0.2.0"
+
+        for name in sorted(annotations):
+            a = var_group.create_array(name, data=np.asarray(annotations[name]))
+            a.attrs["encoding-type"] = "array"
+            a.attrs["encoding-version"] = "0.2.0"
 
         # uns (metadata)
         uns_group = table_group.create_group("uns")

--- a/thyra/core/base_reader.py
+++ b/thyra/core/base_reader.py
@@ -213,6 +213,30 @@ class BaseMSIReader(ABC):
         # Return only the valid indices and their corresponding intensities
         return indices[indices_valid], intensities[indices_valid]
 
+    def get_mass_axis_annotations(
+        self,
+    ) -> Optional[dict]:
+        """Get extra per-channel columns to store alongside the m/z axis.
+
+        Returns a mapping of column name to an array with one entry per
+        entry of :meth:`get_common_mass_axis`. These are written into the
+        table's ``var`` next to ``mz``.
+
+        This exists so a format whose native axis is not m/z can keep that
+        axis in the output. Time-of-flight instruments measure flight time
+        and derive m/z from a calibration, so storing the flight time makes
+        the conversion reversible without the reader: a later recalibration
+        can be applied to the stored times directly.
+
+        Annotations are dropped if their length does not match the axis the
+        converter actually writes, which is what happens when resampling is
+        enabled and the axis is rebuilt.
+
+        Returns:
+            Mapping of column name to per-channel values, or None.
+        """
+        return None
+
     def get_region_map(self) -> Optional[dict]:
         """Get per-pixel region mapping for multi-region datasets.
 

--- a/thyra/core/registry.py
+++ b/thyra/core/registry.py
@@ -36,11 +36,12 @@ class MSIRegistry:
         self._lock = RLock()
         self._readers: Dict[str, Type[BaseMSIReader]] = {}
         self._converters: Dict[str, Type[BaseMSIConverter]] = {}
-        # Extension mapping for file-based formats
+        # Extension mapping for file-based formats. '.raw' is deliberately
+        # absent: it is claimed by both Waters and PHI and can only be
+        # resolved by inspecting the path (see _detect_raw_format).
         self._extension_to_format = {
             ".imzml": "imzml",
             ".d": "bruker",
-            ".raw": "waters",
         }
 
     def register_reader(
@@ -112,6 +113,25 @@ class MSIRegistry:
             pass
         return False
 
+    def _detect_phi_format(self, path: Path) -> bool:
+        """Check if path is a PHI SmartSoft-TOF .raw file.
+
+        PHI writes a single file whose ASCII header opens with the four-byte
+        ``SOFH`` magic. This is what distinguishes it from Waters .raw data,
+        which is a directory.
+
+        Args:
+            path: File path to check
+
+        Returns:
+            True if the file starts with the PHI SOFH magic
+        """
+        try:
+            with path.open("rb") as handle:
+                return handle.read(4) == b"SOFH"
+        except (OSError, PermissionError):
+            return False
+
     def detect_format(self, input_path: Path) -> str:
         """Detect MSI format from input path.
 
@@ -120,6 +140,7 @@ class MSIRegistry:
         - .d directories (Bruker timsTOF)
         - Folders with .dat + _poslog.txt (Bruker Rapiflex)
         - .raw directories (Waters MassLynx)
+        - .raw files (PHI SmartSoft-TOF ToF-SIMS)
         """
         if not input_path.exists():
             raise ValueError(f"Input path does not exist: {input_path}")
@@ -136,7 +157,7 @@ class MSIRegistry:
         if extension == ".d":
             return self._detect_bruker_d_format(input_path)
         if extension == ".raw":
-            return self._detect_waters_raw_format(input_path)
+            return self._detect_raw_format(input_path)
         if input_path.is_dir():
             return self._detect_directory_format(input_path)
         self._raise_unsupported_format(input_path)
@@ -152,16 +173,25 @@ class MSIRegistry:
             return bruker_format
         raise ValueError("Bruker .d directory missing analysis " f"files: {input_path}")
 
-    def _detect_waters_raw_format(self, input_path: Path) -> str:
-        """Validate and detect Waters format from .raw directory."""
-        if not input_path.is_dir():
+    def _detect_raw_format(self, input_path: Path) -> str:
+        """Resolve a .raw path to the vendor that wrote it.
+
+        Two vendors claim the extension and they are distinguished by shape:
+        Waters .raw is a directory of _FUNC*.DAT files, PHI .raw is a single
+        file whose header begins with the SOFH magic.
+        """
+        if input_path.is_dir():
+            if self._detect_waters_format(input_path):
+                return "waters"
             raise ValueError(
-                "Waters format requires .raw directory, " f"got file: {input_path}"
+                "Waters .raw directory missing " f"_FUNC*.DAT files: {input_path}"
             )
-        if self._detect_waters_format(input_path):
-            return "waters"
+        if self._detect_phi_format(input_path):
+            return "phi"
         raise ValueError(
-            "Waters .raw directory missing " f"_FUNC*.DAT files: {input_path}"
+            f"Unrecognised .raw file: {input_path}. Expected either a Waters "
+            "directory containing _FUNC*.DAT files, or a PHI SmartSoft-TOF "
+            "file beginning with the SOFH magic."
         )
 
     def _detect_directory_format(self, input_path: Path) -> str:
@@ -179,7 +209,8 @@ class MSIRegistry:
             ".imzml",
             ".d (timsTOF)",
             "folder (Rapiflex)",
-            ".raw (Waters)",
+            ".raw directory (Waters)",
+            ".raw file (PHI SmartSoft-TOF)",
         ]
         raise ValueError(
             f"Unsupported format for '{input_path}'. "
@@ -265,8 +296,7 @@ def detect_format(input_path: Path) -> str:
         input_path: Path to MSI data file or directory
 
     Returns:
-        Format name ('imzml', 'bruker', 'rapiflex',
-        or 'waters')
+        Format name ('imzml', 'bruker', 'rapiflex', 'waters', or 'phi')
     """
     return _registry.detect_format(input_path)
 

--- a/thyra/metadata/extractors/__init__.py
+++ b/thyra/metadata/extractors/__init__.py
@@ -30,12 +30,14 @@ Example usage:
 
 from .bruker_extractor import BrukerMetadataExtractor
 from .imzml_extractor import ImzMLMetadataExtractor
+from .phi_extractor import PhiMetadataExtractor
 from .waters_extractor import WatersMetadataExtractor
 
 # Public API
 __all__ = [
     "BrukerMetadataExtractor",
     "ImzMLMetadataExtractor",
+    "PhiMetadataExtractor",
     "WatersMetadataExtractor",
 ]
 
@@ -46,6 +48,7 @@ FORMAT_EXTRACTORS = {
     "tsf": BrukerMetadataExtractor,
     "tdf": BrukerMetadataExtractor,
     "waters": WatersMetadataExtractor,
+    "phi": PhiMetadataExtractor,
 }
 
 

--- a/thyra/metadata/extractors/phi_extractor.py
+++ b/thyra/metadata/extractors/phi_extractor.py
@@ -1,0 +1,178 @@
+# thyra/metadata/extractors/phi_extractor.py
+"""Metadata extractor for PHI SmartSoft-TOF ToF-SIMS data.
+
+Reads from the parsed acquisition header and the reader's aggregated event
+index, so no additional file passes are needed.
+"""
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any, Dict
+
+import numpy as np
+
+from ...core.base_extractor import MetadataExtractor
+from ..types import ComprehensiveMetadata, EssentialMetadata
+
+if TYPE_CHECKING:
+    from ...readers.phi.phi_reader import PhiReader
+
+logger = logging.getLogger(__name__)
+
+
+class PhiMetadataExtractor(MetadataExtractor):
+    """PHI-specific metadata extractor.
+
+    Args:
+        reader: The :class:`PhiReader` to describe.
+    """
+
+    def __init__(self, reader: "PhiReader"):
+        """Initialise the extractor.
+
+        Args:
+            reader: The :class:`PhiReader` to describe.
+        """
+        super().__init__(reader)
+        self._reader = reader
+
+    def _extract_essential_impl(self) -> EssentialMetadata:
+        """Extract metadata needed to drive conversion."""
+        reader = self._reader
+        dimensions = reader.dimensions
+        n_x, n_y, _ = dimensions
+
+        peak_counts = reader.get_peak_counts_per_pixel()
+        assert peak_counts is not None
+        total_peaks = int(peak_counts.sum())
+        n_spectra = int(np.count_nonzero(peak_counts))
+
+        pixel_size = None
+        size_um = reader.pixel_size_um
+        if size_um:
+            pixel_size = (float(size_um), float(size_um))
+
+        return EssentialMetadata(
+            dimensions=dimensions,
+            coordinate_bounds=(0.0, float(n_x - 1), 0.0, float(n_y - 1)),
+            mass_range=reader.mass_axis.mass_range,
+            pixel_size=pixel_size,
+            n_spectra=n_spectra,
+            total_peaks=total_peaks,
+            estimated_memory_gb=(total_peaks * 2 * 8) / (1024**3),
+            source_path=str(reader.data_path),
+            coordinate_offsets=(0, 0, 0),
+            # A sparse histogram on the detector's regular time-channel grid,
+            # not a peak-picked list.
+            spectrum_type="profile spectrum",
+            peak_counts_per_pixel=peak_counts,
+        )
+
+    def _extract_comprehensive_impl(self) -> ComprehensiveMetadata:
+        """Extract full metadata including vendor-specific detail."""
+        return ComprehensiveMetadata(
+            essential=self.get_essential(),
+            format_specific=self._extract_format_specific(),
+            acquisition_params=self._extract_acquisition_params(),
+            instrument_info=self._extract_instrument_info(),
+            raw_metadata=self._extract_raw_metadata(),
+        )
+
+    def _extract_format_specific(self) -> Dict[str, Any]:
+        reader = self._reader
+        header = reader.header
+        index = reader.block_index
+        axis = reader.mass_axis
+        return {
+            "format": "PHI SmartSoft-TOF raw",
+            "raw_file_format_version": header.entries.get("RawFileFormatVersion"),
+            "header_size": header.header_size,
+            "image_pixels": header.image_pixels,
+            "n_mass_channels": len(axis),
+            "bin_size_ns": header.bin_size_ns,
+            "flight_time_range_us": (
+                header.start_flight_time_us,
+                header.stop_flight_time_us,
+            ),
+            "n_event_blocks": len(index.data_spans),
+            "n_records": index.n_records,
+            "frames_in_stream": index.n_frames,
+            # Zarr group members must be named, so the block ids are keyed
+            # as strings rather than the ints they are in the file.
+            "block_id_counts": {
+                f"block_{block_id}": int(count)
+                for block_id, count in sorted(index.block_counts.items())
+            },
+            "block_chain_complete": index.clean,
+            "mosaic_tiles": index.tile_grid,
+            "declared_tiles": header.declared_tiles,
+            "pixel_size_source": reader.pixel_size_source,
+            "raster_size_um": header.raster_size_um,
+            "raster_size_calibration": header.raster_size_calibration,
+        }
+
+    def _extract_acquisition_params(self) -> Dict[str, Any]:
+        header = self._reader.header
+        acq = header.sections.get("Acq Base", {})
+        return {
+            "polarity": header.polarity,
+            "technique": header.entries.get("Technique"),
+            "acquisition_type": header.entries.get("AcquisitionType"),
+            "n_frames": header.n_frames,
+            "msms_active": header.msms_active,
+            "primary_species": header.entries.get("AcqPrimSpecies"),
+            "primary_current_na": header.entries.get("AcqPrimCurrent(nA)"),
+            "pulse_width_ns": header.entries.get("AcqPulseWidth"),
+            "raster_pattern": acq.get("Raster Pattern"),
+            "raster_resolution": acq.get("Raster Resolution"),
+            "mass_range_amu": (header.start_mz, header.stop_mz),
+            "acquisition_date": header.entries.get("AcqFileDate"),
+        }
+
+    def _extract_instrument_info(self) -> Dict[str, Any]:
+        header = self._reader.header
+        return {
+            "vendor": "Physical Electronics (PHI)",
+            "software_version": header.entries.get("SoftwareVersion"),
+            "platform": header.entries.get("Platform"),
+            "primary_gun": header.entries.get("AcqPrimGun"),
+            "emitter": header.entries.get("LmigEmitter"),
+            "detector_scan_mode": header.entries.get("DetectorScanMode"),
+        }
+
+    def _extract_raw_metadata(self) -> Dict[str, Any]:
+        reader = self._reader
+        header = reader.header
+        axis = reader.mass_axis
+        calibration: Dict[str, Any] = {
+            "source": reader.calibration_source,
+            "mass_slope_used": axis.slope,
+            "mass_offset_used": axis.offset,
+            "header_mass_slope": header.mass_slope,
+            "header_mass_offset": header.mass_offset,
+            "header_calibrated_flag": header.entries.get("Calibrated"),
+            # JSON strings: AnnData/zarr cannot round-trip a list of dicts.
+            "acquisition_calibrants": json.dumps(
+                [
+                    {
+                        "measured_mz": c.measured_mz,
+                        "species": c.species,
+                        "theoretical_mz": c.theoretical_mz,
+                    }
+                    for c in header.calibrants
+                ]
+            ),
+        }
+        appended = reader.block_index.appended
+        if appended:
+            calibration["appended_blocks"] = json.dumps(appended)
+        # The vendor's own key names are not valid Zarr group members --
+        # 'Mass/Time' contains a forward slash -- so the header is preserved
+        # verbatim as JSON rather than being mangled into a group hierarchy.
+        return {
+            "header_entries": json.dumps(dict(header.entries)),
+            "header_sections": json.dumps(
+                {k: dict(v) for k, v in header.sections.items()}
+            ),
+            "calibration": calibration,
+        }

--- a/thyra/readers/__init__.py
+++ b/thyra/readers/__init__.py
@@ -5,12 +5,17 @@ This package provides reader implementations for different MSI data formats:
 - ImzML: Open format for MSI data
 - Bruker: timsTOF and Rapiflex data
 - Waters: MassLynx .raw imaging data
+- PHI: SmartSoft-TOF .raw ToF-SIMS data
 
 Reader organization:
 - bruker/: All Bruker formats (timsTOF, Rapiflex)
 - imzml/: ImzML format reader
 - waters/: Waters .raw format reader (native DLL via ctypes)
+- phi/: PHI SmartSoft-TOF .raw reader (pure Python, no vendor SDK)
+
+Note that ``.raw`` is claimed by two vendors: Waters stores a directory,
+PHI a single file. See :meth:`thyra.core.registry.MSIRegistry.detect_format`.
 """
 
 # Import readers to trigger registration
-from . import bruker, imzml, waters  # noqa: F401
+from . import bruker, imzml, phi, waters  # noqa: F401

--- a/thyra/readers/phi/__init__.py
+++ b/thyra/readers/phi/__init__.py
@@ -1,0 +1,27 @@
+# thyra/readers/phi/__init__.py
+"""PHI SmartSoft-TOF MSI reader implementation.
+
+Reads ToF-SIMS imaging data from PHI (Physical Electronics) nanoTOF
+instruments, stored as a single ``.raw`` file holding an ASCII acquisition
+header followed by a block-structured stream of individual ion events.
+
+No vendor SDK or native library is required.
+"""
+
+from .event_stream import BlockIndex, DataSpan, iter_event_batches, scan_blocks
+from .mass_axis import PhiMassAxis, build_mass_axis
+from .phi_header import Calibrant, PhiHeader, parse_phi_header
+from .phi_reader import PhiReader
+
+__all__ = [
+    "BlockIndex",
+    "Calibrant",
+    "DataSpan",
+    "PhiHeader",
+    "PhiMassAxis",
+    "PhiReader",
+    "build_mass_axis",
+    "iter_event_batches",
+    "parse_phi_header",
+    "scan_blocks",
+]

--- a/thyra/readers/phi/event_stream.py
+++ b/thyra/readers/phi/event_stream.py
@@ -1,0 +1,303 @@
+# thyra/readers/phi/event_stream.py
+"""Block-structured event stream of PHI SmartSoft-TOF ``.raw`` files.
+
+Everything past ``HeaderSize`` is a chain of blocks, each introduced by a
+16-byte header::
+
+    offset 0   uint16  block id
+    offset 2   10 bytes, not interpreted
+    offset 12  uint32  record size
+
+Block ids observed in imaging acquisitions:
+
+===  ===========================================================
+id   meaning
+===  ===========================================================
+1    ion events (8 bytes each); ``8`` instead when MS/MS is on
+2    end of frame; carries no payload
+6    mosaic tile origin; payload is two uint32 tile indices
+14   appended ASCII info block, e.g. a post-hoc recalibration
+0    end of stream
+===  ===========================================================
+
+Any other id is skipped using its record size. The chain tiles the payload
+exactly, which is what makes it safe to trust: a parse that ends anywhere
+other than end-of-file has gone wrong somewhere.
+
+Each event is a little-endian uint64::
+
+    bit  31      set on a valid event
+    bits 0-30    flight time in picoseconds (27 bits are used)
+    bits 32-42   X pixel index
+    bits 43-53   Y pixel index
+    bits 58-63   clear on a valid event
+
+Records that fail the validity test are dropped. The reference dataset
+carries 64,493 of them among 18.5 million (0.35%), many holding the
+``0xADADADAD`` uninitialised-heap fill; excluding them reproduces the
+vendor's own exported ion images exactly.
+"""
+
+import logging
+import struct
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional, Tuple
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .phi_header import PhiHeader
+
+logger = logging.getLogger(__name__)
+
+BLOCK_HEADER_SIZE = 16
+BLOCK_END = 0
+BLOCK_FRAME_END = 2
+BLOCK_TILE = 6
+BLOCK_ASCII_INFO = 14
+
+EVENT_SIZE = 8
+_VALID_HIGH_SHIFT = 58
+_BIT31 = np.uint64(1 << 31)
+_TOF_MASK = np.uint64(0x7FFFFFFF)
+_COORD_MASK = np.uint64(0x7FF)
+_X_SHIFT = np.uint64(32)
+_Y_SHIFT = np.uint64(43)
+_HIGH_SHIFT = np.uint64(_VALID_HIGH_SHIFT)
+
+_HEADER_STRUCT = struct.Struct("<H")
+_SIZE_STRUCT = struct.Struct("<I")
+_TILE_STRUCT = struct.Struct("<II")
+
+
+@dataclass
+class DataSpan:
+    """One run of ion events, with the mosaic tile origin in effect."""
+
+    offset: int
+    size: int
+    tile_x: int = 0
+    tile_y: int = 0
+
+    @property
+    def n_records(self) -> int:
+        """Number of 8-byte event records in this span."""
+        return self.size // EVENT_SIZE
+
+
+@dataclass
+class BlockIndex:
+    """Result of walking the block chain without reading event payloads.
+
+    Attributes:
+        data_spans: Byte ranges holding ion events, in file order.
+        n_frames: Count of end-of-frame blocks seen.
+        tiles: Distinct ``(tile_x, tile_y)`` origins seen, in file order.
+        appended: Parsed ``AsciiInfoBlock`` payloads, in file order.
+        block_counts: Histogram of block ids, for diagnostics.
+        end_offset: Byte offset at which the walk stopped.
+        clean: Whether the chain terminated exactly at end-of-file.
+        pixels_per_tile: Raster edge length, used to turn the tile indices in
+            :attr:`tiles` into pixel offsets.
+    """
+
+    data_spans: List[DataSpan] = field(default_factory=list)
+    n_frames: int = 0
+    tiles: List[Tuple[int, int]] = field(default_factory=list)
+    appended: List[Dict[str, str]] = field(default_factory=list)
+    block_counts: Dict[int, int] = field(default_factory=dict)
+    end_offset: int = 0
+    clean: bool = True
+    pixels_per_tile: int = 0
+
+    @property
+    def n_records(self) -> int:
+        """Total event records across every span, valid or not."""
+        return sum(span.n_records for span in self.data_spans)
+
+    @property
+    def tile_grid(self) -> Tuple[int, int]:
+        """Mosaic tile counts implied by the origins actually encountered."""
+        if not self.tiles:
+            return (1, 1)
+        return (
+            max(t[0] for t in self.tiles) + 1,
+            max(t[1] for t in self.tiles) + 1,
+        )
+
+    def appended_calibration(self) -> Optional[Tuple[float, float]]:
+        """Return ``(slope, offset)`` from the newest appended block, if any.
+
+        A recalibration run after acquisition is appended rather than written
+        back into the acquisition header, so when one is present it, not the
+        header, describes the flight times actually stored in the file.
+        """
+        for info in reversed(self.appended):
+            if "Mass/Time" in info and "MassOffset" in info:
+                try:
+                    return (float(info["Mass/Time"]), float(info["MassOffset"]))
+                except ValueError:  # pragma: no cover - malformed vendor block
+                    continue
+        return None
+
+
+def _parse_ascii_info(payload: bytes) -> Dict[str, str]:
+    """Parse an appended ASCII info block into key/value pairs."""
+    info: Dict[str, str] = {}
+    for line in payload.decode("latin-1", errors="replace").split("\r\n"):
+        key, sep, value = line.partition(":")
+        if sep and key and not key.startswith("\x00"):
+            info[key.strip()] = value.strip()
+    return info
+
+
+def scan_blocks(path: Path, header: PhiHeader) -> BlockIndex:
+    """Walk the block chain, recording structure without reading event data.
+
+    Payloads are seeked over rather than read, so this is cheap even on very
+    large files and can be run before deciding how to process the events.
+
+    Args:
+        path: Path to the ``.raw`` file.
+        header: The parsed acquisition header.
+
+    Returns:
+        The block index.
+
+    Raises:
+        ValueError: If the block chain is malformed.
+    """
+    path = Path(path)
+    file_size = path.stat().st_size
+    data_id = header.data_block_id
+    index = BlockIndex(pixels_per_tile=header.image_pixels)
+    tile_x = tile_y = 0
+
+    with path.open("rb") as handle:
+        pos = header.header_size
+        while pos + BLOCK_HEADER_SIZE <= file_size:
+            handle.seek(pos)
+            raw = handle.read(BLOCK_HEADER_SIZE)
+            if len(raw) < BLOCK_HEADER_SIZE:
+                break
+            block_id = _HEADER_STRUCT.unpack_from(raw, 0)[0]
+            record_size = _SIZE_STRUCT.unpack_from(raw, 12)[0]
+            pos += BLOCK_HEADER_SIZE
+            index.block_counts[block_id] = index.block_counts.get(block_id, 0) + 1
+
+            if block_id == BLOCK_END:
+                break
+            if block_id == data_id:
+                usable = min(record_size, file_size - pos)
+                usable -= usable % EVENT_SIZE
+                if usable > 0:
+                    index.data_spans.append(DataSpan(pos, usable, tile_x, tile_y))
+                pos += record_size
+            elif block_id == BLOCK_TILE:
+                handle.seek(pos)
+                tile_raw = handle.read(_TILE_STRUCT.size)
+                if len(tile_raw) < _TILE_STRUCT.size:
+                    break
+                tile_x, tile_y = _TILE_STRUCT.unpack(tile_raw)
+                if (tile_x, tile_y) not in index.tiles:
+                    index.tiles.append((tile_x, tile_y))
+                pos += _TILE_STRUCT.size
+            elif block_id == BLOCK_FRAME_END:
+                index.n_frames += 1
+            else:
+                if block_id == BLOCK_ASCII_INFO and record_size:
+                    handle.seek(pos)
+                    info = _parse_ascii_info(handle.read(min(record_size, 1 << 16)))
+                    if info:
+                        index.appended.append(info)
+                pos += record_size
+
+    index.end_offset = pos
+    index.clean = pos == file_size
+    if not index.clean:
+        logger.warning(
+            "PHI block chain for %s ended at byte %d of %d; the trailing %d "
+            "bytes were not accounted for",
+            path.name,
+            pos,
+            file_size,
+            file_size - pos,
+        )
+    if not index.data_spans:
+        raise ValueError(
+            f"No event blocks (id {data_id}) found in {path}. "
+            "Is this a PHI imaging acquisition?"
+        )
+    logger.info(
+        "PHI block scan: %d event blocks, %d records, %d frames, %d tile(s)",
+        len(index.data_spans),
+        index.n_records,
+        index.n_frames,
+        len(index.tiles) or 1,
+    )
+    return index
+
+
+def decode_events(
+    words: NDArray[np.uint64],
+) -> Tuple[NDArray[np.int32], NDArray[np.int32], NDArray[np.int64]]:
+    """Split raw uint64 records into ``(x, y, tof_ps)``, dropping bad records."""
+    valid = ((words >> _HIGH_SHIFT) == 0) & ((words & _BIT31) != 0)
+    good = words[valid]
+    return (
+        ((good >> _X_SHIFT) & _COORD_MASK).astype(np.int32),
+        ((good >> _Y_SHIFT) & _COORD_MASK).astype(np.int32),
+        (good & _TOF_MASK).astype(np.int64),
+    )
+
+
+def iter_event_batches(
+    path: Path, index: BlockIndex, max_records: int = 4_000_000
+) -> Iterator[Tuple[NDArray[np.int32], NDArray[np.int32], NDArray[np.int64]]]:
+    """Stream decoded ``(x, y, tof_ps)`` batches, applying mosaic tile offsets.
+
+    Adjacent event blocks sharing a tile origin are coalesced up to
+    ``max_records`` so the caller sees few, large arrays rather than one per
+    block (the reference dataset has 32,074 event blocks averaging 575
+    records each).
+    """
+    path = Path(path)
+    with path.open("rb") as handle:
+        pending: List[NDArray[np.uint64]] = []
+        pending_tile: Optional[Tuple[int, int]] = None
+        pending_count = 0
+
+        def flush():
+            nonlocal pending, pending_tile, pending_count
+            if not pending:
+                return None
+            words = pending[0] if len(pending) == 1 else np.concatenate(pending)
+            tile = pending_tile or (0, 0)
+            pending, pending_tile, pending_count = [], None, 0
+            x, y, tof = decode_events(words)
+            if tile != (0, 0):
+                # Block 6 carries tile indices, not pixel offsets.
+                stride = index.pixels_per_tile
+                x = x + np.int32(tile[0] * stride)
+                y = y + np.int32(tile[1] * stride)
+            return x, y, tof
+
+        for span in index.data_spans:
+            tile = (span.tile_x, span.tile_y)
+            if pending and (tile != pending_tile or pending_count >= max_records):
+                batch = flush()
+                if batch is not None and batch[2].size:
+                    yield batch
+            handle.seek(span.offset)
+            buf = handle.read(span.size)
+            if len(buf) < EVENT_SIZE:
+                continue
+            usable = len(buf) - (len(buf) % EVENT_SIZE)
+            pending.append(np.frombuffer(buf, dtype="<u8", count=usable // EVENT_SIZE))
+            pending_tile = tile
+            pending_count += usable // EVENT_SIZE
+
+        batch = flush()
+        if batch is not None and batch[2].size:
+            yield batch

--- a/thyra/readers/phi/event_stream.py
+++ b/thyra/readers/phi/event_stream.py
@@ -66,6 +66,9 @@ _X_SHIFT = np.uint64(32)
 _Y_SHIFT = np.uint64(43)
 _HIGH_SHIFT = np.uint64(_VALID_HIGH_SHIFT)
 
+#: Appended ASCII blocks are small; cap the read rather than trusting the size.
+_ASCII_INFO_LIMIT = 1 << 16
+
 _HEADER_STRUCT = struct.Struct("<H")
 _SIZE_STRUCT = struct.Struct("<I")
 _TILE_STRUCT = struct.Struct("<II")
@@ -100,6 +103,7 @@ class BlockIndex:
         clean: Whether the chain terminated exactly at end-of-file.
         pixels_per_tile: Raster edge length, used to turn the tile indices in
             :attr:`tiles` into pixel offsets.
+        data_block_id: Block id the events were read from, for diagnostics.
     """
 
     data_spans: List[DataSpan] = field(default_factory=list)
@@ -110,6 +114,7 @@ class BlockIndex:
     end_offset: int = 0
     clean: bool = True
     pixels_per_tile: int = 0
+    data_block_id: int = 0
 
     @property
     def n_records(self) -> int:
@@ -152,6 +157,53 @@ def _parse_ascii_info(payload: bytes) -> Dict[str, str]:
     return info
 
 
+def _read_tile_origin(handle, pos: int, index: BlockIndex) -> Optional[Tuple[int, int]]:
+    """Read a block 6 tile origin, recording it as newly seen if it is."""
+    handle.seek(pos)
+    raw = handle.read(_TILE_STRUCT.size)
+    if len(raw) < _TILE_STRUCT.size:
+        return None
+    tile = _TILE_STRUCT.unpack(raw)
+    if tile not in index.tiles:
+        index.tiles.append(tile)
+    return tile
+
+
+def _read_ascii_info(handle, pos: int, record_size: int, index: BlockIndex) -> None:
+    """Record an appended ASCII info block, if it parses to anything."""
+    handle.seek(pos)
+    info = _parse_ascii_info(handle.read(min(record_size, _ASCII_INFO_LIMIT)))
+    if info:
+        index.appended.append(info)
+
+
+def _finalise_index(index: BlockIndex, path: Path, pos: int, file_size: int) -> None:
+    """Record where the walk stopped and complain if it stopped early."""
+    index.end_offset = pos
+    index.clean = pos == file_size
+    if not index.clean:
+        logger.warning(
+            "PHI block chain for %s ended at byte %d of %d; the trailing %d "
+            "bytes were not accounted for",
+            path.name,
+            pos,
+            file_size,
+            file_size - pos,
+        )
+    if not index.data_spans:
+        raise ValueError(
+            f"No event blocks (id {index.data_block_id}) found in {path}. "
+            "Is this a PHI imaging acquisition?"
+        )
+    logger.info(
+        "PHI block scan: %d event blocks, %d records, %d frames, %d tile(s)",
+        len(index.data_spans),
+        index.n_records,
+        index.n_frames,
+        max(len(index.tiles), 1),
+    )
+
+
 def scan_blocks(path: Path, header: PhiHeader) -> BlockIndex:
     """Walk the block chain, recording structure without reading event data.
 
@@ -171,8 +223,8 @@ def scan_blocks(path: Path, header: PhiHeader) -> BlockIndex:
     path = Path(path)
     file_size = path.stat().st_size
     data_id = header.data_block_id
-    index = BlockIndex(pixels_per_tile=header.image_pixels)
-    tile_x = tile_y = 0
+    index = BlockIndex(pixels_per_tile=header.image_pixels, data_block_id=data_id)
+    tile = (0, 0)
 
     with path.open("rb") as handle:
         pos = header.header_size
@@ -192,50 +244,22 @@ def scan_blocks(path: Path, header: PhiHeader) -> BlockIndex:
                 usable = min(record_size, file_size - pos)
                 usable -= usable % EVENT_SIZE
                 if usable > 0:
-                    index.data_spans.append(DataSpan(pos, usable, tile_x, tile_y))
+                    index.data_spans.append(DataSpan(pos, usable, *tile))
                 pos += record_size
             elif block_id == BLOCK_TILE:
-                handle.seek(pos)
-                tile_raw = handle.read(_TILE_STRUCT.size)
-                if len(tile_raw) < _TILE_STRUCT.size:
+                read = _read_tile_origin(handle, pos, index)
+                if read is None:
                     break
-                tile_x, tile_y = _TILE_STRUCT.unpack(tile_raw)
-                if (tile_x, tile_y) not in index.tiles:
-                    index.tiles.append((tile_x, tile_y))
+                tile = read
                 pos += _TILE_STRUCT.size
             elif block_id == BLOCK_FRAME_END:
                 index.n_frames += 1
             else:
                 if block_id == BLOCK_ASCII_INFO and record_size:
-                    handle.seek(pos)
-                    info = _parse_ascii_info(handle.read(min(record_size, 1 << 16)))
-                    if info:
-                        index.appended.append(info)
+                    _read_ascii_info(handle, pos, record_size, index)
                 pos += record_size
 
-    index.end_offset = pos
-    index.clean = pos == file_size
-    if not index.clean:
-        logger.warning(
-            "PHI block chain for %s ended at byte %d of %d; the trailing %d "
-            "bytes were not accounted for",
-            path.name,
-            pos,
-            file_size,
-            file_size - pos,
-        )
-    if not index.data_spans:
-        raise ValueError(
-            f"No event blocks (id {data_id}) found in {path}. "
-            "Is this a PHI imaging acquisition?"
-        )
-    logger.info(
-        "PHI block scan: %d event blocks, %d records, %d frames, %d tile(s)",
-        len(index.data_spans),
-        index.n_records,
-        index.n_frames,
-        len(index.tiles) or 1,
-    )
+    _finalise_index(index, path, pos, file_size)
     return index
 
 

--- a/thyra/readers/phi/mass_axis.py
+++ b/thyra/readers/phi/mass_axis.py
@@ -1,0 +1,169 @@
+# thyra/readers/phi/mass_axis.py
+"""Flight-time to m/z conversion for PHI SmartSoft-TOF data.
+
+Flight times are stored in picoseconds at finer granularity than the detector
+time channel, so events are binned onto the channel grid implied by
+``SpecBinSize`` before being mapped to m/z. The conversion itself is the
+standard time-of-flight relation::
+
+    sqrt(m/z) = (Mass/Time) * t_us + MassOffset
+
+Below ``t = -MassOffset / (Mass/Time)`` the root is non-positive and no mass
+is defined, so the usable axis is clipped to the mass range the acquisition
+declares.
+"""
+
+import logging
+import math
+from dataclasses import dataclass
+from typing import Tuple
+
+import numpy as np
+from numpy.typing import NDArray
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PhiMassAxis:
+    """A common m/z axis on the detector's time-channel grid.
+
+    Attributes:
+        mz: Strictly increasing m/z values, one per retained channel.
+        channel_offset: Index of ``mz[0]`` within the full channel grid.
+        bin_ps: Channel width in picoseconds.
+        start_ps: Flight time of channel zero of the full grid.
+        slope: ``Mass/Time`` used to build the axis.
+        offset: ``MassOffset`` used to build the axis.
+    """
+
+    mz: NDArray[np.float64]
+    channel_offset: int
+    bin_ps: float
+    start_ps: float
+    slope: float
+    offset: float
+
+    def __len__(self) -> int:
+        return int(self.mz.size)
+
+    @property
+    def mass_range(self) -> Tuple[float, float]:
+        """Lowest and highest m/z on the axis."""
+        return (float(self.mz[0]), float(self.mz[-1]))
+
+    @property
+    def tof_us(self) -> NDArray[np.float64]:
+        """Flight time in microseconds for each channel of :attr:`mz`.
+
+        This is the quantity the instrument actually measured; ``mz`` is
+        derived from it. Keeping it alongside the m/z axis makes the
+        calibration reversible -- a different slope and offset can be applied
+        to these times without re-reading the raw file.
+        """
+        channels = self.channel_offset + np.arange(self.mz.size, dtype=np.float64)
+        return (self.start_ps + channels * self.bin_ps) * 1e-6
+
+    def mz_to_tof_us(self, mz: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Invert the calibration, mapping m/z back to flight time.
+
+        ``sqrt(m/z) = slope * t + offset`` rearranges to
+        ``t = (sqrt(m/z) - offset) / slope``.
+        """
+        return (np.sqrt(np.asarray(mz, dtype=np.float64)) - self.offset) / self.slope
+
+    def to_channel(
+        self, tof_ps: NDArray[np.int64]
+    ) -> Tuple[NDArray[np.int64], NDArray[np.bool_]]:
+        """Bin flight times onto the axis.
+
+        Args:
+            tof_ps: Flight times in picoseconds.
+
+        Returns:
+            Tuple of channel indices into :attr:`mz`, and a mask marking which
+            entries fall inside the axis. Indices where the mask is ``False``
+            are meaningless and must not be used.
+        """
+        raw = np.rint((tof_ps - self.start_ps) / self.bin_ps).astype(np.int64)
+        raw -= self.channel_offset
+        return raw, (raw >= 0) & (raw < self.mz.size)
+
+
+def build_mass_axis(
+    slope: float,
+    offset: float,
+    start_flight_time_us: float,
+    stop_flight_time_us: float,
+    bin_size_ns: float,
+    start_mz: float = 0.0,
+    stop_mz: float = 0.0,
+) -> PhiMassAxis:
+    """Build the common m/z axis for a PHI acquisition.
+
+    Args:
+        slope: ``Mass/Time`` in sqrt(amu) per microsecond.
+        offset: ``MassOffset`` in sqrt(amu).
+        start_flight_time_us: First retained flight time.
+        stop_flight_time_us: Last retained flight time.
+        bin_size_ns: Detector time-channel width in nanoseconds.
+        start_mz: Declared low end of the mass range; ignored when zero.
+        stop_mz: Declared high end of the mass range; ignored when zero.
+
+    Returns:
+        The mass axis.
+
+    Raises:
+        ValueError: If the parameters leave no usable channel.
+    """
+    if bin_size_ns <= 0:
+        raise ValueError(f"SpecBinSize must be positive, got {bin_size_ns}")
+
+    bin_ps = bin_size_ns * 1000.0
+    start_ps = start_flight_time_us * 1e6
+    stop_ps = stop_flight_time_us * 1e6
+    n_full = int(math.floor((stop_ps - start_ps) / bin_ps)) + 1
+    if n_full <= 0:
+        raise ValueError(
+            f"Flight-time range {start_flight_time_us}-{stop_flight_time_us} us "
+            f"yields no channels at {bin_size_ns} ns per channel"
+        )
+
+    t_us = (start_ps + np.arange(n_full, dtype=np.float64) * bin_ps) * 1e-6
+    root = slope * t_us + offset
+    usable = root > 0.0
+    mz_full = np.where(usable, root * root, 0.0)
+
+    if start_mz > 0:
+        usable &= mz_full >= start_mz
+    if stop_mz > 0:
+        usable &= mz_full <= stop_mz
+
+    hits = np.nonzero(usable)[0]
+    if hits.size == 0:
+        raise ValueError(
+            "No time channel maps into the declared mass range "
+            f"{start_mz}-{stop_mz} with slope={slope}, offset={offset}"
+        )
+    lo, hi = int(hits[0]), int(hits[-1])
+    # m/z increases monotonically with flight time once the root is positive,
+    # so the usable channels form one contiguous run.
+    mz = mz_full[lo : hi + 1]
+
+    logger.debug(
+        "PHI mass axis: %d channels spanning m/z %.4f-%.4f (channels %d-%d of %d)",
+        mz.size,
+        mz[0],
+        mz[-1],
+        lo,
+        hi,
+        n_full,
+    )
+    return PhiMassAxis(
+        mz=mz,
+        channel_offset=lo,
+        bin_ps=bin_ps,
+        start_ps=start_ps,
+        slope=slope,
+        offset=offset,
+    )

--- a/thyra/readers/phi/phi_header.py
+++ b/thyra/readers/phi/phi_header.py
@@ -1,0 +1,262 @@
+# thyra/readers/phi/phi_header.py
+"""ASCII header parsing for PHI SmartSoft-TOF ``.raw`` files.
+
+The file opens with a CRLF-delimited key/value header bracketed by ``SOFH``
+and ``EOFH``, zero-padded out to the byte count the header itself declares in
+``HeaderSize``. Top-level entries use ``Key: value``; entries below a
+``[Section]`` marker use ``Key=value``.
+
+A recalibration performed after acquisition is not written back into this
+header. It is appended near the end of the file as an ``AsciiInfoBlock01``
+(block id 14), and when present its ``Mass/Time`` and ``MassOffset`` supersede
+the values here -- the originals may be stale, which the acquisition header
+usually admits via ``Calibrated: no``.
+"""
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+SOFH_MAGIC = b"SOFH"
+EOFH_MARKER = b"EOFH"
+
+# Generous upper bound for the ASCII region; HeaderSize is read from within it.
+_MAX_HEADER_PROBE = 1 << 20
+
+_SECTION_RE = re.compile(r"^\[(.+)\]$")
+_TOP_LEVEL_RE = re.compile(r"^([A-Za-z][^:]*): ?(.*)$")
+
+#: ``(measured, species, theoretical)`` triplets from a ``Calibration:`` line.
+_CALIBRANT_RE = re.compile(r"\(\s*([\d.eE+-]+)\s*,\s*([^,]+?)\s*,\s*([\d.eE+-]+)\s*\)")
+
+
+@dataclass(frozen=True)
+class Calibrant:
+    """One entry of a ``Calibration:`` line."""
+
+    measured_mz: float
+    species: str
+    theoretical_mz: float
+
+
+@dataclass(frozen=True)
+class PhiHeader:
+    """Parsed PHI acquisition header.
+
+    Attributes:
+        entries: Top-level ``Key: value`` pairs, verbatim.
+        sections: ``[Section]`` blocks mapping key to value, verbatim.
+        header_size: Byte offset at which the binary block stream begins.
+        image_pixels: Raster edge length in pixels (the raster is square).
+        mass_slope: ``Mass/Time``, in sqrt(amu) per microsecond.
+        mass_offset: ``MassOffset``, in sqrt(amu).
+        start_flight_time_us: First flight time retained by the acquisition.
+        stop_flight_time_us: Last flight time retained by the acquisition.
+        bin_size_ns: Detector time-channel width, from ``SpecBinSize``.
+        start_mz: Declared low end of the acquired mass range.
+        stop_mz: Declared high end of the acquired mass range.
+        polarity: ``"negative"`` or ``"positive"``.
+        n_frames: Number of acquisition frames summed into the file.
+        msms_active: Whether MS/MS was enabled; selects the data block id.
+        raster_size_um: Raster edge length in micrometres, when declared.
+        raster_size_calibration: ``Raster Size Calibration`` factor, when
+            declared. See :meth:`pixel_size_um` for why this is not applied.
+        declared_tiles: ``(x, y)`` tile counts declared for mosaic
+            acquisitions. Declared even when mosaic mode is off, so it must
+            not be used to size the pixel grid on its own.
+        mosaic_active: Whether the header declares mosaic mode active.
+        calibrants: Calibrants from the acquisition ``Calibration:`` line.
+    """
+
+    entries: Dict[str, str]
+    sections: Dict[str, Dict[str, str]]
+    header_size: int
+    image_pixels: int
+    mass_slope: float
+    mass_offset: float
+    start_flight_time_us: float
+    stop_flight_time_us: float
+    bin_size_ns: float
+    start_mz: float
+    stop_mz: float
+    polarity: str
+    n_frames: int
+    msms_active: bool
+    raster_size_um: Optional[float] = None
+    raster_size_calibration: Optional[float] = None
+    declared_tiles: Tuple[int, int] = (1, 1)
+    mosaic_active: bool = False
+    calibrants: List[Calibrant] = field(default_factory=list)
+
+    @property
+    def data_block_id(self) -> int:
+        """Block id carrying ion events: 8 under MS/MS, otherwise 1."""
+        return 8 if self.msms_active else 1
+
+    @property
+    def pixel_size_um(self) -> Optional[float]:
+        """Edge length of one pixel in micrometres, or ``None`` if underivable.
+
+        Computed as ``raster_size_um / image_pixels``, which on the reference
+        dataset gives the 1.00 um pitch the operator selected at acquisition.
+
+        The header also carries a ``Raster Size Calibration`` factor (1.550 on
+        that dataset). It is deliberately *not* applied: it trims the scan
+        generator so the raster actually achieves the requested pitch, rather
+        than scaling the field of view. Multiplying by it would inflate every
+        coordinate by 55%. Pass ``pixel_size_um`` to the reader to override.
+        """
+        if not self.raster_size_um or self.image_pixels <= 0:
+            return None
+        return self.raster_size_um / self.image_pixels
+
+
+def _to_float(value: Optional[str], default: float = 0.0) -> float:
+    try:
+        return float(str(value).strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def _to_int(value: Optional[str], default: int = 0) -> int:
+    try:
+        return int(float(str(value).strip()))
+    except (TypeError, ValueError):
+        return default
+
+
+def parse_calibrants(line: str) -> List[Calibrant]:
+    """Parse the ``(measured, species, theoretical)`` triplets of a line."""
+    return [
+        Calibrant(float(m), species.strip(), float(t))
+        for m, species, t in _CALIBRANT_RE.findall(line or "")
+    ]
+
+
+def _split_header_text(text: str) -> Tuple[Dict[str, str], Dict[str, Dict[str, str]]]:
+    entries: Dict[str, str] = {}
+    sections: Dict[str, Dict[str, str]] = {}
+    # Empty means "above the first [Section]"; the section regex requires at
+    # least one character, so no real section name can collide with it.
+    current = ""
+    for line in text.split("\r\n"):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        section = _SECTION_RE.match(stripped)
+        if section is not None:
+            current = section.group(1)
+            sections.setdefault(current, {})
+            continue
+        if not current:
+            match = _TOP_LEVEL_RE.match(line)
+            if match is not None:
+                entries[match.group(1)] = match.group(2).strip()
+        elif "=" in line:
+            key, _, value = line.partition("=")
+            sections[current][key.strip()] = value.strip()
+    return entries, sections
+
+
+def parse_phi_header(path: Path) -> PhiHeader:
+    """Parse the ASCII header of a PHI ``.raw`` file.
+
+    Args:
+        path: Path to the ``.raw`` file.
+
+    Returns:
+        The parsed header.
+
+    Raises:
+        ValueError: If the file is not a PHI raw file, the header is
+            unterminated, or a field required for conversion is missing.
+    """
+    path = Path(path)
+    with path.open("rb") as handle:
+        probe = handle.read(_MAX_HEADER_PROBE)
+
+    if not probe.startswith(SOFH_MAGIC):
+        raise ValueError(
+            f"Not a PHI SmartSoft-TOF raw file (missing SOFH magic): {path}"
+        )
+    end = probe.find(EOFH_MARKER)
+    if end == -1:
+        raise ValueError(f"Malformed PHI header, no EOFH terminator: {path}")
+
+    entries, sections = _split_header_text(probe[:end].decode("latin-1"))
+
+    acq = sections.get("Acq Base", {})
+    lmig = sections.get("PHI LMIG", {})
+    mosaic = sections.get("Mosaic Area", {})
+
+    for required in ("HeaderSize", "ImagePixels", "Mass/Time", "MassOffset"):
+        if required not in entries:
+            raise ValueError(
+                f"PHI header is missing required field '{required}': {path}"
+            )
+
+    polarity_text = sections.get("Polarity", {}).get(
+        "Polarity", entries.get("SecIonPolarity", "")
+    )
+    polarity = (
+        "negative"
+        if "-" in polarity_text or "Negative" in polarity_text
+        else "positive"
+    )
+
+    raster = lmig.get("Raster Size (um)") or entries.get("ScanWidthX")
+    raster_cal = lmig.get("Raster Size Calibration", "")
+    raster_cal_value = (
+        _to_float(raster_cal.split(",")[0]) if raster_cal else None
+    ) or None
+
+    header = PhiHeader(
+        entries=entries,
+        sections=sections,
+        header_size=_to_int(entries["HeaderSize"]),
+        image_pixels=_to_int(entries["ImagePixels"]),
+        mass_slope=_to_float(entries["Mass/Time"]),
+        mass_offset=_to_float(entries["MassOffset"]),
+        start_flight_time_us=_to_float(entries.get("StartFlightTime"), 0.0),
+        stop_flight_time_us=_to_float(entries.get("StopFlightTime"), 0.0),
+        bin_size_ns=_to_float(entries.get("SpecBinSize"), 0.128),
+        start_mz=_to_float(acq.get("Start Mass (amu)"), 0.0),
+        stop_mz=_to_float(acq.get("End Mass (amu)"), 0.0),
+        polarity=polarity,
+        n_frames=_to_int(entries.get("NoFrames") or acq.get("Frames"), 1),
+        msms_active="Inactive" not in acq.get("MSMS Active", "Inactive"),
+        raster_size_um=_to_float(raster) or None,
+        raster_size_calibration=raster_cal_value,
+        declared_tiles=(
+            _to_int(mosaic.get("Number Of Tiles X"), 1) or 1,
+            _to_int(mosaic.get("Number Of Tiles Y"), 1) or 1,
+        ),
+        mosaic_active="True" in acq.get("Mosaic Active", "False"),
+        calibrants=parse_calibrants(entries.get("Calibration", "")),
+    )
+
+    if header.image_pixels <= 0:
+        raise ValueError(f"PHI header declares a non-positive ImagePixels: {path}")
+    if header.mass_slope <= 0:
+        raise ValueError(f"PHI header declares a non-positive Mass/Time: {path}")
+    if header.stop_flight_time_us <= header.start_flight_time_us:
+        raise ValueError(
+            f"PHI header flight-time range is empty: {header.start_flight_time_us} "
+            f"to {header.stop_flight_time_us} us in {path}"
+        )
+
+    logger.debug(
+        "Parsed PHI header: %d x %d px, %s polarity, %d frames, "
+        "calibration slope=%s offset=%s",
+        header.image_pixels,
+        header.image_pixels,
+        header.polarity,
+        header.n_frames,
+        header.mass_slope,
+        header.mass_offset,
+    )
+    return header

--- a/thyra/readers/phi/phi_header.py
+++ b/thyra/readers/phi/phi_header.py
@@ -162,6 +162,54 @@ def _split_header_text(text: str) -> Tuple[Dict[str, str], Dict[str, Dict[str, s
     return entries, sections
 
 
+def _read_header_text(path: Path) -> str:
+    """Read and delimit the ASCII header region of a PHI file."""
+    with path.open("rb") as handle:
+        probe = handle.read(_MAX_HEADER_PROBE)
+
+    if not probe.startswith(SOFH_MAGIC):
+        raise ValueError(
+            f"Not a PHI SmartSoft-TOF raw file (missing SOFH magic): {path}"
+        )
+    end = probe.find(EOFH_MARKER)
+    if end == -1:
+        raise ValueError(f"Malformed PHI header, no EOFH terminator: {path}")
+    return probe[:end].decode("latin-1")
+
+
+def _parse_polarity(
+    entries: Dict[str, str], sections: Dict[str, Dict[str, str]]
+) -> str:
+    """Read the secondary ion polarity, from either place it is recorded."""
+    text = sections.get("Polarity", {}).get(
+        "Polarity", entries.get("SecIonPolarity", "")
+    )
+    return "negative" if "-" in text or "Negative" in text else "positive"
+
+
+def _parse_raster(
+    entries: Dict[str, str], lmig: Dict[str, str]
+) -> Tuple[Optional[float], Optional[float]]:
+    """Read the raster edge length and its scan-generator calibration factor."""
+    raster = _to_float(lmig.get("Raster Size (um)") or entries.get("ScanWidthX"))
+    calibration = lmig.get("Raster Size Calibration", "")
+    factor = _to_float(calibration.split(",")[0]) if calibration else 0.0
+    return (raster or None, factor or None)
+
+
+def _validate_header(header: PhiHeader, path: Path) -> None:
+    """Reject headers whose numbers cannot describe a real acquisition."""
+    if header.image_pixels <= 0:
+        raise ValueError(f"PHI header declares a non-positive ImagePixels: {path}")
+    if header.mass_slope <= 0:
+        raise ValueError(f"PHI header declares a non-positive Mass/Time: {path}")
+    if header.stop_flight_time_us <= header.start_flight_time_us:
+        raise ValueError(
+            f"PHI header flight-time range is empty: {header.start_flight_time_us} "
+            f"to {header.stop_flight_time_us} us in {path}"
+        )
+
+
 def parse_phi_header(path: Path) -> PhiHeader:
     """Parse the ASCII header of a PHI ``.raw`` file.
 
@@ -176,43 +224,21 @@ def parse_phi_header(path: Path) -> PhiHeader:
             unterminated, or a field required for conversion is missing.
     """
     path = Path(path)
-    with path.open("rb") as handle:
-        probe = handle.read(_MAX_HEADER_PROBE)
-
-    if not probe.startswith(SOFH_MAGIC):
-        raise ValueError(
-            f"Not a PHI SmartSoft-TOF raw file (missing SOFH magic): {path}"
-        )
-    end = probe.find(EOFH_MARKER)
-    if end == -1:
-        raise ValueError(f"Malformed PHI header, no EOFH terminator: {path}")
-
-    entries, sections = _split_header_text(probe[:end].decode("latin-1"))
+    entries, sections = _split_header_text(_read_header_text(path))
 
     acq = sections.get("Acq Base", {})
     lmig = sections.get("PHI LMIG", {})
     mosaic = sections.get("Mosaic Area", {})
 
-    for required in ("HeaderSize", "ImagePixels", "Mass/Time", "MassOffset"):
-        if required not in entries:
-            raise ValueError(
-                f"PHI header is missing required field '{required}': {path}"
-            )
+    missing = [
+        name
+        for name in ("HeaderSize", "ImagePixels", "Mass/Time", "MassOffset")
+        if name not in entries
+    ]
+    if missing:
+        raise ValueError(f"PHI header is missing required field '{missing[0]}': {path}")
 
-    polarity_text = sections.get("Polarity", {}).get(
-        "Polarity", entries.get("SecIonPolarity", "")
-    )
-    polarity = (
-        "negative"
-        if "-" in polarity_text or "Negative" in polarity_text
-        else "positive"
-    )
-
-    raster = lmig.get("Raster Size (um)") or entries.get("ScanWidthX")
-    raster_cal = lmig.get("Raster Size Calibration", "")
-    raster_cal_value = (
-        _to_float(raster_cal.split(",")[0]) if raster_cal else None
-    ) or None
+    raster_um, raster_calibration = _parse_raster(entries, lmig)
 
     header = PhiHeader(
         entries=entries,
@@ -226,11 +252,11 @@ def parse_phi_header(path: Path) -> PhiHeader:
         bin_size_ns=_to_float(entries.get("SpecBinSize"), 0.128),
         start_mz=_to_float(acq.get("Start Mass (amu)"), 0.0),
         stop_mz=_to_float(acq.get("End Mass (amu)"), 0.0),
-        polarity=polarity,
+        polarity=_parse_polarity(entries, sections),
         n_frames=_to_int(entries.get("NoFrames") or acq.get("Frames"), 1),
         msms_active="Inactive" not in acq.get("MSMS Active", "Inactive"),
-        raster_size_um=_to_float(raster) or None,
-        raster_size_calibration=raster_cal_value,
+        raster_size_um=raster_um,
+        raster_size_calibration=raster_calibration,
         declared_tiles=(
             _to_int(mosaic.get("Number Of Tiles X"), 1) or 1,
             _to_int(mosaic.get("Number Of Tiles Y"), 1) or 1,
@@ -239,16 +265,7 @@ def parse_phi_header(path: Path) -> PhiHeader:
         calibrants=parse_calibrants(entries.get("Calibration", "")),
     )
 
-    if header.image_pixels <= 0:
-        raise ValueError(f"PHI header declares a non-positive ImagePixels: {path}")
-    if header.mass_slope <= 0:
-        raise ValueError(f"PHI header declares a non-positive Mass/Time: {path}")
-    if header.stop_flight_time_us <= header.start_flight_time_us:
-        raise ValueError(
-            f"PHI header flight-time range is empty: {header.start_flight_time_us} "
-            f"to {header.stop_flight_time_us} us in {path}"
-        )
-
+    _validate_header(header, path)
     logger.debug(
         "Parsed PHI header: %d x %d px, %s polarity, %d frames, "
         "calibration slope=%s offset=%s",

--- a/thyra/readers/phi/phi_reader.py
+++ b/thyra/readers/phi/phi_reader.py
@@ -1,0 +1,360 @@
+# thyra/readers/phi/phi_reader.py
+"""PHI SmartSoft-TOF ``.raw`` MSI reader (ToF-SIMS, nanoTOF instruments).
+
+The file records individual ion arrivals rather than per-pixel spectra, so
+the reader aggregates events into sparse per-pixel spectra on the detector's
+time-channel grid before handing them to the converter.
+
+Unlike the Waters and Bruker readers this needs no vendor SDK -- the format is
+parsed directly, so it works identically on every platform.
+"""
+
+import logging
+from pathlib import Path
+from typing import Generator, Optional, Tuple
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ...core.base_extractor import MetadataExtractor
+from ...core.base_reader import BaseMSIReader
+from ...core.registry import register_reader
+from .event_stream import BlockIndex, iter_event_batches, scan_blocks
+from .mass_axis import PhiMassAxis, build_mass_axis
+from .phi_header import PhiHeader, parse_phi_header
+
+logger = logging.getLogger(__name__)
+
+
+@register_reader("phi")
+class PhiReader(BaseMSIReader):
+    """Reader for PHI SmartSoft-TOF ``.raw`` ToF-SIMS imaging data.
+
+    The reader:
+
+    1. Parses the ASCII acquisition header
+    2. Walks the block chain to index event blocks, frames and mosaic tiles
+    3. Adopts any appended recalibration in preference to the header's
+    4. Builds a common m/z axis on the detector time-channel grid
+    5. Aggregates ion events into sparse per-pixel spectra
+    """
+
+    def __init__(
+        self,
+        data_path: Path,
+        pixel_size_um: Optional[float] = None,
+        use_appended_calibration: bool = True,
+        intensity_threshold: Optional[float] = None,
+        **kwargs: object,
+    ) -> None:
+        """Initialise a PHI reader.
+
+        Args:
+            data_path: Path to the ``.raw`` file.
+            pixel_size_um: Override the pixel size in micrometres. When
+                omitted it is derived as ``Raster Size (um) / ImagePixels``.
+                See :attr:`PhiHeader.pixel_size_um` for the caveat about the
+                header's ``Raster Size Calibration`` factor.
+            use_appended_calibration: Prefer a recalibration appended to the
+                file over the acquisition header's coefficients. The appended
+                values describe the flight times actually stored, so this
+                should only be disabled to reproduce a legacy conversion.
+            intensity_threshold: Minimum intensity to retain.
+            **kwargs: Passed to :class:`BaseMSIReader`.
+        """
+        super().__init__(data_path, intensity_threshold=intensity_threshold, **kwargs)
+
+        if not self.data_path.is_file():
+            raise ValueError(
+                f"PHI .raw must be a file, not a directory: {self.data_path}. "
+                "Waters .raw data is a directory and is handled by WatersReader."
+            )
+
+        self._pixel_size_override = pixel_size_um
+        self._use_appended_calibration = use_appended_calibration
+
+        self._header: Optional[PhiHeader] = None
+        self._index: Optional[BlockIndex] = None
+        self._axis: Optional[PhiMassAxis] = None
+        self._dimensions: Optional[Tuple[int, int, int]] = None
+        self._calibration_source = "header"
+
+        # Aggregated sparse spectra, built on first use.
+        self._pixel_ids: Optional[NDArray[np.int64]] = None
+        self._group_starts: Optional[NDArray[np.int64]] = None
+        self._group_ends: Optional[NDArray[np.int64]] = None
+        self._channels: Optional[NDArray[np.int32]] = None
+        self._counts: Optional[NDArray[np.int32]] = None
+        self._closed = False
+
+    # ------------------------------------------------------------------ setup
+
+    def _ensure_initialized(self) -> None:
+        """Parse the header and index the block chain. Idempotent."""
+        if self._axis is not None:
+            return
+        if self._closed:
+            raise RuntimeError("Reader has been closed and cannot be reused")
+
+        header = parse_phi_header(self.data_path)
+        index = scan_blocks(self.data_path, header)
+
+        slope, offset = header.mass_slope, header.mass_offset
+        if self._use_appended_calibration:
+            appended = index.appended_calibration()
+            if appended is not None:
+                slope, offset = appended
+                self._calibration_source = "appended"
+                logger.info(
+                    "Using appended recalibration (Mass/Time=%s, MassOffset=%s) "
+                    "in place of the header values (%s, %s)",
+                    slope,
+                    offset,
+                    header.mass_slope,
+                    header.mass_offset,
+                )
+
+        self._header = header
+        self._index = index
+        self._axis = build_mass_axis(
+            slope=slope,
+            offset=offset,
+            start_flight_time_us=header.start_flight_time_us,
+            stop_flight_time_us=header.stop_flight_time_us,
+            bin_size_ns=header.bin_size_ns,
+            start_mz=header.start_mz,
+            stop_mz=header.stop_mz,
+        )
+
+        tiles_x, tiles_y = index.tile_grid
+        self._dimensions = (
+            header.image_pixels * tiles_x,
+            header.image_pixels * tiles_y,
+            1,
+        )
+        logger.info(
+            "Initialised PHI reader: %s, %dx%d px, %d m/z channels, %s calibration",
+            self.data_path.name,
+            self._dimensions[0],
+            self._dimensions[1],
+            len(self._axis),
+            self._calibration_source,
+        )
+
+    @property
+    def header(self) -> PhiHeader:
+        """The parsed acquisition header."""
+        self._ensure_initialized()
+        assert self._header is not None
+        return self._header
+
+    @property
+    def block_index(self) -> BlockIndex:
+        """The indexed block chain."""
+        self._ensure_initialized()
+        assert self._index is not None
+        return self._index
+
+    @property
+    def mass_axis(self) -> PhiMassAxis:
+        """The common m/z axis."""
+        self._ensure_initialized()
+        assert self._axis is not None
+        return self._axis
+
+    @property
+    def dimensions(self) -> Tuple[int, int, int]:
+        """Grid dimensions as ``(x, y, z)``; ``z`` is always 1."""
+        self._ensure_initialized()
+        assert self._dimensions is not None
+        return self._dimensions
+
+    @property
+    def calibration_source(self) -> str:
+        """``"appended"`` if a post-hoc recalibration was used, else ``"header"``."""
+        self._ensure_initialized()
+        return self._calibration_source
+
+    @property
+    def pixel_size_um(self) -> Optional[float]:
+        """Pixel edge length in micrometres, or ``None`` if underivable."""
+        if self._pixel_size_override is not None:
+            return self._pixel_size_override
+        return self.header.pixel_size_um
+
+    @property
+    def pixel_size_source(self) -> str:
+        """Where :attr:`pixel_size_um` came from, for provenance."""
+        if self._pixel_size_override is not None:
+            return "user override"
+        return "Raster Size (um) / ImagePixels"
+
+    # ------------------------------------------------------------ aggregation
+
+    def _aggregate(self) -> None:
+        """Bin every ion event into sparse per-pixel spectra.
+
+        Events arrive scattered across frames and blocks, so they are keyed by
+        ``pixel * n_channels + channel``, sorted once, then run-length encoded.
+        Peak memory is about 8 bytes per recorded event during the sort.
+        """
+        if self._counts is not None:
+            return
+        self._ensure_initialized()
+        assert self._axis is not None and self._index is not None
+
+        n_x, n_y, _ = self.dimensions
+        n_channels = len(self._axis)
+        keys = np.empty(self._index.n_records, dtype=np.int64)
+        filled = 0
+        dropped = 0
+
+        for x, y, tof in iter_event_batches(self.data_path, self._index):
+            channel, ok = self._axis.to_channel(tof)
+            ok &= (x >= 0) & (x < n_x) & (y >= 0) & (y < n_y)
+            n_ok = int(ok.sum())
+            dropped += ok.size - n_ok
+            if n_ok == 0:
+                continue
+            pixel = y[ok].astype(np.int64) * n_x + x[ok].astype(np.int64)
+            batch = pixel * n_channels + channel[ok]
+            if filled + n_ok > keys.size:  # pragma: no cover - defensive
+                keys = np.resize(keys, filled + n_ok)
+            keys[filled : filled + n_ok] = batch
+            filled += n_ok
+
+        keys = keys[:filled]
+        if keys.size == 0:
+            raise ValueError(
+                f"No usable ion events in {self.data_path}. All {dropped} records "
+                "fell outside the mass axis or the pixel grid."
+            )
+        keys.sort()
+
+        change = np.empty(keys.size, dtype=bool)
+        change[0] = True
+        np.not_equal(keys[1:], keys[:-1], out=change[1:])
+        starts = np.nonzero(change)[0]
+        unique = keys[starts]
+        counts = np.diff(np.append(starts, keys.size))
+        del keys, change, starts
+
+        pixel_of = unique // n_channels
+        self._channels = (unique - pixel_of * n_channels).astype(np.int32)
+        self._counts = counts.astype(np.int32)
+        del unique, counts
+
+        pchange = np.empty(pixel_of.size, dtype=bool)
+        pchange[0] = True
+        np.not_equal(pixel_of[1:], pixel_of[:-1], out=pchange[1:])
+        gstarts = np.nonzero(pchange)[0]
+        self._pixel_ids = pixel_of[gstarts]
+        self._group_starts = gstarts
+        self._group_ends = np.append(gstarts[1:], pixel_of.size)
+
+        logger.info(
+            "Aggregated %d ion events into %d peaks across %d occupied pixels "
+            "(%d records dropped)",
+            filled,
+            self._channels.size,
+            self._pixel_ids.size,
+            dropped,
+        )
+
+    # --------------------------------------------------------- reader interface
+
+    def _create_metadata_extractor(self) -> MetadataExtractor:
+        """Create the PHI metadata extractor."""
+        from ...metadata.extractors.phi_extractor import PhiMetadataExtractor
+
+        self._ensure_initialized()
+        return PhiMetadataExtractor(self)
+
+    @property
+    def has_shared_mass_axis(self) -> bool:
+        """Each pixel stores only its occupied channels, so arrays differ."""
+        return False
+
+    def get_common_mass_axis(self) -> NDArray[np.float64]:
+        """Return the m/z axis, derived analytically from the calibration."""
+        return self.mass_axis.mz
+
+    def get_mass_axis_annotations(self) -> Optional[dict]:
+        """Store the measured flight time alongside the derived m/z axis.
+
+        The instrument measures time, not mass. Keeping the flight time makes
+        the calibration reversible: if the stored coefficients later turn out
+        to be wrong, a corrected m/z axis follows from these times alone,
+        without re-reading the raw file.
+        """
+        return {"tof_us": self.mass_axis.tof_us}
+
+    def get_peak_counts_per_pixel(self) -> Optional[NDArray[np.int32]]:
+        """Return occupied channels per pixel, for CSR ``indptr`` construction."""
+        self._aggregate()
+        assert self._pixel_ids is not None
+        assert self._group_starts is not None and self._group_ends is not None
+
+        n_x, n_y, n_z = self.dimensions
+        peaks = np.zeros(n_x * n_y * n_z, dtype=np.int32)
+        peaks[self._pixel_ids] = (self._group_ends - self._group_starts).astype(
+            np.int32
+        )
+        return peaks
+
+    def iter_spectra(self, batch_size: Optional[int] = None) -> Generator[
+        Tuple[Tuple[int, int, int], NDArray[np.float64], NDArray[np.float64]],
+        None,
+        None,
+    ]:
+        """Iterate occupied pixels in raster order.
+
+        Pixels that recorded no ions are skipped entirely.
+
+        Args:
+            batch_size: Ignored; present for interface compatibility.
+
+        Yields:
+            ``((x, y, z), mzs, intensities)`` with 0-based coordinates.
+        """
+        self._aggregate()
+        assert self._pixel_ids is not None and self._axis is not None
+        assert self._group_starts is not None and self._group_ends is not None
+        assert self._channels is not None and self._counts is not None
+
+        n_x = self.dimensions[0]
+        mz_axis = self._axis.mz
+
+        for pixel, start, end in zip(
+            self._pixel_ids, self._group_starts, self._group_ends
+        ):
+            mzs = mz_axis[self._channels[start:end]]
+            intensities = self._counts[start:end].astype(np.float64)
+            mzs, intensities = self._apply_intensity_filter(mzs, intensities)
+            if mzs.size == 0:
+                continue
+            yield (int(pixel % n_x), int(pixel // n_x), 0), mzs, intensities
+
+    def reset(self) -> None:
+        """Reset for re-iteration; the aggregate is cached so this is a no-op."""
+
+    def close(self) -> None:
+        """Release the aggregated arrays."""
+        if self._closed:
+            return
+        self._pixel_ids = None
+        self._group_starts = None
+        self._group_ends = None
+        self._channels = None
+        self._counts = None
+        self._closed = True
+
+    def __repr__(self) -> str:
+        """Return a string representation of the reader."""
+        if self._dimensions is None:
+            return f"PhiReader(path={self.data_path}, uninitialised)"
+        return (
+            f"PhiReader(path={self.data_path}, "
+            f"grid={self._dimensions[0]}x{self._dimensions[1]}, "
+            f"calibration={self._calibration_source})"
+        )

--- a/thyra/utils/windows_paths.py
+++ b/thyra/utils/windows_paths.py
@@ -23,11 +23,16 @@ path with the prefix converts cleanly.
 
 The prefix is applied only when the projected deepest key would not fit
 otherwise, so ordinary paths are handled exactly as before. It is not
-applied to input paths: readers reach vendor SDKs that may not accept
-extended-length syntax.
+applied to the *source data* path: readers reach vendor SDKs that may not
+accept extended-length syntax.
+
+Reading a converted store back is subject to the same limit, and a store
+whose keys sit past it looks structurally invalid rather than merely
+unreachable -- see :func:`prepare_zarr_read_path`.
 """
 
 import logging
+import os
 import sys
 from pathlib import Path
 
@@ -96,6 +101,55 @@ def projected_deepest_key_length(output_path: Path, dataset_id: str) -> int:
     return len(str(output_path)) + 1 + len(dataset_id) + DEEPEST_KEY_RESERVE
 
 
+def prepare_zarr_read_path(store_path: Path) -> Path:
+    r"""Return a path that can actually open a store written to a long path.
+
+    The write side is protected by :func:`prepare_zarr_output_path`, but the
+    limit applies just as much to reading it back. A store whose keys sit past
+    260 characters is written correctly and then cannot be opened by
+    ``spatialdata.read_zarr(path)``: the deep keys are invisible, so the store
+    looks structurally invalid rather than merely unreachable. Plain
+    ``os.path.exists`` on those keys returns ``False`` too, which makes the
+    store look corrupt when it is intact.
+
+    Unlike the output helper this cannot project the deepest key, because the
+    keys already exist and their length depends on what was written. It walks
+    the store to find the longest key instead, which is cheap next to the
+    read that follows.
+
+    Args:
+        store_path: Path to an existing Zarr store.
+
+    Returns:
+        The path to hand to the reader, extended if the store needs it.
+    """
+    if sys.platform != "win32":
+        return store_path
+
+    longest = len(str(store_path))
+    try:
+        for root, _dirs, files in os.walk(store_path):
+            for name in files:
+                longest = max(longest, len(root) + 1 + len(name))
+    except OSError:
+        # Walking already failed, which is itself a sign the prefix is needed.
+        return to_extended_length_path(store_path)
+
+    if longest <= WINDOWS_MAX_PATH:
+        return store_path
+
+    if _long_paths_enabled():
+        return store_path
+
+    logger.info(
+        "Store contains keys up to %d characters, past the %d character "
+        "Windows limit. Reading through an extended-length path.",
+        longest,
+        WINDOWS_MAX_PATH,
+    )
+    return to_extended_length_path(store_path)
+
+
 def prepare_zarr_output_path(output_path: Path, dataset_id: str) -> Path:
     """Return the path to hand to Zarr, extended if the store needs it.
 
@@ -122,10 +176,13 @@ def prepare_zarr_output_path(output_path: Path, dataset_id: str) -> Path:
         return output_path
 
     extended = to_extended_length_path(output_path)
-    logger.info(
+    logger.warning(
         "Output path is long enough that the deepest Zarr key would exceed "
         "the %d character Windows limit (projected %d). Writing through an "
-        "extended-length path so the conversion is not truncated.",
+        "extended-length path so the conversion is not truncated. Note that "
+        "reading the store back is subject to the same limit: pass it "
+        "through thyra.utils.windows_paths.prepare_zarr_read_path, or move "
+        "the store somewhere shallower, or enable Windows long-path support.",
         WINDOWS_MAX_PATH,
         projected,
     )


### PR DESCRIPTION
Adds support for PHI (Physical Electronics) SmartSoft-TOF `.raw` files from
nanoTOF instruments, Thyra's first ToF-SIMS format.

Parsed directly with **no vendor SDK**, so unlike Waters and Bruker this
behaves identically on every platform and adds no binary or licensing baggage.

## How it was verified

The format was reverse engineered, so the evidence matters more than usual.
The instrument software exports its own total ion image and peak images as
`.bif6` sidecars, which gives an independent oracle.

Reconstructing the total ion image from this parse reproduces the vendor
export **bit-exactly** — 262,144 of 262,144 pixels identical, `max|diff| = 0`
— and this holds end to end, through `convert_msi` and back out of the written
Zarr store, not just at the reader boundary. The ten exported peak images
(CN⁻, CNO⁻, PO₂⁻, PO₃⁻ and others) come back at 99.7% with a mean correlation
of 0.985.

## Three behaviours worth reviewing

**`.raw` is now resolved by shape, not extension.** Waters writes a directory
of `_FUNC*.DAT`; PHI writes a single file starting with the `SOFH` magic. A
`.raw` that is neither names both possibilities in the error rather than
complaining only about Waters. This touches shared detection code, so both
sides have tests.

**The header calibration is often stale, and the real one is appended to the
file.** A recalibration run after acquisition is written as a block 14
`AsciiInfoBlock` near the end of the file rather than back into the header,
which frequently still says `Calibrated: no`. On the reference file the header
coefficients place nine known negative ions +3.02 mDa high (sd 0.46) and
recover 83.4% of the vendor's peak counts; the appended ones recover 99.7%.
The appended block wins by default (`use_appended_calibration=False` opts
out), and both sets of coefficients plus the block verbatim are kept in `uns`.

**`Raster Size Calibration` is deliberately not applied** to the pixel size.
It trims the scan generator so the raster achieves the requested pitch rather
than scaling the field of view; applying it would inflate every coordinate by
55%. Confirmed against what the operator actually selected (1.00 µm).

## Shared-code changes

Each of these was first needed by the PHI path but is general, and all are
additive no-ops for existing readers.

- **`BaseMSIReader.get_mass_axis_annotations()`** lets a reader keep a native
  non-m/z axis alongside `mz` in `var`. A ToF instrument measures *time* and
  derives mass, so PHI stores flight time and the calibration stays reversible
  from the output alone. Wired into **both** write paths — the streaming route
  builds `var` by hand and hardcoded `column-order = ["mz"]`, so patching the
  dataframe path alone would have silently dropped it.
- **`_serialize_for_zarr` coerces dict keys to strings.** A non-string key
  previously raised at write time, after the entire conversion had been done.
- **`prepare_zarr_read_path()`** applies the extended-length prefix when
  *reading* a store back. Writing was already protected; reading was not, so a
  store written to a long Windows path was intact yet failed to open, and
  `os.path.exists` on its deep keys returned `False` — together that reads as
  corruption rather than as a path-length limit.

## On binning

The file records individual ion arrivals, not spectra, so a bin width has to
be chosen. 128 ps (the detector channel) is measured rather than assumed: it
merges 232 cells out of 16.7 million while shrinking the mass axis 128-fold,
and agreement with the vendor's peak images *improves* (0.9846 → 0.9937),
because 128 ps is the grid the instrument software itself works on. Full table
in the docs.

## Docs

New `docs/supported-formats.md` (all five input formats, detection rules, and
a capability matrix) and `docs/phi-tofsims-notes.md` (file layout, calibration
behaviour, binning analysis, and an explicit "not yet exercised on real data"
section). `docs/api.md` gains the new reader hooks.

## Testing

44 new tests build synthetic `.raw` files from the documented layout, so the
suite needs no vendor data. Full suite: **1421 passing**. The 4 failures in
`test_pandas3_string_dtypes.py` are pre-existing — verified identical with
these changes stashed — and unrelated.

## Not exercised on real data

Implemented from the format and covered by synthetic tests, but never run
against a real acquisition: **mosaic** (block 6 tile origins), **MS/MS**
(events move to block id 8), and **depth profiling / 3D**. The reference file
is single-tile, non-MS/MS, `NoSputCycles: 0`. Called out in the docs too.
