### PR TITLE
feat(resampling): recognise PHI ToF-SIMS instead of defaulting it to constant

### DIFF
--- a/docs/phi-tofsims-notes.md
+++ b/docs/phi-tofsims-notes.md
@@ -194,6 +194,58 @@ from their bin centre, worst case 64 ps, which at m/z 79 is 4.7 ppm or
 
 ---
 
+## Resampling onto a common axis
+
+Converting a single `.raw` needs no resampling -- the reader's own axis is the
+output axis. Resampling only comes up when several samples have to share one
+mass axis, and PHI is an awkward case for it.
+
+`InstrumentDetectorChain` recognises the format (via the
+`format_specific["format"]` stamp) and answers **`nearest_neighbor` on a
+`linear_tof` axis**. Both halves matter.
+
+**Why `linear_tof`.** Channels are laid out at a constant flight-time step, and
+m/z goes as the square of time, so the m/z spacing grows as `sqrt(m/z)` -- the
+`linear_tof` law exactly. Measured on the reference file: 9.8e-5 u per channel
+at m/z 1 against 5.0e-4 at m/z 26, a ratio of 5.1 where `sqrt(26)` is 5.099.
+
+**Why not `tic_preserving`.** The method interpolates onto the target axis and
+rescales the result back to the source TIC. A PHI pixel is not a profile
+spectrum -- it holds only the channels that happened to fire, a median of 44
+points spread across m/z 0.5--1850. `np.interp` draws a straight line between
+consecutive points, so every bin in those gaps comes back with an intensity
+nothing measured, and the rescale then normalises the total to the pixel's true
+TIC. **The fabrication is invisible to any total-ion check**: on the reference
+file the total came out at 70.3704 against a true 70.3707, while the average
+spectrum went from 56% hard zeros to 0.1% -- empty regions such as m/z 200
+sitting at 44% of the base peak. Use `nearest_neighbor`, or if the method is
+forced, set `ResamplingConfig.gap_tolerance_da` (see
+[Resampling](resampling.md) and `thyra.resampling.gaps`).
+
+### Choosing a bin width
+
+The instrument's measured resolving power on the reference file is **R ~ 4,000**
+(median), which is normal for a nanoTOF:
+
+| ion | m/z | FWHM | R |
+|---|---|---|---|
+| C⁻ | 12.000 | 5.02 mDa | 2,393 |
+| CN⁻ | 26.003 | 5.35 mDa | 4,861 |
+| CNO⁻ | 41.998 | 8.90 mDa | 4,717 |
+| PO₃⁻ | 78.958 | 17.12 mDa | 4,613 |
+
+Note that this is resolving power, not axis spacing -- the 128 ps grid samples
+each peak 11 to 20 times. A target axis only has to keep a few samples per
+FWHM. A `linear_tof` axis of 0.01 Da at a reference of m/z 500 gives 189,191
+bins over the full range and 2.3 to 4.3 samples per FWHM, which keeps CN⁻ and
+C₂H₂⁻ -- 12.6 mDa apart, or 1.94 FWHM, genuinely resolved by this instrument --
+5.5 bins apart.
+
+!!! danger "A constant 0.1 Da axis destroys this data"
+    It is roughly 19x the peak width at m/z 26, so CN⁻ and C₂H₂⁻ land in the
+    same bin along with everything else between them. Constant-width axes suit
+    profile MALDI-TOF; they do not suit ToF-SIMS.
+
 ## Pixel size
 
 Derived as `Raster Size (um) / ImagePixels`, which for the reference file is

