### PR TITLE
ci: move every action off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/complexity-monitoring.yml
+++ b/.github/workflows/complexity-monitoring.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         # The monitor's --files-changed mode diffs this checkout against the
         # PR's base branch, so that ref has to be here. The default
@@ -38,7 +38,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
@@ -51,7 +51,7 @@ jobs:
 
     - name: Load cached venv
       id: cached-poetry-dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
@@ -105,7 +105,7 @@ jobs:
       id: complexity-check
 
     - name: Upload complexity reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         name: complexity-reports
@@ -114,7 +114,7 @@ jobs:
 
     - name: Comment on PR with complexity results
       if: github.event_name == 'pull_request'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       continue-on-error: true
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,9 +47,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,13 +54,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -255,7 +255,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'release' && github.event.release.tag_name || 'main' }}
           fetch-depth: 0
@@ -265,7 +265,7 @@ jobs:
         run: git pull origin main
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,9 +26,9 @@ jobs:
         python-version: ['3.12', '3.13']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -41,9 +41,11 @@ jobs:
         poetry run pytest -m "not integration" --disable-warnings --cov=thyra --cov-report=xml --cov-report=term-missing
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v7
       with:
-        file: ./coverage.xml
+        # v5 renamed `file` to `files`. The old name is not an alias: it is
+        # simply unrecognised, so the upload silently covers nothing.
+        files: ./coverage.xml
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false
@@ -67,9 +69,9 @@ jobs:
         python-version: ['3.12', '3.13']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -97,9 +99,9 @@ jobs:
         python-version: ['3.12', '3.13']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install thyra from a clean venv (no lockfile)


### PR DESCRIPTION
GitHub has deprecated Node 20 and is already force-running these actions on
Node 24, which shows up as an annotation on every workflow run.

I checked the declared runtime of each pinned version rather than trusting the
annotation, which only named the two actions the docs job happens to use. Six
were on Node 20:

| action | was | now | runtime |
|---|---|---|---|
| `actions/checkout` | v4 | **v5** | node24 |
| `actions/setup-python` | v5 | **v6** | node24 |
| `actions/cache` | v4 | **v6** | node24 |
| `actions/upload-artifact` | v4 | **v7** | node24 |
| `actions/github-script` | v7 | **v9** | node24 |
| `codecov/codecov-action` | v4 | **v7** | composite |

`snok/install-poetry@v1` and `pypa/gh-action-pypi-publish@release/v1` are
composite actions and were already unaffected.

## Two things worth a reviewer's eye

**`upload-artifact@v5` is still Node 20.** Bumping one major would not have
fixed anything — v6 is the first release that moves, and v7 is current.

**codecov renamed `file` to `files` in v5.** The old name is not an alias, it
is simply unrecognised, so leaving it would have uploaded no coverage *while
still reporting success* (`fail_ci_if_error` is false). That input is renamed
in this PR — it is the only behavioural change here, everything else is a
version number.

## Compatibility

Verified that every input and output this repo actually uses still exists at
the new majors: `fetch-depth` on checkout, `python-version` on setup-python,
`path`/`key` plus the `cache-hit` output on cache, `name`/`path`/
`retention-days` on upload-artifact, `script`/`github-token` on github-script,
and `files`/`flags`/`name`/`fail_ci_if_error` on codecov.

## Coverage of this change

`tests.yml` and `complexity-monitoring.yml` run on pull requests, so this PR
exercises them directly — including the codecov upload and the cache restore.
`docs.yml` runs on push to main and is exercised at merge. `release.yml` is
not exercised until the next release; its only changed actions are checkout
and setup-python, both used with defaults there.