--- a/docs/resampling.md
+++ b/docs/resampling.md
@@ -90,7 +90,7 @@ because Bruker names the family many ways (`timsTOF fleX MALDI-2`,
 ### Which detector wins
 
 Detectors are tried in a fixed priority order and the first match wins:
-timsTOF, Rapiflex, FT-ICR, Orbitrap, generic centroid, then a catch-all
+timsTOF, Rapiflex, FT-ICR, Orbitrap, PHI, generic centroid, then a catch-all
 default. This table is the actual observed behaviour of that chain:
 
 | Metadata | Detector | Method | Axis type |
@@ -99,9 +99,23 @@ default. This table is the actual observed behaviour of that chain:
 | timsTOF, profile high-density | timsTOF | `nearest_neighbor` | `reflector_tof` |
 | Rapiflex, profile | Rapiflex MALDI-TOF | `tic_preserving` | `constant` |
 | Bruker MALDI-TOF | Rapiflex MALDI-TOF | `tic_preserving` | `constant` |
+| PHI SmartSoft-TOF `.raw` | PHI SmartSoft-TOF (ToF-SIMS) | `nearest_neighbor` | `linear_tof` |
 | unknown vendor, profile (any density) | Unknown (default) | `nearest_neighbor` | `constant` |
 | unknown, centroid | ImzML Centroid | `nearest_neighbor` | `reflector_tof` |
 | no usable metadata | Unknown (default) | `nearest_neighbor` | `constant` |
+
+!!! note "Why PHI needs its own row"
+    Without it PHI reaches the catch-all default and is reported as
+    `constant`. Thyra's own answer would still be `nearest_neighbor`, so
+    nothing breaks inside Thyra -- but `preview_msi` hands that axis type
+    to callers, and a caller that maps `constant` to profile-MALDI
+    conventions arrives at `tic_preserving` onto an equidistant axis. That
+    combination is destructive here: a PHI pixel holds a median of 44
+    measured points across m/z 0.5--1850, and interpolating between them
+    fabricates intensity in every bin in the gaps, with the TIC rescale
+    hiding it behind a total that still balances. The detector reports the
+    law the data actually follows -- `PhiMassAxis` steps at a constant
+    flight time, so spacing goes as `sqrt(m/z)` -- which is `linear_tof`.
 
 !!! info "`tic_preserving` is gated on the source and target axis laws matching"
     A detector may only ask for `tic_preserving` if it knows the spacing law

--- a/tests/unit/resampling/test_decision_tree.py
+++ b/tests/unit/resampling/test_decision_tree.py
@@ -14,6 +14,7 @@ from thyra.resampling.instrument_detectors import (
     InstrumentDetector,
     InstrumentDetectorChain,
     OrbitrapDetector,
+    PhiToFSIMSDetector,
     RapiflexDetector,
     TimsTOFDetector,
 )
@@ -183,6 +184,7 @@ class TestInstrumentDetectorChain:
             "RapiflexDetector",
             "FTICRDetector",
             "OrbitrapDetector",
+            "PhiToFSIMSDetector",
             "CentroidImzMLDetector",
             "DefaultDetector",
         ]
@@ -207,6 +209,72 @@ class TestInstrumentDetectorChain:
         characteristics = DataCharacteristics()
         detector = self.chain.detect(characteristics)
         assert isinstance(detector, DefaultDetector)
+
+    def test_phi_detected_before_default(self):
+        """PHI must not reach DefaultDetector, which would report CONSTANT."""
+        characteristics = DataCharacteristics(is_phi_tofsims=True)
+        detector = self.chain.detect(characteristics)
+        assert isinstance(detector, PhiToFSIMSDetector)
+
+
+class TestPhiToFSIMSDetector:
+    """PHI ToF-SIMS: sparse per-pixel data on a flight-time grid.
+
+    Reaching ``DefaultDetector`` here is not a cosmetic miss. It reports a
+    CONSTANT axis, and a caller that maps constant to profile-MALDI
+    conventions ends up interpolating a pixel that holds a median of 44
+    measured points across m/z 0.5-1850 -- fabricating intensity in every
+    bin between them, with the TIC rescale hiding it behind a balanced
+    total.
+    """
+
+    def setup_method(self):
+        self.detector = PhiToFSIMSDetector()
+
+    def test_matches_the_phi_raw_format_stamp(self):
+        """PhiMetadataExtractor writes format_specific["format"]."""
+        characteristics = DataCharacteristics.from_metadata(
+            {"format_specific": {"format": "PHI SmartSoft-TOF raw"}}
+        )
+        assert characteristics.is_phi_tofsims
+        assert self.detector.matches(characteristics)
+
+    def test_does_not_match_other_formats(self):
+        for fmt in ("Rapiflex", "imzML", "Bruker TSF", ""):
+            characteristics = DataCharacteristics.from_metadata(
+                {"format_specific": {"format": fmt}}
+            )
+            assert not characteristics.is_phi_tofsims, fmt
+            assert not self.detector.matches(characteristics), fmt
+
+    def test_missing_format_specific_does_not_match(self):
+        assert not DataCharacteristics.from_metadata({}).is_phi_tofsims
+
+    def test_uses_nearest_neighbor(self):
+        """Interpolating across the gaps in a sparse pixel invents signal."""
+        assert (
+            self.detector.get_resampling_method() is ResamplingMethod.NEAREST_NEIGHBOR
+        )
+
+    def test_uses_linear_tof_axis(self):
+        """PhiMassAxis steps at a constant flight time, so spacing ~ sqrt(m)."""
+        assert self.detector.get_axis_type() is AxisType.LINEAR_TOF
+
+    def test_declares_its_source_grid_law(self):
+        """An undeclared law cannot clear the TIC-preserving gate."""
+        assert self.detector.source_grid_law is AxisType.LINEAR_TOF
+
+    def test_chain_selects_nearest_neighbor_for_phi(self):
+        """The whole chain, not just the detector in isolation."""
+        chain = InstrumentDetectorChain()
+        characteristics = DataCharacteristics.from_metadata(
+            {"format_specific": {"format": "PHI SmartSoft-TOF raw"}}
+        )
+        assert (
+            chain.get_resampling_method(characteristics)
+            is ResamplingMethod.NEAREST_NEIGHBOR
+        )
+        assert chain.get_axis_type(characteristics) is AxisType.LINEAR_TOF
 
 
 class _TICPreservingDetector(InstrumentDetector):

--- a/tests/unit/test_preview.py
+++ b/tests/unit/test_preview.py
@@ -19,7 +19,7 @@ from pathlib import Path
 import pytest
 
 from thyra import MsiPreview, preview_msi
-from thyra.resampling.types import AxisType
+from thyra.resampling.types import AxisType, ResamplingMethod
 
 
 class TestImzMLPreview:
@@ -59,6 +59,22 @@ class TestImzMLPreview:
         # either ``None`` or a valid AxisType enum value.
         assert result.instrument_type is None or isinstance(
             result.instrument_type, AxisType
+        )
+
+    def test_resampling_method_is_reported(self, create_minimal_imzml):
+        """The method is its own answer, not something callers re-derive.
+
+        A caller that infers the method from the axis type gets it wrong
+        wherever a detector pairs them unconventionally -- which is how PHI
+        ToF-SIMS ended up interpolated: the catch-all default reports a
+        ``constant`` axis while asking for ``nearest_neighbor``.
+        """
+        imzml_path, _ibd_path, _mzs, _intensities = create_minimal_imzml
+
+        result = preview_msi(imzml_path)
+
+        assert result.resampling_method is None or isinstance(
+            result.resampling_method, ResamplingMethod
         )
 
     def test_escdat_probe_false_for_bare_imzml(self, create_minimal_imzml):
@@ -113,6 +129,7 @@ class TestUnreadableInputs:
         assert result.grid_dims == (0, 0)
         assert result.instrument_type is None
         assert result.pixel_size_um is None
+        assert result.resampling_method is None
 
     def test_unsupported_extension(self, temp_dir):
         bogus = temp_dir / "data.xyz"

--- a/thyra/preview.py
+++ b/thyra/preview.py
@@ -25,7 +25,7 @@ from typing import Any, Dict, Optional, Tuple
 
 from .core.registry import detect_format, get_reader_class
 from .resampling.decision_tree import ResamplingDecisionTree
-from .resampling.types import AxisType
+from .resampling.types import AxisType, ResamplingMethod
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +63,17 @@ class MsiPreview:
             without raising.
         error: The exception's ``str()`` when ``readable=False``;
             ``None`` otherwise.
+        resampling_method: The :class:`ResamplingMethod` the
+            :class:`ResamplingDecisionTree` picks for this input, or
+            ``None`` if metadata could not be extracted.  Report this
+            rather than re-deriving a method from
+            :attr:`instrument_type`: the two are separate answers from
+            the detector, and inferring one from the other gets it
+            wrong wherever a detector pairs them unconventionally.  A
+            caller that assumed ``constant`` implied profile MALDI --
+            and so ``tic_preserving`` -- reached exactly that bug on
+            PHI ToF-SIMS, which the catch-all default reports as
+            ``constant`` while asking for ``nearest_neighbor``.
     """
 
     mz_range: Tuple[float, float]
@@ -73,6 +84,7 @@ class MsiPreview:
     has_escdat_folder: bool
     readable: bool
     error: Optional[str] = None
+    resampling_method: Optional[ResamplingMethod] = None
 
 
 def _probe_escdat(path: Path) -> bool:
@@ -207,6 +219,23 @@ def _guess_axis_type(essential: Any, comprehensive: Any) -> Optional[AxisType]:
         return None
 
 
+def _guess_resampling_method(
+    essential: Any, comprehensive: Any
+) -> Optional[ResamplingMethod]:
+    """Best-effort ResamplingMethod pick.  Returns ``None`` on hard failure.
+
+    Same contract as :func:`_guess_axis_type`, and deliberately a separate
+    call rather than something a caller derives from the axis type -- the
+    detector answers the two questions independently.
+    """
+    try:
+        metadata_dict = _resampling_metadata_dict(essential, comprehensive)
+        return ResamplingDecisionTree().select_strategy(metadata_dict)
+    except Exception as exc:
+        logger.debug("ResamplingMethod auto-detection failed for preview: %s", exc)
+        return None
+
+
 def _close_quietly(reader: Optional[Any]) -> None:
     """Close a reader, swallowing any errors.  Best-effort cleanup."""
     if reader is None:
@@ -275,6 +304,7 @@ def preview_msi(path: Path) -> MsiPreview:
             has_escdat_folder=_probe_escdat(path),
             readable=True,
             error=None,
+            resampling_method=_guess_resampling_method(essential, comprehensive),
         )
     finally:
         _close_quietly(reader)

--- a/thyra/resampling/data_characteristics.py
+++ b/thyra/resampling/data_characteristics.py
@@ -33,6 +33,7 @@ class DataCharacteristics:
     # Format-specific flags
     is_rapiflex_format: bool = False
     is_timstof: bool = False
+    is_phi_tofsims: bool = False
 
     @property
     def needs_resampling(self) -> bool:
@@ -137,6 +138,12 @@ class DataCharacteristics:
         # but case-sensitive on the brand "timsTOF" / "timstof".
         is_timstof = bool(instrument_name and "timstof" in instrument_name.lower())
 
+        # PhiMetadataExtractor stamps the exact string "PHI SmartSoft-TOF raw";
+        # the prefix match leaves room for a future SmartSoft revision to
+        # extend it without silently dropping back to DefaultDetector.
+        source_format = format_specific.get("format") if format_specific else None
+        is_phi_tofsims = bool(source_format and source_format.startswith("PHI "))
+
         return cls(
             spectrum_type=spectrum_type,
             total_peaks=total_peaks,
@@ -146,4 +153,5 @@ class DataCharacteristics:
             manufacturer=manufacturer,
             is_rapiflex_format=is_rapiflex,
             is_timstof=is_timstof,
+            is_phi_tofsims=is_phi_tofsims,
         )

--- a/thyra/resampling/instrument_detectors.py
+++ b/thyra/resampling/instrument_detectors.py
@@ -240,6 +240,64 @@ class OrbitrapDetector(InstrumentDetector):
         return AxisType.ORBITRAP
 
 
+class PhiToFSIMSDetector(InstrumentDetector):
+    """Detector for PHI SmartSoft-TOF ToF-SIMS data (nanoTOF instruments).
+
+    Without this detector PHI data reaches :class:`DefaultDetector`, which
+    reports ``CONSTANT``. That answer is wrong twice over, and the second
+    way is expensive: a downstream caller that maps a constant axis to
+    profile-MALDI conventions gets ``tic_preserving`` onto an equidistant
+    axis, and interpolating a PHI pixel -- a median of 44 measured points
+    spread over m/z 0.5-1850 -- fabricates intensity in every bin between
+    them. The TIC rescale then hides the damage behind a total that still
+    balances.
+    """
+
+    @property
+    def name(self) -> str:
+        """Return detector name."""
+        return "PHI SmartSoft-TOF (ToF-SIMS)"
+
+    def matches(self, characteristics: DataCharacteristics) -> bool:
+        """Check whether the reader stamped the PHI raw format."""
+        return characteristics.is_phi_tofsims
+
+    def get_resampling_method(self) -> ResamplingMethod:
+        """Return nearest-neighbour: PHI pixels are sparse, not profile.
+
+        The instrument records individual ion arrivals, so a pixel holds
+        only the channels that happened to fire -- 64 occupied channels out
+        of 863,670 on the reference acquisition. That is centroid-like data
+        whatever the axis says, and interpolating across the gaps between
+        those points invents signal. Nearest-neighbour cannot.
+        """
+        return ResamplingMethod.NEAREST_NEIGHBOR
+
+    def get_axis_type(self) -> AxisType:
+        """Return the linear-TOF law the detector's own grid follows."""
+        return AxisType.LINEAR_TOF
+
+    @property
+    def source_grid_law(self) -> Optional[AxisType]:
+        """Report the linear-TOF law of the source grid.
+
+        ``PhiMassAxis`` lays channels out at a constant flight-time step
+        (``SpecBinSize``, 128 ps on the reference file) and derives m/z as
+        ``(slope * t + offset) ** 2``. Constant steps in time put the m/z
+        spacing proportional to ``sqrt(m/z)``, which is exactly
+        :attr:`AxisType.LINEAR_TOF`. Measured on the reference acquisition:
+        9.8e-5 u per channel at m/z 1 against 5.0e-4 at m/z 26, a ratio of
+        5.1 where ``sqrt(26)`` is 5.099.
+
+        Declaring it matters even though :meth:`get_resampling_method`
+        returns nearest-neighbour, because it is what would let a caller
+        that explicitly asks for ``tic_preserving`` clear
+        ``_gate_tic_preserving`` when it targets a linear-TOF axis -- the
+        one case where interpolating this data is defensible.
+        """
+        return AxisType.LINEAR_TOF
+
+
 class DefaultDetector(InstrumentDetector):
     """Fallback detector for unknown instruments.
 
@@ -292,6 +350,7 @@ class InstrumentDetectorChain:
             RapiflexDetector(),
             FTICRDetector(),
             OrbitrapDetector(),
+            PhiToFSIMSDetector(),
             # Generic spectrum type detector
             CentroidImzMLDetector(),
             # Fallback last


### PR DESCRIPTION
## Description

PHI ToF-SIMS data matched no detector in `InstrumentDetectorChain`, so it
reached `DefaultDetector` and was reported as a `CONSTANT` axis. Thyra's own
answer stayed safe — the default asks for `nearest_neighbor` — but
`preview_msi` hands that axis type to callers, and a caller that maps
`constant` to profile-MALDI conventions arrives at `tic_preserving` onto an
equidistant axis.

That combination destroys this data, and does so silently.

`tic_preserving` is `np.interp` onto the target axis followed by a rescale back
to the source TIC. A PHI pixel is not a profile spectrum: it holds only the
channels that fired, a **median of 44 measured points spread over m/z
0.5–1850**. `np.interp` draws a straight line between consecutive points, so
every bin in the gaps comes back carrying an intensity nothing measured, and
the rescale then normalises the total to the pixel's true TIC.

Measured on the reference acquisition (512×512, 18.4M events), resampled onto a
constant 0.1 Da axis:

| | source | resampled |
|---|---|---|
| total ion current | 70.3707 | 70.3704 |
| hard zeros in the average spectrum | 56% | 0.1% |
| m/z 200, as % of base peak | ~0% | 44% |

The TIC balances to four significant figures while the spectrum has become a
smooth continuum. No total-ion check can see this.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

**`PhiToFSIMSDetector`** — matches the format stamp `PhiMetadataExtractor`
already writes, and answers `nearest_neighbor` on a `linear_tof` axis.

The axis law is not a guess. `PhiMassAxis` steps at a constant flight time and
derives m/z as `(slope * t + offset) ** 2`, so the m/z spacing goes as
`sqrt(m/z)`. Measured on the reference file: 9.8e-5 u per channel at m/z 1
against 5.0e-4 at m/z 26 — a ratio of 5.1, where `sqrt(26)` is 5.099. It
declares `source_grid_law` for the same reason, so a caller that explicitly
asks for `tic_preserving` onto a `linear_tof` axis can still clear the gate.

**`DataCharacteristics.is_phi_tofsims`** — the flag feeding that detector,
following the existing `is_rapiflex_format` pattern. Prefix match on `"PHI "`
so a future SmartSoft revision extending the string does not silently drop back
to `DefaultDetector`.

**`MsiPreview.resampling_method`** — removes the class of bug rather than this
instance of it. The method and the axis type are separate answers from the
detector, and a caller that derives one from the other gets it wrong wherever a
detector pairs them unconventionally. Callers should report what the decision
tree picked instead of inferring it. The field is appended after `error`, which
already carries a default, so positional construction is unaffected.

## Testing

- [x] All existing tests pass
- [x] New tests have been added to cover the changes
- [x] Manual testing has been performed

1,430 unit tests pass. Four failures in
`tests/unit/converters/test_pandas3_string_dtypes.py` are pre-existing and
unrelated — confirmed by stashing this branch's changes and re-running on the
base commit.

New coverage: `TestPhiToFSIMSDetector` (format matching including negative
cases, method, axis type, declared grid law, and the whole chain end-to-end),
a chain-order assertion update, and two `MsiPreview.resampling_method`
assertions covering the readable and unreadable paths.

Verified against the real acquisition: `preview_msi()` now returns
`AxisType.LINEAR_TOF` and `ResamplingMethod.NEAREST_NEIGHBOR`.

## Documentation

- [x] Documentation has been updated
- [x] Docstrings have been added/updated for new functions
- [ ] CHANGELOG.md — left to release-please

`docs/resampling.md` gains a PHI row in the detector table plus a note on why
the row is needed. `docs/phi-tofsims-notes.md` gains a resampling section
covering the method and axis choice, the measured resolving power, and
bin-width guidance.

## Performance Impact

- [x] No performance impact

One extra predicate in the detector chain and one extra decision-tree call per
`preview_msi()`, which is a metadata-only path.

Downstream, a PHI conversion that follows these defaults produces a **wider
table**: a `linear_tof` axis at 0.01 Da / m/z 500 gives 189,191 bins over m/z
0.5–1850, against 18,494 for the constant 0.1 Da axis it replaces (and 863,670
native). That buys 2.3–4.3 samples per FWHM and keeps CN⁻ and C₂H₂⁻ 5.5 bins
apart, where the old axis merged them into one bin. This PR only changes what
is *recommended*; nothing here forces an axis on an existing project.

## Additional Notes

Measured resolving power on the reference file is R ≈ 4,000 (FWHM 5.35 mDa at
CN⁻, 17.12 mDa at PO₃⁻), normal for a nanoTOF. The constant 0.1 Da axis this
replaces was roughly 19× the peak width at m/z 26.

The PHI reader itself was never at fault, and neither was any rendering code —
the reader reproduces the vendor TIC bit-exactly, and the converted table's
stored `average_spectrum` was correct wherever resampling was not involved.
