### PR TITLE
feat: versioned, ontology-mapped MSI metadata schema with validate and METASPACE export

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ for a full walkthrough, including the published example dataset
 - **Optical Alignment**: Automatic MSI-to-optical image registration for Bruker data
 - **Multi-Region Support**: Handles slides with multiple tissue sections
 - **Resampling**: Physics-aware mass axis resampling (on by default in the CLI; opt-in from the Python API)
+- **Validated Metadata**: Versioned, ontology-mapped metadata schema (PSI-MS, NCBITaxon, UBERON, CHEBI) with `thyra validate` and one-command METASPACE export
 - **3D Support**: Process volume data or treat as 2D slices
 - **Cross-Platform**: Windows, macOS, and Linux
 
@@ -84,6 +85,18 @@ print(f"Shape: {msi_table.shape}")  # (pixels, m/z bins)
 print(f"m/z range: {msi_table.var['mz'].min():.1f} -- {msi_table.var['mz'].max():.1f}")
 ```
 
+### Metadata
+
+Every converted store carries a versioned, ontology-mapped metadata block
+(`uns["msi_metadata"]`), auto-populated from the source file:
+
+```bash
+thyra validate output.zarr                               # schema + ontology checks
+thyra export-metaspace output.zarr --merge sample.json   # METASPACE submission JSON
+```
+
+See [Metadata Schema](https://M4i-Imaging-Mass-Spectrometry.github.io/thyra/metadata-schema/).
+
 ## Documentation
 
 Full documentation: **[M4i-Imaging-Mass-Spectrometry.github.io/thyra](https://M4i-Imaging-Mass-Spectrometry.github.io/thyra)**
@@ -91,6 +104,7 @@ Full documentation: **[M4i-Imaging-Mass-Spectrometry.github.io/thyra](https://M4
 - [Getting Started](https://M4i-Imaging-Mass-Spectrometry.github.io/thyra/getting-started/) -- installation, first conversion, common workflows
 - [CLI Reference](https://M4i-Imaging-Mass-Spectrometry.github.io/thyra/cli/) -- all command-line options
 - [Output Format](https://M4i-Imaging-Mass-Spectrometry.github.io/thyra/output-format/) -- understanding the zarr structure
+- [Metadata Schema](https://M4i-Imaging-Mass-Spectrometry.github.io/thyra/metadata-schema/) -- the validated, ontology-mapped metadata block and METASPACE export
 - [Coordinate Systems](https://M4i-Imaging-Mass-Spectrometry.github.io/thyra/coordinate-systems/) -- the ``"global"`` contract Thyra writes for downstream consumers
 - [API Reference](https://M4i-Imaging-Mass-Spectrometry.github.io/thyra/api/) -- Python API documentation
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -219,6 +219,52 @@ with ImzMLReader("sample.imzML") as reader:
 
 ---
 
+## Metadata Schema
+
+The versioned, ontology-mapped `uns["msi_metadata"]` block every store
+carries. See [Metadata Schema](metadata-schema.md) for the storage
+contract, the CLI (`thyra validate`, `thyra export-metaspace`), and the
+versioning rules.
+
+```python
+from thyra.metadata.schema import (
+    read_msi_metadata_blocks,
+    to_metaspace,
+    validate_document,
+)
+
+blocks = read_msi_metadata_blocks("output.zarr")
+meta, issues = validate_document(blocks["msi_dataset_z0"])
+submission, warnings = to_metaspace(meta)
+```
+
+::: thyra.metadata.schema.models.MSIMetadata
+    options:
+      show_root_heading: true
+      heading_level: 3
+
+::: thyra.metadata.schema.validate.validate_document
+    options:
+      show_root_heading: true
+      heading_level: 3
+
+::: thyra.metadata.schema.store_io.read_msi_metadata_blocks
+    options:
+      show_root_heading: true
+      heading_level: 3
+
+::: thyra.metadata.schema.metaspace.to_metaspace
+    options:
+      show_root_heading: true
+      heading_level: 3
+
+::: thyra.metadata.schema.builder.build_msi_metadata
+    options:
+      show_root_heading: true
+      heading_level: 3
+
+---
+
 ## Reader Base Class
 
 All format readers (ImzML, Bruker, Waters, PHI) inherit from this base class.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,6 +8,9 @@ thyra [OPTIONS] INPUT OUTPUT
 
 **OUTPUT** -- Path for output `.zarr` directory
 
+`thyra` also has two metadata subcommands, `thyra validate` and
+`thyra export-metaspace` -- see [Metadata subcommands](#metadata-subcommands).
+
 !!! tip "Grouped help"
     `thyra --help` lists every option under a category heading -- Conversion,
     Logging, Resampling (advanced), Performance, imzML-specific,
@@ -321,6 +324,61 @@ the number has to come from whoever cut them.
     Without 3D handling each slice is written as its own 2D image and there is
     no z axis to space out. Passing `--z-spacing` on its own is logged as
     ignored rather than silently accepted.
+
+---
+
+## Metadata subcommands
+
+Both take either a converted `.zarr` store or a standalone metadata
+`.json` document. Only the metadata block is read, never the intensity
+data, so both are instant on stores of any size. See
+[Metadata Schema](metadata-schema.md) for the schema itself.
+
+### `thyra validate`
+
+```
+thyra validate PATH [OPTIONS]
+```
+
+Validates the `uns["msi_metadata"]` block (or a JSON document) against
+the schema: structure, schema version, and ontology terms.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--merge PATH` | none | JSON file overlaid onto the metadata before validation |
+| `--json` | off | Machine-readable report on stdout instead of text |
+
+Exit status follows the conversion command's convention: `0` when every
+document conforms (warnings allowed), `1` otherwise, `2` for usage
+errors -- so `thyra validate` can gate a CI pipeline.
+
+```bash
+thyra validate output.zarr
+thyra validate output.zarr --merge sample.json
+thyra validate metadata.json --json
+```
+
+### `thyra export-metaspace`
+
+```
+thyra export-metaspace PATH [OPTIONS]
+```
+
+Writes the [METASPACE](https://metaspace2020.org) submission metadata
+JSON for a dataset. Required fields the store cannot know (organism,
+condition, ...) are emitted empty and reported as warnings on stderr;
+supply them with `--merge` or fill them on the submission form.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--merge PATH` | none | JSON file overlaid onto the metadata before export |
+| `--table NAME` | the only one | Table to export when the store has several |
+| `-o, --output PATH` | `<input>.metaspace.json` | Output file; `-` for stdout |
+
+```bash
+thyra export-metaspace output.zarr --merge sample.json
+thyra export-metaspace output.zarr -o -          # print to stdout
+```
 
 ---
 

--- a/docs/coordinate-systems.md
+++ b/docs/coordinate-systems.md
@@ -35,6 +35,11 @@ zarr.attrs["coordinate_systems"] = {
         "reference_element": str | None,
         "convention_version": 1,
         "produced_by": "thyra/<version>",
+        "raster_to_global_affine": [[a, b, tx], [c, d, ty], [0, 0, 1]],
+
+        # Only when the reader reports raw coordinate offsets
+        "coordinate_offsets_px": [x, y, z],
+        "stage_offset_um": [x_um, y_um],  # micrometer variant only
 
         # Multi-slice volumes only -- see "The z axis" below
         "z_spacing_um": float,
@@ -50,6 +55,9 @@ zarr.attrs["coordinate_systems"] = {
 | ``reference_element`` | Name of the canonical raster element that defines pixel space, when ``unit="pixel"``. ``None`` otherwise. |
 | ``convention_version`` | Schema version; bump when the shape of this attr changes. Currently ``1``. |
 | ``produced_by`` | ``"thyra/<version>"`` for Thyra-produced zarrs. |
+| ``raster_to_global_affine`` | Explicit 3x3 row-major affine from TIC raster indices to ``"global"`` -- the same mapping the TIC element's transform expresses, duplicated here so a consumer that reads only attrs still gets the full placement. A pure pixel-size scale in the micrometer variant; the optical alignment matrix in the pixel variant. Purely additive (``convention_version`` stays 1, same reasoning as the z fields below). |
+| ``coordinate_offsets_px`` | The source's raw acquisition-index offsets ``[x, y, z]``, which 0-based normalisation otherwise erases. **Only present when the reader reports them.** |
+| ``stage_offset_um`` | ``coordinate_offsets_px`` times the pixel size: where the raster origin sat, in micrometers, relative to the source's index origin. **Only written when ``unit="micrometer"``**, so it cannot be misread in the optical-pixel variant. |
 | ``z_spacing_um`` | Micrometers between consecutive slices. **Only present on multi-slice volumes.** Always an absolute micrometer distance, even when ``unit="pixel"``: the optical affine governs only x and y, while z is always scaled directly. |
 | ``z_spacing_source`` | Where ``z_spacing_um`` came from. **Only present on multi-slice volumes.** |
 

--- a/docs/metadata-schema.md
+++ b/docs/metadata-schema.md
@@ -1,0 +1,229 @@
+# Metadata Schema
+
+Every store Thyra writes carries a versioned, ontology-mapped metadata
+block: `table.uns["msi_metadata"]`. Its base fields mirror the
+[METASPACE](https://metaspace2020.org) submission form, so the metadata a
+converted dataset carries is, by construction, what a METASPACE submission
+needs -- filling it costs nothing extra.
+
+The schema exists because MSI has had no structured metadata convention
+the way other spatial omics modalities do. Vendor files spell the same
+fact many ways, imzML metadata is free-form cvParams, and every pipeline
+re-invents its own dictionary. This block fixes the names, maps them to
+ontologies, and ships a validator.
+
+```python
+import spatialdata as sd
+
+sdata = sd.read_zarr("output.zarr")
+block = sdata.tables["msi_dataset_z0"].uns["msi_metadata"]
+
+print(block["schema_version"])                       # "0.1.0"
+print(block["ms_analysis"]["pixel_size_um"])         # {"x": 20.0, "y": 20.0}
+print(block["ms_analysis"]["ionisation_source"])     # "MALDI"
+print(block["ms_analysis"]["ionisation_source_term"])
+# {"accession": "MS:1000075",
+#  "name": "matrix-assisted laser desorption ionization"}
+```
+
+---
+
+## The document
+
+Four sections. `ms_analysis` and `provenance` are written by the converter
+for every store; `sample` and `preparation` describe things no raw file
+records (what the tissue was, how it was prepared) and are supplied by
+you -- see [Completing the metadata](#completing-the-metadata).
+
+| Section | Field | Type | Ontology |
+|---------|-------|------|----------|
+| (root) | `schema_version` | `MAJOR.MINOR.PATCH` string, required | -- |
+| `sample` | `organism`, `organism_term` | text + term | NCBITaxon |
+| | `organism_part`, `organism_part_term` | text + term | UBERON |
+| | `condition` | text | -- |
+| | `sample_growth_conditions` | text | -- |
+| `preparation` | `sample_stabilisation` | text | -- |
+| | `tissue_modification` | text | -- |
+| | `matrix`, `matrix_term` | text + term | CHEBI |
+| | `matrix_application` | text | -- |
+| | `solvent` | text | -- |
+| `ms_analysis` | `polarity`, `polarity_term` | `"positive"`/`"negative"` + term | PSI-MS |
+| | `ionisation_source`, `ionisation_source_term` | text + term | PSI-MS |
+| | `analyzer`, `analyzer_term` | text + term | PSI-MS |
+| | `instrument_model` | text | -- |
+| | `detector_resolving_power` | `{value, at_mz}` | -- |
+| | `pixel_size_um` | `{x, y}`, **required** | -- |
+| `provenance` | `thyra_version` | text, required | -- |
+| | `source_format` | `"imzml"`, `"bruker"`, ... | -- |
+| | `source_path` | text | -- |
+| | `pixel_size_source` | `"automatic"` / `"manual"` / `"default"` | -- |
+
+An ontology term is always the pair
+`{"accession": "MS:1000075", "name": "matrix-assisted laser desorption ionization"}` --
+a [CURIE](https://www.w3.org/TR/curie/) plus the term's label, so the block
+is readable without resolving anything.
+
+`pixel_size_um` is the one acquisition field that is required: conversion
+refuses to run without a pixel size, so a document without it describes no
+store Thyra ever wrote.
+
+!!! note "Unknown fields are rejected"
+    Validation refuses keys the schema does not define, so a typo fails
+    loudly instead of becoming an unread field. Anything genuinely
+    vendor-specific already has a home in the sections beside this block
+    (`format_specific`, `acquisition_params`, `raw_metadata` -- see
+    [Output Format](output-format.md#provenance)).
+
+### What is auto-populated
+
+Auto-population is deliberately honest: a field the source does not report
+is left unset, never guessed. The only inferences are facts that follow
+from the format itself.
+
+| Source | polarity | ionisation source | analyzer | instrument model |
+|--------|----------|-------------------|----------|------------------|
+| imzML | -- | -- | -- | from `instrument model` |
+| Bruker `.d` | -- | MALDI, when the laser tables are present | TOF (timsTOF-family formats) | from the DB |
+| PHI ToF-SIMS | from the header | SIMS | TOF | platform name |
+| Waters `.raw` | -- | -- | -- | from `_HEADER.TXT` |
+
+Everything else -- organism, tissue, condition, matrix, resolving power --
+cannot come from a raw file and stays empty until you provide it.
+
+---
+
+## Storage contract
+
+- The block lives at `table.uns["msi_metadata"]`, in every table the
+  store has. This location is stable, like `uns["essential_metadata"]`
+  and the `coordinate_systems` root attribute; consumers read it from
+  here and nowhere else.
+- It is written identically by every converter write path (the uns
+  parity tests assert this), and contains no timestamps, so converting
+  the same input twice produces the same block.
+- Sections with nothing in them are omitted rather than written empty,
+  following the store-wide convention.
+
+## Versioning
+
+`schema_version` follows semantic-version rules:
+
+- Adding an optional field bumps the **minor** version.
+- Renaming, removing, retyping, or making a field required bumps the
+  **major** version.
+- A validator implementing major version N rejects documents with a
+  different major version, accepts older minors, and warns on newer
+  minors.
+
+The JSON Schema rendering is committed at
+`thyra/metadata/schema/msi_metadata_schema_v0_1.json` and ships in the
+wheel, so non-Python consumers can validate documents without importing
+Thyra:
+
+```python
+from importlib import resources
+import json
+
+schema = json.loads(
+    resources.files("thyra.metadata.schema")
+    .joinpath("msi_metadata_schema_v0_1.json")
+    .read_text()
+)
+```
+
+A unit test keeps the artifact in sync with the models; regenerate it with
+`python -m thyra.metadata.schema.generate` after a model change.
+
+---
+
+## `thyra validate`
+
+```
+thyra validate PATH [--merge USER.json] [--json]
+```
+
+`PATH` is a converted `.zarr` store or a standalone metadata `.json`
+document. Only the metadata block is read -- validating a 100 GB store is
+instant. Exit status is `0` when every document conforms (warnings
+allowed) and `1` otherwise, so it can gate CI.
+
+Errors mean the document does not conform: structural violations, unknown
+PSI-MS/IMS/UO accessions, version incompatibility. Warnings mean it
+conforms but says something suspicious: a term label that does not match
+its accession, or a term from an unexpected ontology.
+
+```bash
+thyra validate output.zarr
+# msi_dataset_z0: OK
+
+thyra validate output.zarr --json   # machine-readable report on stdout
+```
+
+## `thyra export-metaspace`
+
+```
+thyra export-metaspace PATH [--merge USER.json] [--table NAME] [-o OUT.json]
+```
+
+Writes the METASPACE submission metadata JSON (default:
+`<input>.metaspace.json` next to the input; `-o -` for stdout). Required
+fields the store cannot know are emitted empty and reported as warnings on
+stderr -- the output is a truthful starting point, never a fabricated
+record. The one inference: matrix-free sources (DESI, SIMS) truthfully get
+`MALDI_Matrix: "none"`.
+
+```bash
+thyra export-metaspace output.zarr
+# warning: Sample_Information.Organism is required ... and is not set
+# Wrote METASPACE metadata for msi_dataset_z0 to output.metaspace.json
+```
+
+## Completing the metadata
+
+The fields only you can know go in a small JSON overlay, merged at
+validation or export time with `--merge`:
+
+```json
+{
+  "sample": {
+    "organism": "Mus musculus",
+    "organism_term": {"accession": "NCBITaxon:10090", "name": "Mus musculus"},
+    "organism_part": "liver",
+    "organism_part_term": {"accession": "UBERON:0002107", "name": "liver"},
+    "condition": "wildtype"
+  },
+  "preparation": {
+    "sample_stabilisation": "fresh frozen",
+    "matrix": "2,5-dihydroxybenzoic acid (DHB)",
+    "matrix_term": {"accession": "CHEBI:17189", "name": "2,5-dihydroxybenzoic acid"},
+    "matrix_application": "ImagePrep"
+  },
+  "ms_analysis": {
+    "detector_resolving_power": {"value": 130000, "at_mz": 400}
+  }
+}
+```
+
+```bash
+thyra validate output.zarr --merge sample.json
+thyra export-metaspace output.zarr --merge sample.json
+```
+
+The overlay merges key-by-key over the stored block, so it only needs the
+fields you are adding. Keep it next to the store; it applies unchanged to
+every dataset from the same study.
+
+## Python API
+
+```python
+from thyra.metadata.schema import (
+    MSIMetadata,             # the pydantic model
+    read_msi_metadata_blocks,  # {table_name: block} from a store
+    validate_document,       # (model | None, issues)
+    to_metaspace,            # (submission_dict, warnings)
+)
+
+blocks = read_msi_metadata_blocks("output.zarr")
+meta, issues = validate_document(blocks["msi_dataset_z0"])
+submission, warnings = to_metaspace(meta)
+```

--- a/docs/metadata-schema.md
+++ b/docs/metadata-schema.md
@@ -12,6 +12,16 @@ fact many ways, imzML metadata is free-form cvParams, and every pipeline
 re-invents its own dictionary. This block fixes the names, maps them to
 ontologies, and ships a validator.
 
+!!! info "Where this sits in the format stack"
+    Raw/archival exchange is the domain of
+    [mzPeak](https://github.com/HUPO-PSI/mzPeak) (the HUPO-PSI working
+    draft succeeding mzML); SpatialData is the analysis-ready layer and
+    Thyra's output. Thyra is the bridge between the two, and this
+    schema is the analysis-layer metadata contract: PSI CV-anchored
+    like the raw layer, so nothing is lost crossing the bridge. Raw
+    ragged spectra stay in the raw layer; they are deliberately not
+    part of Thyra's output.
+
 ```python
 import spatialdata as sd
 
@@ -116,6 +126,61 @@ On disk the list is stored as a JSON string (AnnData/zarr cannot
 round-trip a list of objects -- the same reason `uns["regions"]` is
 JSON); `read_msi_metadata_blocks` and `validate_document` decode it
 transparently.
+
+---
+
+## PSI CV alignment
+
+Beyond the per-document `*_term` values, every schema **field** that
+instantiates a PSI CV concept is bound to that concept's accession in
+the JSON Schema itself (a `cv` annotation on the field definition), so
+the claim "Thyra's output is annotated with the same PSI CV terms as
+the raw file it came from" is machine-checkable from the committed
+artifact alone:
+
+| Field | CV concept |
+|-------|-----------|
+| `ms_analysis.pixel_size_um.x` | `IMS:1000046` pixel size (x) |
+| `ms_analysis.pixel_size_um.y` | `IMS:1000047` pixel size y |
+| `ms_analysis.polarity` | `MS:1000465` scan polarity |
+| `ms_analysis.ionisation_source` | `MS:1000008` ionization type |
+| `ms_analysis.analyzer` | `MS:1000443` mass analyzer type |
+| `ms_analysis.instrument_model` | `MS:1000031` instrument model |
+| `ms_analysis.detector_resolving_power` | `MS:1000800` mass resolving power |
+
+On the input side, every imzML file-description cvParam is preserved in
+`uns["raw_metadata"]["cvParams"]` **with its accession** (and unit
+accession where the source set one) -- the name alone cannot be resolved
+back to the CV concept. Polarity declared there (`MS:1000130` /
+`MS:1000129`) auto-populates the schema field.
+
+### Candidate CV terms
+
+Several imaging concepts this schema needs have no CV term yet. They
+are tracked in `CANDIDATE_CV_CONCEPTS` as the vocabulary to raise in
+the PSI/mzPeak imaging discussions, so this schema and the future
+standard converge:
+
+- pixel size semantics (raster pitch vs laser spot vs binned size)
+- pixel size provenance (measured vs user-supplied vs default)
+- coordinate origin and axis handedness
+- stage offset of the raster origin
+- ROI / acquisition region identity
+- missing / empty pixel semantics
+- continuous-vs-processed source provenance after conversion
+- mass axis resampling provenance (method, axis law, target bins)
+
+### LinkML rendering
+
+The schema is also rendered as LinkML at
+`thyra/metadata/schema/msi_metadata.linkml.yaml` -- classes, slots,
+required flags, `slot_uri` CV bindings and the polarity enum with
+`meaning:` accessions. The pydantic models remain the source of truth
+for what Thyra writes and validates; the YAML is the discussion artifact
+for LinkML-native settings (the PSI/mzPeak imaging work, the planned
+spec repository), and a unit test keeps the two from drifting. A later
+migration to LinkML-as-source changes no field names and nothing on
+disk.
 
 ---
 

--- a/docs/metadata-schema.md
+++ b/docs/metadata-schema.md
@@ -53,6 +53,7 @@ you -- see [Completing the metadata](#completing-the-metadata).
 | | `instrument_model` | text | -- |
 | | `detector_resolving_power` | `{value, at_mz}` | -- |
 | | `pixel_size_um` | `{x, y}`, **required** | -- |
+| `processing` | list of `{name, software {name, version, uri}, parameters}` | ordered steps, oldest first | -- |
 | `provenance` | `thyra_version` | text, required | -- |
 | | `source_format` | `"imzml"`, `"bruker"`, ... | -- |
 | | `source_path` | text | -- |
@@ -89,6 +90,53 @@ from the format itself.
 
 Everything else -- organism, tissue, condition, matrix, resolving power --
 cannot come from a raw file and stays empty until you provide it.
+
+### Processing history
+
+`processing` is the dataset's processing provenance, modeled on
+[mzQC](https://github.com/HUPO-PSI/mzQC): an ordered list of steps, each
+naming the software that performed it and the parameters it ran with.
+The converter records its own steps -- `conversion` always, and
+`mass axis resampling` with the resolved resampling parameters when
+resampling was enabled. Downstream tools (normalisation, peak picking,
+annotation) append theirs when they modify the store.
+
+```python
+[
+  {"name": "conversion",
+   "software": {"name": "thyra", "version": "3.5.0"}},
+  {"name": "mass axis resampling",
+   "software": {"name": "thyra", "version": "3.5.0"},
+   "parameters": {"method": "nearest_neighbor", "target_bins": 50000,
+                  "reference_mz": 1000.0}}
+]
+```
+
+On disk the list is stored as a JSON string (AnnData/zarr cannot
+round-trip a list of objects -- the same reason `uns["regions"]` is
+JSON); `read_msi_metadata_blocks` and `validate_document` decode it
+transparently.
+
+---
+
+## var column conventions
+
+The MSI table's `.var` column names are fixed by the spec so every
+consumer can rely on one spelling:
+
+| Column | Written by | Meaning |
+|--------|-----------|---------|
+| `mz` | every converter, **required** | The common mass axis. Numeric, finite, strictly increasing. |
+| `formula` | annotation tools | Molecular formula of the annotation |
+| `adduct` | annotation tools | Adduct, e.g. `+H`, `-H`, `+Na` |
+| `annotation_source` | annotation tools | Tool/database that produced the annotation |
+| `fdr` | annotation tools | False discovery rate of the annotation |
+
+Readers may add extra per-channel columns (a non-m/z native axis such as
+flight time stays alongside `mz`), and annotation tools may add columns
+beyond these -- but the reserved names above must never be reused with a
+different meaning. `thyra validate` checks the `mz` contract on every
+table of a store.
 
 ---
 
@@ -143,9 +191,11 @@ thyra validate PATH [--merge USER.json] [--json]
 ```
 
 `PATH` is a converted `.zarr` store or a standalone metadata `.json`
-document. Only the metadata block is read -- validating a 100 GB store is
-instant. Exit status is `0` when every document conforms (warnings
-allowed) and `1` otherwise, so it can gate CI.
+document. Only the metadata block (and, for stores, the `var` axis) is
+read -- validating a 100 GB store is instant. For stores it also checks
+the [var column contract](#var-column-conventions) and that every table
+carries a metadata block. Exit status is `0` when every document
+conforms (warnings allowed) and `1` otherwise, so it can gate CI.
 
 Errors mean the document does not conform: structural violations, unknown
 PSI-MS/IMS/UO accessions, version incompatibility. Warnings mean it

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -219,6 +219,16 @@ plt.title(f"Pixel {pixel_idx}")
 plt.show()
 ```
 
+### var columns
+
+`var` always carries `mz` (numeric, finite, strictly increasing).
+Readers whose native axis is not m/z keep that axis alongside it, and
+annotation tools add `formula`, `adduct`, `annotation_source` and
+`fdr` -- names fixed by the
+[metadata schema](metadata-schema.md#var-column-conventions) so they
+mean the same thing in every store. `thyra validate` checks the `mz`
+contract on every table.
+
 ---
 
 ## Pixel Coordinates

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -460,6 +460,26 @@ A section the source format has nothing for is omitted rather than written
 empty, so `"instrument_info" not in uns` means "this format does not carry
 it" rather than "it was carried and lost".
 
+### Structured metadata: `uns["msi_metadata"]`
+
+The sections above preserve what the source said, in the source's own
+vocabulary. `uns["msi_metadata"]` is the normalised, versioned view of the
+same facts: fixed field names, PSI-MS/NCBITaxon/UBERON/CHEBI ontology
+terms, and a schema a validator can hold it to.
+
+```python
+block = msi_table.uns["msi_metadata"]
+
+print(block["schema_version"])                    # "0.1.0"
+print(block["ms_analysis"]["pixel_size_um"])      # {"x": 20.0, "y": 20.0}
+print(block["provenance"]["source_format"])       # "imzml"
+```
+
+It is written by every converter path identically, validated by
+`thyra validate`, and exported to a METASPACE submission by
+`thyra export-metaspace`. See [Metadata Schema](metadata-schema.md) for
+the full contract.
+
 ---
 
 ## Recipes

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
   - CLI Reference: cli.md
   - Resampling: resampling.md
   - Output Format: output-format.md
+  - Metadata Schema: metadata-schema.md
   - Coordinate Systems: coordinate-systems.md
   - imzML Parser Notes: imzml-parser-notes.md
   - PHI ToF-SIMS Notes: phi-tofsims-notes.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,15 @@ dependencies = [
     # that coercion was deleted when this floor moved. See issue #117.
     "anndata>=0.13.2, <0.14",         # tested 0.13.2
     "psutil>=5.0.0",
+    # The MSI metadata schema (thyra/metadata/schema) is written against the
+    # pydantic v2 validation API, and the committed JSON Schema artifact is
+    # generated from the models (a unit test keeps the two in sync). pydantic
+    # already arrives transitively -- ome-zarr-models in the spatialdata stack
+    # requires >=2.11.5 -- so like click above this restates a direct import
+    # as a direct dependency rather than changing the resolved set. Floor 2.7
+    # is the oldest line the code is plausibly compatible with; the lockfile
+    # resolves 2.12.x and the JSON-sync test pins the emission against it.
+    "pydantic>=2.7, <3",              # tested 2.12.5
     # Imported directly, not merely re-exported through spatialdata: tifffile by
     # converters/spatialdata/base_spatialdata_converter.py, xarray by that module
     # and the 2D, 3D and streaming converters. Both arrive transitively today
@@ -141,7 +150,10 @@ Changelog = "https://github.com/M4i-Imaging-Mass-Spectrometry/thyra/blob/main/CH
 Contributing = "https://M4i-Imaging-Mass-Spectrometry.github.io/thyra/contributing/"
 
 [project.scripts]
-thyra = "thyra.__main__:main"
+# cli() dispatches `thyra validate` / `thyra export-metaspace` by first
+# argument and falls through to the positional conversion command, so
+# `thyra INPUT OUTPUT` keeps working unchanged.
+thyra = "thyra.__main__:cli"
 thyra-check-ontology = "thyra.tools.check_ontology:main"
 thyra-example-data = "thyra.tools.make_example_data:main"
 

--- a/tests/unit/converters/test_uns_provenance_parity.py
+++ b/tests/unit/converters/test_uns_provenance_parity.py
@@ -287,6 +287,7 @@ def test_every_path_stores_the_same_provenance(stores):
         "instrument_info",
         "raw_metadata",
         "regions",
+        "msi_metadata",
     )
     blocks = {
         name: {

--- a/tests/unit/metadata/extractors/test_imzml_extractor.py
+++ b/tests/unit/metadata/extractors/test_imzml_extractor.py
@@ -750,3 +750,26 @@ class TestNoFabricatedMassRange:
         with production_parser(path) as parser:
             with pytest.raises(ValueError, match="Could not determine the mass range"):
                 ImzMLMetadataExtractor(parser, path).get_mass_range_for_resampling()
+
+
+class TestRawCvParamAccessions:
+    """cvParams reach raw_metadata with their accessions attached.
+
+    The stored copy is only lossless if the accession travels with the
+    name: the goal is that a converted store is annotated with the same
+    PSI CV terms as the raw file it came from (docs/metadata-schema.md).
+    The name alone cannot be resolved back to the CV concept.
+    """
+
+    def test_cvparams_carry_accessions(self, tmp_path):
+        path = _write_imzml(tmp_path, "accessions", "centroid")
+        with production_parser(path) as parser:
+            raw = ImzMLMetadataExtractor(parser, path).get_comprehensive().raw_metadata
+
+        cv_params = raw["cvParams"]
+        assert cv_params, "no cvParams preserved"
+        for entry in cv_params:
+            assert set(entry) >= {"name", "accession", "value"}
+
+        accessions = {entry["accession"] for entry in cv_params}
+        assert "IMS:1000080" in accessions  # the UUID the writer stamps

--- a/tests/unit/metadata/schema/__init__.py
+++ b/tests/unit/metadata/schema/__init__.py
@@ -1,0 +1,1 @@
+# Tests for the versioned MSI metadata schema.

--- a/tests/unit/metadata/schema/test_builder.py
+++ b/tests/unit/metadata/schema/test_builder.py
@@ -1,0 +1,119 @@
+"""Auto-population: the builder reports what the source knows, nothing more."""
+
+from thyra.metadata.schema import build_msi_metadata
+from thyra.metadata.types import ComprehensiveMetadata, EssentialMetadata
+
+
+def _essential(source_path: str = "input.imzML") -> EssentialMetadata:
+    return EssentialMetadata(
+        dimensions=(10, 10, 1),
+        coordinate_bounds=(0.0, 9.0, 0.0, 9.0),
+        mass_range=(100.0, 1000.0),
+        pixel_size=(20.0, 25.0),
+        n_spectra=100,
+        total_peaks=1000,
+        estimated_memory_gb=0.1,
+        source_path=source_path,
+        spectrum_type="centroid spectrum",
+    )
+
+
+def _comprehensive(
+    acquisition_params=None,
+    instrument_info=None,
+    format_specific=None,
+) -> ComprehensiveMetadata:
+    return ComprehensiveMetadata(
+        essential=_essential(),
+        format_specific=format_specific or {},
+        acquisition_params=acquisition_params or {},
+        instrument_info=instrument_info or {},
+        raw_metadata={},
+    )
+
+
+class TestBuildMsiMetadata:
+    def test_pixel_size_and_provenance_are_always_present(self):
+        meta = build_msi_metadata(
+            _comprehensive(),
+            pixel_size_um=(20.0, 25.0),
+            pixel_size_source="automatic",
+            source_format="imzml",
+        )
+        assert meta.ms_analysis.pixel_size_um.x == 20.0
+        assert meta.ms_analysis.pixel_size_um.y == 25.0
+        assert meta.provenance.source_format == "imzml"
+        assert meta.provenance.source_path == "input.imzML"
+        assert meta.provenance.pixel_size_source == "automatic"
+        assert meta.provenance.thyra_version
+
+    def test_without_comprehensive_metadata_the_block_still_builds(self):
+        meta = build_msi_metadata(None, pixel_size_um=(5.0, 5.0))
+        assert meta.ms_analysis.pixel_size_um.x == 5.0
+        assert meta.provenance.source_path is None
+
+    def test_unreported_fields_stay_unset(self):
+        meta = build_msi_metadata(_comprehensive(), pixel_size_um=(20.0, 20.0))
+        analysis = meta.ms_analysis
+        assert analysis.polarity is None
+        assert analysis.ionisation_source is None
+        assert analysis.analyzer is None
+        assert analysis.instrument_model is None
+
+    def test_phi_polarity_and_format_facts(self):
+        # PHI reports polarity in acquisition_params; SIMS/TOF follow
+        # from the format itself.
+        meta = build_msi_metadata(
+            _comprehensive(acquisition_params={"polarity": "Positive"}),
+            pixel_size_um=(2.0, 2.0),
+            source_format="phi",
+        )
+        analysis = meta.ms_analysis
+        assert analysis.polarity == "positive"
+        assert analysis.polarity_term is not None
+        assert analysis.polarity_term.accession == "MS:1000130"
+        assert analysis.ionisation_source == "SIMS"
+        assert analysis.analyzer == "TOF"
+
+    def test_bruker_maldi_flag_sets_the_source(self):
+        meta = build_msi_metadata(
+            _comprehensive(format_specific={"is_maldi": True}),
+            pixel_size_um=(20.0, 20.0),
+            source_format="bruker",
+        )
+        analysis = meta.ms_analysis
+        assert analysis.ionisation_source == "MALDI"
+        assert analysis.ionisation_source_term is not None
+        assert analysis.ionisation_source_term.accession == "MS:1000075"
+        assert analysis.analyzer == "TOF"
+
+    def test_imzml_gets_no_format_default_analyzer(self):
+        # imzML can come off any instrument; claiming an analyzer for
+        # it would be a guess.
+        meta = build_msi_metadata(
+            _comprehensive(),
+            pixel_size_um=(20.0, 20.0),
+            source_format="imzml",
+        )
+        assert meta.ms_analysis.analyzer is None
+
+    def test_instrument_model_is_probed_across_key_spellings(self):
+        for key in ("instrument_model", "instrument_name", "model", "platform"):
+            meta = build_msi_metadata(
+                _comprehensive(instrument_info={key: "rapifleX"}),
+                pixel_size_um=(20.0, 20.0),
+            )
+            assert meta.ms_analysis.instrument_model == "rapifleX"
+
+    def test_built_block_passes_validation(self):
+        from thyra.metadata.schema import validate_document
+
+        meta = build_msi_metadata(
+            _comprehensive(acquisition_params={"polarity": "negative"}),
+            pixel_size_um=(20.0, 25.0),
+            pixel_size_source="manual",
+            source_format="bruker",
+        )
+        model, issues = validate_document(meta.to_uns_dict())
+        assert model is not None
+        assert issues == []

--- a/tests/unit/metadata/schema/test_builder.py
+++ b/tests/unit/metadata/schema/test_builder.py
@@ -22,13 +22,14 @@ def _comprehensive(
     acquisition_params=None,
     instrument_info=None,
     format_specific=None,
+    raw_metadata=None,
 ) -> ComprehensiveMetadata:
     return ComprehensiveMetadata(
         essential=_essential(),
         format_specific=format_specific or {},
         acquisition_params=acquisition_params or {},
         instrument_info=instrument_info or {},
-        raw_metadata={},
+        raw_metadata=raw_metadata or {},
     )
 
 
@@ -74,6 +75,42 @@ class TestBuildMsiMetadata:
         assert analysis.polarity_term.accession == "MS:1000130"
         assert analysis.ionisation_source == "SIMS"
         assert analysis.analyzer == "TOF"
+
+    def test_imzml_polarity_comes_from_the_preserved_cv_params(self):
+        # imzML declares polarity as MS:1000130/MS:1000129 in the file
+        # description; the extractor preserves those with accessions.
+        meta = build_msi_metadata(
+            _comprehensive(
+                raw_metadata={
+                    "cvParams": [
+                        {
+                            "name": "positive scan",
+                            "accession": "MS:1000130",
+                            "value": True,
+                        }
+                    ]
+                }
+            ),
+            pixel_size_um=(20.0, 20.0),
+            source_format="imzml",
+        )
+        assert meta.ms_analysis.polarity == "positive"
+        assert meta.ms_analysis.polarity_term is not None
+        assert meta.ms_analysis.polarity_term.accession == "MS:1000130"
+
+    def test_a_file_declaring_both_polarities_stays_unset(self):
+        meta = build_msi_metadata(
+            _comprehensive(
+                raw_metadata={
+                    "cvParams": [
+                        {"accession": "MS:1000130"},
+                        {"accession": "MS:1000129"},
+                    ]
+                }
+            ),
+            pixel_size_um=(20.0, 20.0),
+        )
+        assert meta.ms_analysis.polarity is None
 
     def test_bruker_maldi_flag_sets_the_source(self):
         meta = build_msi_metadata(

--- a/tests/unit/metadata/schema/test_cli_metadata.py
+++ b/tests/unit/metadata/schema/test_cli_metadata.py
@@ -1,0 +1,161 @@
+﻿"""The `thyra validate` / `thyra export-metaspace` subcommands."""
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from thyra.metadata.schema import build_msi_metadata
+from thyra.metadata.schema.cli import export_metaspace_command, validate_command
+
+
+def _make_runner() -> CliRunner:
+    """A runner whose results expose stderr on every supported click.
+
+    click < 8.2 mixes stderr into output unless asked not to (and
+    ``result.stderr`` raises); 8.2 removed the ``mix_stderr`` kwarg and
+    always separates.  The project supports both (see the click pin in
+    pyproject.toml).
+    """
+    try:
+        return CliRunner(mix_stderr=False)  # type: ignore[call-arg]
+    except TypeError:
+        return CliRunner()
+
+
+@pytest.fixture
+def runner():
+    return _make_runner()
+
+
+def _write_doc(tmp_path, name="meta.json", mutate=None):
+    doc = build_msi_metadata(
+        None, pixel_size_um=(20.0, 20.0), source_format="imzml"
+    ).to_uns_dict()
+    if mutate:
+        mutate(doc)
+    path = tmp_path / name
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    return path
+
+
+class TestValidateCommand:
+    def test_valid_document_exits_zero(self, runner, tmp_path):
+        result = runner.invoke(validate_command, [str(_write_doc(tmp_path))])
+        assert result.exit_code == 0
+        assert "OK" in result.output
+
+    def test_invalid_document_exits_one_and_names_the_field(self, runner, tmp_path):
+        def corrupt(doc):
+            doc["ms_analysis"]["pixel_size_um"]["x"] = -5.0
+
+        path = _write_doc(tmp_path, mutate=corrupt)
+        result = runner.invoke(validate_command, [str(path)])
+        assert result.exit_code == 1
+        assert "ms_analysis.pixel_size_um.x" in result.output
+
+    def test_missing_input_exits_two(self, runner, tmp_path):
+        result = runner.invoke(validate_command, [str(tmp_path / "nope.json")])
+        assert result.exit_code == 2
+
+    def test_merge_overlays_user_fields(self, runner, tmp_path):
+        # An overlay can also break the document; that must be caught.
+        path = _write_doc(tmp_path)
+        overlay = tmp_path / "user.json"
+        overlay.write_text(
+            json.dumps({"ms_analysis": {"polarity": "sideways"}}),
+            encoding="utf-8",
+        )
+        result = runner.invoke(validate_command, [str(path), "--merge", str(overlay)])
+        assert result.exit_code == 1
+        assert "polarity" in result.output
+
+    def test_json_report_is_machine_readable(self, runner, tmp_path):
+        path = _write_doc(tmp_path)
+        result = runner.invoke(validate_command, [str(path), "--json"])
+        assert result.exit_code == 0
+        report = json.loads(result.stdout)
+        assert report[path.name]["valid"] is True
+        assert report[path.name]["issues"] == []
+
+
+class TestExportMetaspaceCommand:
+    def test_writes_the_submission_json(self, runner, tmp_path):
+        path = _write_doc(tmp_path)
+        output = tmp_path / "out.json"
+        result = runner.invoke(export_metaspace_command, [str(path), "-o", str(output)])
+        assert result.exit_code == 0
+        document = json.loads(output.read_text(encoding="utf-8"))
+        assert document["Data_Type"] == "Imaging MS"
+        assert document["MS_Analysis"]["Pixel_Size"] == {"Xaxis": 20, "Yaxis": 20}
+
+    def test_default_output_lands_next_to_the_input(self, runner, tmp_path):
+        path = _write_doc(tmp_path)
+        result = runner.invoke(export_metaspace_command, [str(path)])
+        assert result.exit_code == 0
+        assert (tmp_path / "meta.metaspace.json").exists()
+
+    def test_stdout_output(self, runner, tmp_path):
+        path = _write_doc(tmp_path)
+        result = runner.invoke(export_metaspace_command, [str(path), "-o", "-"])
+        assert result.exit_code == 0
+        assert json.loads(result.stdout)["Data_Type"] == "Imaging MS"
+
+    def test_missing_required_fields_are_warned_on_stderr(self, runner, tmp_path):
+        path = _write_doc(tmp_path)
+        result = runner.invoke(export_metaspace_command, [str(path), "-o", "-"])
+        assert result.exit_code == 0
+        assert "Organism" in (result.stderr or "")
+
+    def test_merge_completes_the_submission(self, runner, tmp_path):
+        path = _write_doc(tmp_path)
+        overlay = tmp_path / "user.json"
+        overlay.write_text(
+            json.dumps(
+                {
+                    "sample": {
+                        "organism": "Mus musculus",
+                        "organism_part": "liver",
+                        "condition": "wildtype",
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = runner.invoke(
+            export_metaspace_command,
+            [str(path), "--merge", str(overlay), "-o", "-"],
+        )
+        assert result.exit_code == 0
+        document = json.loads(result.stdout)
+        assert document["Sample_Information"]["Organism"] == "Mus musculus"
+
+    def test_non_conforming_document_is_refused(self, runner, tmp_path):
+        def corrupt(doc):
+            doc["ms_analysis"]["pixel_size_um"]["x"] = -5.0
+
+        path = _write_doc(tmp_path, mutate=corrupt)
+        result = runner.invoke(export_metaspace_command, [str(path), "-o", "-"])
+        assert result.exit_code == 1
+
+
+class TestDispatcher:
+    def test_subcommands_are_dispatched(self, monkeypatch, capsys):
+        from thyra.__main__ import cli
+
+        monkeypatch.setattr("sys.argv", ["thyra", "validate", "--help"], raising=False)
+        with pytest.raises(SystemExit) as excinfo:
+            cli()
+        assert excinfo.value.code == 0
+        assert "Validate MSI metadata" in capsys.readouterr().out
+
+    def test_conversion_interface_still_owns_bare_help(self, monkeypatch, capsys):
+        from thyra.__main__ import cli
+
+        monkeypatch.setattr("sys.argv", ["thyra", "--help"], raising=False)
+        with pytest.raises(SystemExit) as excinfo:
+            cli()
+        assert excinfo.value.code == 0
+        out = capsys.readouterr().out
+        assert "INPUT" in out and "OUTPUT" in out
+        assert "export-metaspace" in out

--- a/tests/unit/metadata/schema/test_linkml_sync.py
+++ b/tests/unit/metadata/schema/test_linkml_sync.py
@@ -1,0 +1,95 @@
+"""The LinkML rendering must not drift from the pydantic models.
+
+The YAML is the discussion artifact for the PSI/mzPeak imaging work and
+the planned spec repository; the pydantic models are what Thyra actually
+writes and validates.  This test pins the two together on everything
+that matters for convergence: class and slot inventory, required flags,
+CV bindings, and the polarity enum's term meanings.
+"""
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+from pathlib import Path  # noqa: E402
+
+from thyra.metadata.schema import models  # noqa: E402
+from thyra.metadata.schema.vocab import POLARITY_ACCESSIONS  # noqa: E402
+
+_LINKML_PATH = Path(models.__file__).resolve().parent / "msi_metadata.linkml.yaml"
+
+# LinkML records the on-disk requirement; pydantic gives some of those
+# fields construction-time defaults. These are the deliberate deltas.
+_REQUIRED_DESPITE_DEFAULT = {("MSIMetadata", "schema_version")}
+
+_MODEL_CLASSES = {
+    "OntologyTerm": models.OntologyTerm,
+    "PixelSizeUm": models.PixelSizeUm,
+    "ResolvingPower": models.ResolvingPower,
+    "SampleInformation": models.SampleInformation,
+    "SamplePreparation": models.SamplePreparation,
+    "MSAnalysis": models.MSAnalysis,
+    "SoftwareRef": models.SoftwareRef,
+    "ProcessingStep": models.ProcessingStep,
+    "Provenance": models.Provenance,
+    "MSIMetadata": models.MSIMetadata,
+}
+
+
+@pytest.fixture(scope="module")
+def linkml_schema():
+    return yaml.safe_load(_LINKML_PATH.read_text(encoding="utf-8"))
+
+
+def test_versions_agree(linkml_schema):
+    assert linkml_schema["version"] == models.MSI_METADATA_SCHEMA_VERSION
+
+
+def test_every_model_class_is_rendered(linkml_schema):
+    assert set(linkml_schema["classes"]) == set(_MODEL_CLASSES)
+
+
+@pytest.mark.parametrize("class_name", sorted(_MODEL_CLASSES))
+def test_slots_and_required_flags_match(linkml_schema, class_name):
+    model = _MODEL_CLASSES[class_name]
+    attributes = linkml_schema["classes"][class_name]["attributes"]
+
+    assert set(attributes) == set(model.model_fields), class_name
+
+    for field_name, field in model.model_fields.items():
+        rendered = attributes[field_name] or {}
+        expected = field.is_required() or (
+            (class_name, field_name) in _REQUIRED_DESPITE_DEFAULT
+        )
+        assert (
+            bool(rendered.get("required")) == expected
+        ), f"{class_name}.{field_name} required flag drifted"
+
+
+@pytest.mark.parametrize("class_name", sorted(_MODEL_CLASSES))
+def test_cv_bindings_match(linkml_schema, class_name):
+    """Every `_cv` binding on a pydantic field is the slot's slot_uri."""
+    model = _MODEL_CLASSES[class_name]
+    attributes = linkml_schema["classes"][class_name]["attributes"]
+
+    for field_name, field in model.model_fields.items():
+        extra = field.json_schema_extra
+        bound = (
+            extra.get("cv", {}).get("accession") if isinstance(extra, dict) else None
+        )
+        rendered = (attributes[field_name] or {}).get("slot_uri")
+        assert rendered == bound, (
+            f"{class_name}.{field_name}: LinkML slot_uri {rendered!r} vs "
+            f"pydantic cv binding {bound!r}"
+        )
+
+
+def test_polarity_enum_meanings_match(linkml_schema):
+    values = linkml_schema["enums"]["PolarityEnum"]["permissible_values"]
+    assert {
+        name: entry.get("meaning") for name, entry in values.items()
+    } == POLARITY_ACCESSIONS
+
+
+def test_tree_root_is_the_document(linkml_schema):
+    assert linkml_schema["classes"]["MSIMetadata"].get("tree_root") is True

--- a/tests/unit/metadata/schema/test_metaspace.py
+++ b/tests/unit/metadata/schema/test_metaspace.py
@@ -1,0 +1,100 @@
+"""METASPACE export: a straight mapping that never fabricates data."""
+
+from thyra.metadata.schema import MSIMetadata, to_metaspace
+
+
+def _full_meta() -> MSIMetadata:
+    return MSIMetadata.model_validate(
+        {
+            "schema_version": "0.1.0",
+            "sample": {
+                "organism": "Mus musculus",
+                "organism_part": "liver",
+                "condition": "wildtype",
+            },
+            "preparation": {
+                "sample_stabilisation": "fresh frozen",
+                "matrix": "2,5-dihydroxybenzoic acid (DHB)",
+                "matrix_application": "ImagePrep",
+                "solvent": "methanol",
+            },
+            "ms_analysis": {
+                "polarity": "positive",
+                "ionisation_source": "MALDI",
+                "analyzer": "Orbitrap",
+                "detector_resolving_power": {"value": 130000, "at_mz": 400},
+                "pixel_size_um": {"x": 20, "y": 40},
+            },
+            "provenance": {"thyra_version": "1.0.0"},
+        }
+    )
+
+
+class TestToMetaspace:
+    def test_complete_document_maps_without_warnings(self):
+        document, warnings = to_metaspace(_full_meta())
+        assert warnings == []
+        assert document == {
+            "Data_Type": "Imaging MS",
+            "Sample_Information": {
+                "Organism": "Mus musculus",
+                "Organism_Part": "liver",
+                "Condition": "wildtype",
+                "Sample_Growth_Conditions": "",
+            },
+            "Sample_Preparation": {
+                "Sample_Stabilisation": "fresh frozen",
+                "Tissue_Modification": "",
+                "MALDI_Matrix": "2,5-dihydroxybenzoic acid (DHB)",
+                "MALDI_Matrix_Application": "ImagePrep",
+                "Solvent": "methanol",
+            },
+            "MS_Analysis": {
+                "Polarity": "Positive",
+                "Ionisation_Source": "MALDI",
+                "Analyzer": "Orbitrap",
+                "Pixel_Size": {"Xaxis": 20, "Yaxis": 40},
+                "Detector_Resolving_Power": {"mz": 400, "Resolving_Power": 130000},
+            },
+        }
+
+    def test_missing_required_fields_are_empty_and_warned(self):
+        meta = _full_meta().model_copy(deep=True)
+        meta.sample.organism = None
+        meta.ms_analysis.polarity = None
+        document, warnings = to_metaspace(meta)
+        assert document["Sample_Information"]["Organism"] == ""
+        assert document["MS_Analysis"]["Polarity"] == ""
+        joined = " ".join(warnings)
+        assert "Sample_Information.Organism" in joined
+        assert "MS_Analysis.Polarity" in joined
+
+    def test_matrix_free_source_truthfully_reports_no_matrix(self):
+        meta = _full_meta().model_copy(deep=True)
+        meta.preparation.matrix = None
+        meta.preparation.matrix_application = None
+        meta.ms_analysis.ionisation_source = "DESI"
+        document, warnings = to_metaspace(meta)
+        assert document["Sample_Preparation"]["MALDI_Matrix"] == "none"
+        assert document["Sample_Preparation"]["MALDI_Matrix_Application"] == "none"
+        assert not any("MALDI_Matrix" in w for w in warnings)
+
+    def test_missing_matrix_on_maldi_is_warned_not_invented(self):
+        meta = _full_meta().model_copy(deep=True)
+        meta.preparation.matrix = None
+        document, warnings = to_metaspace(meta)
+        assert document["Sample_Preparation"]["MALDI_Matrix"] == ""
+        assert any("MALDI_Matrix" in w for w in warnings)
+
+    def test_missing_resolving_power_is_omitted_and_warned(self):
+        meta = _full_meta().model_copy(deep=True)
+        meta.ms_analysis.detector_resolving_power = None
+        document, warnings = to_metaspace(meta)
+        assert "Detector_Resolving_Power" not in document["MS_Analysis"]
+        assert any("Detector_Resolving_Power" in w for w in warnings)
+
+    def test_fractional_pixel_size_stays_a_float(self):
+        meta = _full_meta().model_copy(deep=True)
+        meta.ms_analysis.pixel_size_um.x = 12.5
+        document, _ = to_metaspace(meta)
+        assert document["MS_Analysis"]["Pixel_Size"]["Xaxis"] == 12.5

--- a/tests/unit/metadata/schema/test_models.py
+++ b/tests/unit/metadata/schema/test_models.py
@@ -1,0 +1,94 @@
+"""Structural validation: the pydantic models enforce the schema's shape."""
+
+import pytest
+from pydantic import ValidationError
+
+from thyra.metadata.schema import (
+    MSI_METADATA_SCHEMA_VERSION,
+    MSAnalysis,
+    MSIMetadata,
+    OntologyTerm,
+    PixelSizeUm,
+    Provenance,
+)
+
+
+def _minimal() -> MSIMetadata:
+    return MSIMetadata(
+        ms_analysis=MSAnalysis(pixel_size_um=PixelSizeUm(x=20.0, y=20.0)),
+        provenance=Provenance(thyra_version="1.0.0"),
+    )
+
+
+class TestMSIMetadata:
+    def test_minimal_document_is_valid(self):
+        meta = _minimal()
+        assert meta.schema_version == MSI_METADATA_SCHEMA_VERSION
+
+    def test_round_trips_through_dump_and_validate(self):
+        meta = _minimal()
+        assert MSIMetadata.model_validate(meta.model_dump()) == meta
+
+    def test_pixel_size_is_required(self):
+        with pytest.raises(ValidationError):
+            MSAnalysis()
+
+    def test_pixel_size_must_be_positive(self):
+        with pytest.raises(ValidationError):
+            PixelSizeUm(x=0.0, y=20.0)
+
+    def test_unknown_fields_are_rejected(self):
+        doc = _minimal().model_dump()
+        doc["ms_analysis"]["lazer_power"] = 3.0
+        with pytest.raises(ValidationError):
+            MSIMetadata.model_validate(doc)
+
+    def test_accession_must_be_a_curie(self):
+        with pytest.raises(ValidationError):
+            OntologyTerm(accession="not a curie", name="x")
+
+    def test_polarity_vocabulary_is_closed(self):
+        doc = _minimal().model_dump()
+        doc["ms_analysis"]["polarity"] = "both"
+        with pytest.raises(ValidationError):
+            MSIMetadata.model_validate(doc)
+
+    def test_contradicting_polarity_term_is_rejected(self):
+        with pytest.raises(ValidationError, match="contradicts"):
+            MSAnalysis(
+                pixel_size_um=PixelSizeUm(x=20.0, y=20.0),
+                polarity="positive",
+                polarity_term=OntologyTerm(
+                    accession="MS:1000129", name="negative scan"
+                ),
+            )
+
+    def test_agreeing_polarity_term_is_accepted(self):
+        analysis = MSAnalysis(
+            pixel_size_um=PixelSizeUm(x=20.0, y=20.0),
+            polarity="negative",
+            polarity_term=OntologyTerm(accession="MS:1000129", name="negative scan"),
+        )
+        assert analysis.polarity == "negative"
+
+
+class TestToUnsDict:
+    def test_none_fields_are_dropped(self):
+        data = _minimal().to_uns_dict()
+        assert "polarity" not in data["ms_analysis"]
+        assert "source_format" not in data["provenance"]
+
+    def test_empty_user_sections_are_omitted_not_written_empty(self):
+        data = _minimal().to_uns_dict()
+        assert "sample" not in data
+        assert "preparation" not in data
+
+    def test_populated_user_sections_are_kept(self):
+        meta = _minimal().model_copy(deep=True)
+        meta.sample.organism = "Mus musculus"
+        data = meta.to_uns_dict()
+        assert data["sample"] == {"organism": "Mus musculus"}
+
+    def test_uns_dict_validates_back(self):
+        data = _minimal().to_uns_dict()
+        assert MSIMetadata.model_validate(data) is not None

--- a/tests/unit/metadata/schema/test_models.py
+++ b/tests/unit/metadata/schema/test_models.py
@@ -72,6 +72,31 @@ class TestMSIMetadata:
         assert analysis.polarity == "negative"
 
 
+class TestProcessing:
+    def test_processing_steps_round_trip(self):
+        from thyra.metadata.schema import ProcessingStep, SoftwareRef
+
+        meta = _minimal().model_copy(deep=True)
+        meta.processing = [
+            ProcessingStep(
+                name="mass axis resampling",
+                software=SoftwareRef(name="thyra", version="1.0.0"),
+                parameters={"target_bins": 50000, "method": "nearest_neighbor"},
+            )
+        ]
+        restored = MSIMetadata.model_validate(meta.model_dump())
+        assert restored.processing[0].parameters["target_bins"] == 50000
+
+    def test_empty_processing_is_omitted_from_uns(self):
+        assert "processing" not in _minimal().to_uns_dict()
+
+    def test_step_requires_software(self):
+        from thyra.metadata.schema import ProcessingStep
+
+        with pytest.raises(ValidationError):
+            ProcessingStep(name="normalisation")
+
+
 class TestToUnsDict:
     def test_none_fields_are_dropped(self):
         data = _minimal().to_uns_dict()

--- a/tests/unit/metadata/schema/test_models.py
+++ b/tests/unit/metadata/schema/test_models.py
@@ -72,6 +72,55 @@ class TestMSIMetadata:
         assert analysis.polarity == "negative"
 
 
+class TestCvBindings:
+    def test_bound_fields_are_exactly_the_expected_set(self):
+        from thyra.metadata.schema.models import field_cv_bindings
+
+        accessions = {cv["accession"] for cv in field_cv_bindings().values()}
+        assert accessions == {
+            "IMS:1000046",  # pixel size (x)
+            "IMS:1000047",  # pixel size y
+            "MS:1000465",  # scan polarity
+            "MS:1000008",  # ionization type
+            "MS:1000443",  # mass analyzer type
+            "MS:1000031",  # instrument model
+            "MS:1000800",  # mass resolving power
+        }
+
+    def test_every_binding_resolves_in_the_local_tables(self):
+        from thyra.metadata.ontology.cache import ONTOLOGY
+        from thyra.metadata.schema.models import field_cv_bindings
+
+        for path, cv in field_cv_bindings().items():
+            entry = ONTOLOGY.terms.get(cv["accession"])
+            assert entry is not None, f"{path}: unknown {cv['accession']}"
+            assert (
+                entry[0] == cv["name"]
+            ), f"{path}: bound name {cv['name']!r} vs CV label {entry[0]!r}"
+
+    def test_bindings_land_in_the_committed_json_schema(self):
+        # The claim must be checkable from the artifact alone, without
+        # importing Thyra.
+        import json
+        from pathlib import Path
+
+        from thyra.metadata.schema import models
+
+        artifact = (
+            Path(models.__file__).parent / models.SCHEMA_JSON_FILENAME
+        ).read_text(encoding="utf-8")
+        rendered = json.dumps(json.loads(artifact))
+        assert '"IMS:1000046"' in rendered
+        assert '"MS:1000443"' in rendered
+
+    def test_candidate_concepts_are_declared(self):
+        from thyra.metadata.schema import models
+
+        concepts = [c for c, _ in models.CANDIDATE_CV_CONCEPTS]
+        assert any("resampling" in c for c in concepts)
+        assert any("stage offset" in c for c in concepts)
+
+
 class TestProcessing:
     def test_processing_steps_round_trip(self):
         from thyra.metadata.schema import ProcessingStep, SoftwareRef

--- a/tests/unit/metadata/schema/test_schema_json_sync.py
+++ b/tests/unit/metadata/schema/test_schema_json_sync.py
@@ -1,0 +1,39 @@
+"""The committed JSON Schema artifact must match the pydantic models.
+
+The artifact exists so non-Python consumers can validate documents
+without importing Thyra; it is only trustworthy if it cannot drift from
+the models.  When this test fails, regenerate with::
+
+    python -m thyra.metadata.schema.generate
+
+and commit the result together with the model change (plus the
+``MSI_METADATA_SCHEMA_VERSION`` bump the change warrants: additive
+optional fields bump minor, anything else bumps major).
+"""
+
+import json
+from pathlib import Path
+
+from thyra.metadata.schema.models import SCHEMA_JSON_FILENAME, MSIMetadata
+
+_SCHEMA_DIR = Path(__file__).resolve().parents[4] / "thyra" / "metadata" / "schema"
+
+
+def test_committed_json_schema_matches_the_models():
+    committed = json.loads(
+        (_SCHEMA_DIR / SCHEMA_JSON_FILENAME).read_text(encoding="utf-8")
+    )
+    assert committed == MSIMetadata.model_json_schema()
+
+
+def test_schema_artifact_ships_in_the_package():
+    # importlib.resources is how consumers are told to read it, so the
+    # file must be importable package data, not just a repo file.
+    from importlib import resources
+
+    data = (
+        resources.files("thyra.metadata.schema")
+        .joinpath(SCHEMA_JSON_FILENAME)
+        .read_text(encoding="utf-8")
+    )
+    assert json.loads(data)["title"] == "MSIMetadata"

--- a/tests/unit/metadata/schema/test_store_roundtrip.py
+++ b/tests/unit/metadata/schema/test_store_roundtrip.py
@@ -1,0 +1,82 @@
+"""The block a converter writes must read back and validate.
+
+The uns parity suite (tests/unit/converters/test_uns_provenance_parity.py)
+asserts the block is identical across all four write paths; this file
+covers the consumer side: reading it out of a real store, validating
+it, and exporting METASPACE metadata from it.
+"""
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from tests.fixtures.mock_msi_generator import MockMSIConfig, MockMSIReader
+from thyra.converters.spatialdata.base_spatialdata_converter import (
+    SPATIALDATA_AVAILABLE,
+)
+from thyra.metadata.schema import (
+    MSI_METADATA_SCHEMA_VERSION,
+    read_msi_metadata_blocks,
+    validate_document,
+)
+
+pytestmark = pytest.mark.skipif(
+    not SPATIALDATA_AVAILABLE,
+    reason="SpatialData dependencies not available",
+)
+
+
+@pytest.fixture(scope="module")
+def store(tmp_path_factory):
+    from thyra.converters.spatialdata.spatialdata_2d_converter import (
+        SpatialData2DConverter,
+    )
+
+    output = tmp_path_factory.mktemp("schema_store") / "out.zarr"
+    converter = SpatialData2DConverter(
+        reader=MockMSIReader(
+            MockMSIConfig(n_x=4, n_y=4, n_mz_bins=200, peaks_per_spectrum=(10, 20))
+        ),
+        output_path=output,
+        dataset_id="mock",
+        pixel_size_um=10.0,
+    )
+    assert converter.convert() is True
+    return output
+
+
+class TestStoreRoundTrip:
+    def test_block_reads_back_and_validates(self, store):
+        blocks = read_msi_metadata_blocks(store)
+        assert blocks, "converted store carries no msi_metadata block"
+        for block in blocks.values():
+            assert block["schema_version"] == MSI_METADATA_SCHEMA_VERSION
+            assert block["ms_analysis"]["pixel_size_um"] == {"x": 10.0, "y": 10.0}
+            meta, issues = validate_document(block)
+            assert meta is not None
+            assert not [i for i in issues if i.severity == "error"]
+
+    def test_validate_cli_passes_on_a_real_store(self, store):
+        from thyra.metadata.schema.cli import validate_command
+
+        result = CliRunner().invoke(validate_command, [str(store)])
+        assert result.exit_code == 0, result.output
+
+    def test_export_metaspace_cli_works_on_a_real_store(self, store, tmp_path):
+        from thyra.metadata.schema.cli import export_metaspace_command
+
+        output = tmp_path / "submission.json"
+        result = CliRunner().invoke(
+            export_metaspace_command, [str(store), "-o", str(output)]
+        )
+        assert result.exit_code == 0, result.output
+        document = json.loads(output.read_text(encoding="utf-8"))
+        assert document["MS_Analysis"]["Pixel_Size"] == {"Xaxis": 10, "Yaxis": 10}
+
+    def test_a_zarr_group_that_is_not_spatialdata_is_reported_cleanly(self, tmp_path):
+        import zarr
+
+        zarr.open_group(str(tmp_path / "plain.zarr"), mode="a")
+        with pytest.raises(ValueError, match="tables"):
+            read_msi_metadata_blocks(tmp_path / "plain.zarr")

--- a/tests/unit/metadata/schema/test_store_roundtrip.py
+++ b/tests/unit/metadata/schema/test_store_roundtrip.py
@@ -57,6 +57,31 @@ class TestStoreRoundTrip:
             assert meta is not None
             assert not [i for i in issues if i.severity == "error"]
 
+    def test_processing_history_records_the_conversion(self, store):
+        from thyra import __version__
+
+        for block in read_msi_metadata_blocks(store).values():
+            steps = block["processing"]
+            assert steps[0]["name"] == "conversion"
+            assert steps[0]["software"] == {
+                "name": "thyra",
+                "version": __version__,
+            }
+            # No resampling was configured, so no resampling step.
+            assert [s["name"] for s in steps] == ["conversion"]
+
+    def test_root_attrs_carry_the_explicit_affine(self, store):
+        import zarr
+
+        cs_global = dict(zarr.open_group(str(store), mode="r").attrs)[
+            "coordinate_systems"
+        ]["global"]
+        assert cs_global["raster_to_global_affine"] == [
+            [10.0, 0.0, 0.0],
+            [0.0, 10.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+
     def test_validate_cli_passes_on_a_real_store(self, store):
         from thyra.metadata.schema.cli import validate_command
 
@@ -73,6 +98,28 @@ class TestStoreRoundTrip:
         assert result.exit_code == 0, result.output
         document = json.loads(output.read_text(encoding="utf-8"))
         assert document["MS_Analysis"]["Pixel_Size"] == {"Xaxis": 10, "Yaxis": 10}
+
+    def test_resampling_step_serialises_the_config(self, tmp_path):
+        from thyra.converters.spatialdata.spatialdata_2d_converter import (
+            SpatialData2DConverter,
+        )
+
+        converter = SpatialData2DConverter(
+            reader=MockMSIReader(
+                MockMSIConfig(n_x=4, n_y=4, n_mz_bins=200, peaks_per_spectrum=(10, 20))
+            ),
+            output_path=tmp_path / "out.zarr",
+            dataset_id="mock",
+            pixel_size_um=10.0,
+            resampling_config={"method": "nearest_neighbor", "target_bins": 100},
+        )
+        steps = converter._processing_provenance()
+        assert [s.name for s in steps] == ["conversion", "mass axis resampling"]
+        parameters = steps[1].parameters
+        assert parameters["method"] == "nearest_neighbor"
+        assert parameters["target_bins"] == 100
+        # Unset config fields are dropped, not serialised as nulls.
+        assert "min_mz" not in parameters
 
     def test_a_zarr_group_that_is_not_spatialdata_is_reported_cleanly(self, tmp_path):
         import zarr

--- a/tests/unit/metadata/schema/test_validate.py
+++ b/tests/unit/metadata/schema/test_validate.py
@@ -1,0 +1,116 @@
+"""Document validation: version rules, structure, ontology checks."""
+
+from thyra.metadata.schema import (
+    MSI_METADATA_SCHEMA_VERSION,
+    build_msi_metadata,
+    validate_document,
+)
+
+
+def _valid_doc() -> dict:
+    return build_msi_metadata(None, pixel_size_um=(20.0, 20.0)).to_uns_dict()
+
+
+def _errors(issues):
+    return [i for i in issues if i.severity == "error"]
+
+
+def _warnings(issues):
+    return [i for i in issues if i.severity == "warning"]
+
+
+class TestSchemaVersion:
+    def test_valid_document_has_no_issues(self):
+        meta, issues = validate_document(_valid_doc())
+        assert meta is not None
+        assert issues == []
+
+    def test_missing_schema_version_is_an_error(self):
+        doc = _valid_doc()
+        del doc["schema_version"]
+        meta, issues = validate_document(doc)
+        assert meta is None
+        assert any(i.location == "schema_version" for i in _errors(issues))
+
+    def test_different_major_version_is_an_error(self):
+        doc = _valid_doc()
+        doc["schema_version"] = "99.0.0"
+        meta, issues = validate_document(doc)
+        assert meta is None
+        assert _errors(issues)
+
+    def test_newer_minor_version_warns_but_validates(self):
+        doc = _valid_doc()
+        major, minor, patch = (int(p) for p in MSI_METADATA_SCHEMA_VERSION.split("."))
+        doc["schema_version"] = f"{major}.{minor + 1}.{patch}"
+        meta, issues = validate_document(doc)
+        assert meta is not None
+        assert _warnings(issues)
+        assert not _errors(issues)
+
+    def test_garbage_version_is_an_error(self):
+        doc = _valid_doc()
+        doc["schema_version"] = "not-a-version"
+        meta, issues = validate_document(doc)
+        assert meta is None
+
+
+class TestStructure:
+    def test_non_mapping_document_is_an_error(self):
+        meta, issues = validate_document(["not", "a", "mapping"])
+        assert meta is None
+        assert _errors(issues)
+
+    def test_structural_errors_carry_their_location(self):
+        doc = _valid_doc()
+        doc["ms_analysis"]["pixel_size_um"]["x"] = -1.0
+        meta, issues = validate_document(doc)
+        assert meta is None
+        assert any(i.location == "ms_analysis.pixel_size_um.x" for i in _errors(issues))
+
+
+class TestOntologyChecks:
+    def test_unknown_ms_accession_is_an_error(self):
+        doc = _valid_doc()
+        doc["ms_analysis"]["analyzer_term"] = {
+            "accession": "MS:9999999",
+            "name": "made up",
+        }
+        _, issues = validate_document(doc)
+        assert any(i.location == "ms_analysis.analyzer_term" for i in _errors(issues))
+
+    def test_mismatched_term_name_is_a_warning(self):
+        doc = _valid_doc()
+        doc["ms_analysis"]["analyzer_term"] = {
+            "accession": "MS:1000084",
+            "name": "definitely not time-of-flight",
+        }
+        meta, issues = validate_document(doc)
+        assert meta is not None
+        assert any(i.location == "ms_analysis.analyzer_term" for i in _warnings(issues))
+        assert not _errors(issues)
+
+    def test_wrong_prefix_for_designated_ontology_is_a_warning(self):
+        doc = _valid_doc()
+        doc["sample"] = {
+            "organism": "Mus musculus",
+            "organism_term": {"accession": "CHEBI:12345", "name": "mouse"},
+        }
+        meta, issues = validate_document(doc)
+        assert meta is not None
+        assert any(i.location == "sample.organism_term" for i in _warnings(issues))
+
+    def test_foreign_prefixes_are_not_checked_against_local_tables(self):
+        # NCBITaxon is not shipped locally; a plausible term must pass
+        # without an existence check.
+        doc = _valid_doc()
+        doc["sample"] = {
+            "organism": "Mus musculus",
+            "organism_term": {
+                "accession": "NCBITaxon:10090",
+                "name": "Mus musculus",
+            },
+        }
+        meta, issues = validate_document(doc)
+        assert meta is not None
+        assert issues == []

--- a/tests/unit/metadata/schema/test_var_conventions.py
+++ b/tests/unit/metadata/schema/test_var_conventions.py
@@ -1,0 +1,76 @@
+"""The fixed var column contract, checked straight off the zarr layout.
+
+These tests fabricate minimal zarr stores rather than converting, so
+they run without the SpatialData stack and cover the failure shapes a
+conversion can never produce.
+"""
+
+import numpy as np
+import pytest
+import zarr
+
+from thyra.metadata.schema import check_store_var_conventions
+
+
+def _store_with_var(tmp_path, mz=None, extra=None, skip_var=False):
+    root = zarr.open_group(str(tmp_path / "store.zarr"), mode="a")
+    table = root.create_group("tables").create_group("t")
+    if not skip_var:
+        var = table.create_group("var")
+        if mz is not None:
+            var.create_array("mz", data=np.asarray(mz))
+        if extra is not None:
+            var.create_array(extra, data=np.zeros(3))
+    return tmp_path / "store.zarr"
+
+
+def _messages(issues):
+    return " ".join(i.message for i in issues)
+
+
+class TestCheckStoreVarConventions:
+    def test_conforming_var_has_no_issues(self, tmp_path):
+        store = _store_with_var(tmp_path, mz=[100.0, 200.5, 300.0])
+        assert check_store_var_conventions(store) == {"t": []}
+
+    def test_missing_var_group_is_an_error(self, tmp_path):
+        store = _store_with_var(tmp_path, skip_var=True)
+        issues = check_store_var_conventions(store)["t"]
+        assert issues and issues[0].severity == "error"
+
+    def test_missing_mz_column_is_an_error(self, tmp_path):
+        store = _store_with_var(tmp_path, mz=None, extra="flight_time")
+        issues = check_store_var_conventions(store)["t"]
+        assert "'mz' is missing" in _messages(issues)
+
+    def test_non_monotonic_mz_is_an_error(self, tmp_path):
+        store = _store_with_var(tmp_path, mz=[100.0, 300.0, 200.0])
+        issues = check_store_var_conventions(store)["t"]
+        assert "strictly increasing" in _messages(issues)
+
+    def test_non_finite_mz_is_an_error(self, tmp_path):
+        store = _store_with_var(tmp_path, mz=[100.0, np.nan, 300.0])
+        issues = check_store_var_conventions(store)["t"]
+        assert "non-finite" in _messages(issues)
+
+    def test_not_a_store_raises(self, tmp_path):
+        zarr.open_group(str(tmp_path / "plain.zarr"), mode="a")
+        with pytest.raises(ValueError, match="tables"):
+            check_store_var_conventions(tmp_path / "plain.zarr")
+
+
+class TestReservedColumnNames:
+    def test_spec_reserves_the_annotation_columns(self):
+        from thyra.metadata.schema import (
+            MSI_VAR_REQUIRED_COLUMNS,
+            MSI_VAR_RESERVED_COLUMNS,
+        )
+
+        assert MSI_VAR_REQUIRED_COLUMNS == ("mz",)
+        assert set(MSI_VAR_RESERVED_COLUMNS) == {
+            "mz",
+            "formula",
+            "adduct",
+            "annotation_source",
+            "fdr",
+        }

--- a/tests/unit/metadata/schema/test_vocab.py
+++ b/tests/unit/metadata/schema/test_vocab.py
@@ -1,0 +1,105 @@
+"""Vocabulary normalisation: vendor spellings land on PSI-MS terms."""
+
+import pytest
+
+from thyra.metadata.ontology.cache import ONTOLOGY
+from thyra.metadata.schema.vocab import (
+    ANALYZER_ACCESSIONS,
+    IONISATION_SOURCE_ACCESSIONS,
+    POLARITY_ACCESSIONS,
+    normalize_analyzer,
+    normalize_ionisation_source,
+    normalize_polarity,
+    term_from_accession,
+)
+
+
+class TestTermFromAccession:
+    def test_name_comes_from_the_local_table(self):
+        term = term_from_accession("MS:1000075")
+        assert term.name == ONTOLOGY.terms["MS:1000075"][0]
+
+    def test_unknown_accession_raises(self):
+        with pytest.raises(KeyError):
+            term_from_accession("MS:9999999")
+
+    @pytest.mark.parametrize(
+        "accession",
+        sorted(
+            set(POLARITY_ACCESSIONS.values())
+            | set(IONISATION_SOURCE_ACCESSIONS.values())
+            | set(ANALYZER_ACCESSIONS.values())
+        ),
+    )
+    def test_every_vocabulary_accession_resolves_locally(self, accession):
+        # The vocabularies may only reference accessions the shipped
+        # ontology tables actually contain, or written blocks would
+        # fail their own validation.
+        assert term_from_accession(accession).name
+
+
+class TestNormalizePolarity:
+    @pytest.mark.parametrize(
+        "raw", ["positive", "Positive", "POS", "+", "positive scan"]
+    )
+    def test_positive_spellings(self, raw):
+        result = normalize_polarity(raw)
+        assert result is not None
+        canonical, term = result
+        assert canonical == "positive"
+        assert term.accession == "MS:1000130"
+
+    @pytest.mark.parametrize("raw", ["negative", "NEG", "-", "negative ion mode"])
+    def test_negative_spellings(self, raw):
+        result = normalize_polarity(raw)
+        assert result is not None
+        assert result[0] == "negative"
+        assert result[1].accession == "MS:1000129"
+
+    @pytest.mark.parametrize("raw", [None, "", "  ", "alternating", 42, "both"])
+    def test_unrecognised_input_normalises_to_none(self, raw):
+        assert normalize_polarity(raw) is None
+
+
+class TestNormalizeIonisationSource:
+    @pytest.mark.parametrize(
+        ("raw", "label", "accession"),
+        [
+            ("MALDI", "MALDI", "MS:1000075"),
+            ("matrix-assisted laser desorption ionization", "MALDI", "MS:1000075"),
+            ("DESI", "DESI", "MS:1002011"),
+            ("esi", "ESI", "MS:1000073"),
+            ("TOF-SIMS", "SIMS", "MS:1000402"),
+            ("secondary ion mass spectrometry", "SIMS", "MS:1000402"),
+        ],
+    )
+    def test_known_spellings(self, raw, label, accession):
+        result = normalize_ionisation_source(raw)
+        assert result is not None
+        assert result[0] == label
+        assert result[1].accession == accession
+
+    def test_unrecognised_input_normalises_to_none(self):
+        assert normalize_ionisation_source("laser magic") is None
+
+
+class TestNormalizeAnalyzer:
+    @pytest.mark.parametrize(
+        ("raw", "label", "accession"),
+        [
+            ("TOF", "TOF", "MS:1000084"),
+            ("time-of-flight", "TOF", "MS:1000084"),
+            ("qTOF", "TOF", "MS:1000084"),
+            ("Orbitrap", "Orbitrap", "MS:1000484"),
+            ("FTICR", "FTICR", "MS:1000079"),
+            ("ion trap", "Ion trap", "MS:1000264"),
+        ],
+    )
+    def test_known_spellings(self, raw, label, accession):
+        result = normalize_analyzer(raw)
+        assert result is not None
+        assert result[0] == label
+        assert result[1].accession == accession
+
+    def test_unrecognised_input_normalises_to_none(self):
+        assert normalize_analyzer("quadrupole array of mystery") is None

--- a/tests/unit/tools/test_check_ontology.py
+++ b/tests/unit/tools/test_check_ontology.py
@@ -18,7 +18,7 @@ class TestCheckOntology:
         # Setup mocks
         mock_validator_instance = mock_validator_class.return_value
         # The 'summary' is overwritten by main() when not in verbose mode.
-        mock_validator_instance.validate_file.return_value = {"unknown_terms": []}
+        mock_validator_instance.validate_file.return_value = {"unknown_list": []}
         mock_ontology.report_unknown_terms.return_value = "Global unknown terms: None"
 
         # Create a dummy imzML file
@@ -50,6 +50,42 @@ class TestCheckOntology:
                 "Global unknown terms: None\n"
             )
             assert expected_output == captured.out
+        finally:
+            sys.argv = original_argv
+
+    @patch("thyra.tools.check_ontology.ONTOLOGY", autospec=True)
+    @patch("thyra.metadata.validator.ImzMLOntologyValidator", autospec=True)
+    @patch("sys.argv")
+    def test_main_file_check_with_unknown_terms(
+        self, mock_argv, mock_validator_class, mock_ontology, capsys, tmp_path
+    ):
+        """A file with unknown terms lists them rather than crashing.
+
+        Regression test: main() used to read `unknown_terms` -- which
+        validate_file reports as a COUNT -- where it needed the
+        `unknown_list` entries, so the first real file with any unknown
+        term died on len() of an int.  The earlier mocks fed a list
+        under the count's key, so the suite agreed with the bug.
+        """
+        mock_validator_instance = mock_validator_class.return_value
+        mock_validator_instance.validate_file.return_value = {
+            "unknown_terms": 1,
+            "unknown_list": [
+                {"accession": "MS:9999999", "name": "mystery", "value": ""}
+            ],
+        }
+        mock_ontology.report_unknown_terms.return_value = "Global unknown terms: Some"
+
+        dummy_imzml = tmp_path / "test.imzML"
+        dummy_imzml.write_text("<mzML/>")
+
+        original_argv = sys.argv.copy()
+        try:
+            sys.argv = ["check_ontology", str(dummy_imzml)]
+            main()
+            captured = capsys.readouterr()
+            assert "Found 1 unknown terms:" in captured.out
+            assert "  - MS:9999999: mystery" in captured.out
         finally:
             sys.argv = original_argv
 
@@ -116,7 +152,10 @@ class TestCheckOntology:
         mock_validator_instance = mock_validator_class.return_value
         validation_result = {
             "summary": "Test summary for JSON",
-            "unknown_terms": ["json_term"],
+            "unknown_terms": 1,
+            "unknown_list": [
+                {"accession": "MS:9999999", "name": "json_term", "value": ""}
+            ],
         }
         mock_validator_instance.validate_file.return_value = validation_result
         mock_ontology.report_unknown_terms.return_value = "Global unknown terms: JSON"
@@ -166,7 +205,7 @@ class TestCheckOntology:
         mock_validator_instance = mock_validator_class.return_value
         mock_validator_instance.validate_file.return_value = {
             "summary": "Verbose summary",
-            "unknown_terms": [],
+            "unknown_list": [],
         }
         mock_ontology.report_unknown_terms.return_value = (
             "Global unknown terms: Verbose"

--- a/thyra/__main__.py
+++ b/thyra/__main__.py
@@ -659,6 +659,10 @@ def main(
 
     INPUT: Path to input MSI file or directory
     OUTPUT: Path for output file
+
+    Subcommands (each has its own --help): 'thyra validate PATH'
+    validates MSI metadata against the schema; 'thyra export-metaspace
+    PATH' writes the METASPACE submission JSON.
     """
     # Validate all parameters
     _validate_basic_params(pixel_size, dataset_id)
@@ -746,5 +750,27 @@ def main(
         raise SystemExit(1)
 
 
-if __name__ == "__main__":
+def cli() -> None:
+    """Console-script entry point: dispatch subcommands, else convert.
+
+    ``thyra INPUT OUTPUT`` converts exactly as it always has; the
+    metadata subcommands (``thyra validate``, ``thyra
+    export-metaspace``) are picked off by their first argument before
+    click sees it.  Dispatch is hand-rolled rather than a
+    ``click.Group`` because a group cannot carry the two positional
+    arguments the conversion interface is documented with.
+    """
+    import sys
+
+    from thyra.metadata.schema.cli import METADATA_SUBCOMMANDS
+
+    args = sys.argv[1:]
+    if args and args[0] in METADATA_SUBCOMMANDS:
+        command = METADATA_SUBCOMMANDS[args[0]]
+        command.main(args[1:], prog_name=f"thyra {args[0]}")
+        return
     main()
+
+
+if __name__ == "__main__":
+    cli()

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -597,10 +597,41 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 pixel_size_um=self._resolved_pixel_size_xy(),
                 pixel_size_source=self.pixel_size_source.value,
                 source_format=info.get("source_format"),
+                processing=self._processing_provenance(),
             )
             uns[MSI_METADATA_UNS_KEY] = meta.to_uns_dict()
         except Exception as e:
             logger.warning("Could not build the msi_metadata block: %s", e)
+
+    def _processing_provenance(self) -> List[Any]:
+        """The processing steps this conversion performed, oldest first.
+
+        Modeled on mzQC provenance.  The list must be identical across
+        every write path for the same input (the uns parity suite
+        compares the block verbatim), so nothing route-specific -- the
+        sparse layout, the streaming/in-memory split -- belongs here.
+        """
+        from thyra import __version__
+        from thyra.metadata.schema import ProcessingStep, SoftwareRef
+
+        thyra_ref = SoftwareRef(name="thyra", version=__version__)
+        steps = [ProcessingStep(name="conversion", software=thyra_ref)]
+
+        config = self._resampling_config
+        if config is not None:
+            parameters: Dict[str, Any] = {}
+            for field_name, value in vars(config).items():
+                if value is None:
+                    continue
+                parameters[field_name] = getattr(value, "value", value)
+            steps.append(
+                ProcessingStep(
+                    name="mass axis resampling",
+                    software=thyra_ref,
+                    parameters=parameters,
+                )
+            )
+        return steps
 
     def _collect_essential_metadata(self, uns: Dict[str, Any], comp_meta: Any) -> None:
         """Add ``essential_metadata`` (tuples become lists for Zarr)."""
@@ -1518,11 +1549,20 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             logger.warning("Reader failed to supply mass axis annotations: %s", detail)
             return {}
 
+        from thyra.metadata.schema import MSI_VAR_RESERVED_COLUMNS
+
         validated: Dict[str, Any] = {}
         for name, values in (annotations or {}).items():
             if name == "mz":
                 logger.warning("Ignoring mass axis annotation named 'mz'")
                 continue
+            if name in MSI_VAR_RESERVED_COLUMNS:
+                logger.info(
+                    "Mass axis annotation %r uses a var column name the "
+                    "metadata spec reserves for annotation results; it must "
+                    "carry that meaning (see docs/metadata-schema.md)",
+                    name,
+                )
             if len(values) != n_channels:
                 logger.info(
                     "Dropping mass axis annotation %r: %d values for a "
@@ -2406,11 +2446,55 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             "produced_by": f"thyra/{thyra_version}",
         }
 
+        # Additive keys; `convention_version` stays 1 for the same
+        # reason as z_spacing_um below.  `raster_to_global_affine` is
+        # the explicit 3x3 row-major affine from TIC raster indices to
+        # "global" (the same mapping the TIC element's transform
+        # expresses), so a consumer that reads only attrs still gets
+        # the full placement.  `coordinate_offsets_px` preserves the
+        # source's raw acquisition-index offsets, which 0-based
+        # normalisation otherwise erases; `stage_offset_um` is their
+        # physical equivalent, written only when "global" is in
+        # micrometers so it cannot be misread in the optical-pixel
+        # variant.
+        if self._tic_to_image_matrix is not None:
+            global_cs["raster_to_global_affine"] = [
+                [float(v) for v in row] for row in self._tic_to_image_matrix
+            ]
+        else:
+            in_plane = float(self.pixel_size_um)
+            global_cs["raster_to_global_affine"] = [
+                [in_plane, 0.0, 0.0],
+                [0.0, in_plane, 0.0],
+                [0.0, 0.0, 1.0],
+            ]
+        offsets = self._source_coordinate_offsets()
+        if offsets is not None:
+            global_cs["coordinate_offsets_px"] = [int(v) for v in offsets]
+            if unit == "micrometer":
+                global_cs["stage_offset_um"] = [
+                    float(offsets[0]) * float(self.pixel_size_um),
+                    float(offsets[1]) * float(self.pixel_size_um),
+                ]
+
         if self._is_volume:
             global_cs["z_spacing_um"] = float(self.z_spacing_um)
             global_cs["z_spacing_source"] = self.z_spacing_source.value
 
         return {"global": global_cs}
+
+    def _source_coordinate_offsets(self) -> Optional[Tuple[int, int, int]]:
+        """The reader's raw coordinate offsets, if it reported any."""
+        try:
+            essential = self.reader.get_essential_metadata()
+        except Exception as e:
+            logger.debug("Could not read coordinate offsets: %s", e)
+            return None
+        offsets = getattr(essential, "coordinate_offsets", None)
+        if offsets is None:
+            return None
+        x, y, z = offsets
+        return (int(x), int(y), int(z))
 
     def _add_comprehensive_sections(
         self, pixel_size_attrs: Dict[str, Any], comprehensive_metadata_obj

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -562,7 +562,45 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         except Exception as e:
             logger.warning("Could not build the full uns provenance block: %s", e)
 
+        self._collect_msi_metadata_block(uns, comp_meta)
+
         return uns
+
+    def _resolved_pixel_size_xy(self) -> Tuple[float, float]:
+        """The in-plane pixel pitch as ``(x_um, y_um)``.
+
+        The converter itself carries a single float (auto-detection
+        keeps the source's x pitch), but the detection info still has
+        the true per-axis values for anisotropic rasters -- the
+        metadata block records those, since it describes the
+        acquisition rather than the rendering.
+        """
+        info = self._pixel_size_detection_info or {}
+        if "detected_x_um" in info and "detected_y_um" in info:
+            return (float(info["detected_x_um"]), float(info["detected_y_um"]))
+        return (float(self.pixel_size_um), float(self.pixel_size_um))
+
+    def _collect_msi_metadata_block(self, uns: Dict[str, Any], comp_meta: Any) -> None:
+        """Add the versioned ``msi_metadata`` schema block.
+
+        Built in its own try so a schema failure cannot take the other
+        provenance sections down with it.  See docs/metadata-schema.md
+        for the storage contract and ``thyra validate`` for the
+        consumer side.
+        """
+        from thyra.metadata.schema import MSI_METADATA_UNS_KEY, build_msi_metadata
+
+        try:
+            info = self._pixel_size_detection_info or {}
+            meta = build_msi_metadata(
+                comp_meta,
+                pixel_size_um=self._resolved_pixel_size_xy(),
+                pixel_size_source=self.pixel_size_source.value,
+                source_format=info.get("source_format"),
+            )
+            uns[MSI_METADATA_UNS_KEY] = meta.to_uns_dict()
+        except Exception as e:
+            logger.warning("Could not build the msi_metadata block: %s", e)
 
     def _collect_essential_metadata(self, uns: Dict[str, Any], comp_meta: Any) -> None:
         """Add ``essential_metadata`` (tuples become lists for Zarr)."""

--- a/thyra/metadata/extractors/imzml_extractor.py
+++ b/thyra/metadata/extractors/imzml_extractor.py
@@ -611,25 +611,48 @@ class ImzMLMetadataExtractor(MetadataExtractor):
         return raw_metadata
 
     def _extract_spectrum_cvparams(self) -> Optional[List[Dict[str, Any]]]:
-        """Extract cvParams from first spectrum for centroid detection."""
+        """Extract the file-description cvParams, accessions included.
+
+        The tuples on ``ParamGroup.cv_params`` are
+        ``(name, accession, value, raw_name, raw_value, unit_name,
+        unit_accession)``.  The accession is the part that makes the
+        stored copy lossless: the name alone cannot be resolved back to
+        the CV concept, and the whole point of carrying these through is
+        that the converted store is annotated with the same PSI CV terms
+        as the raw file it came from.  Unit fields are included only
+        when the source set them, following the omit-vs-empty
+        convention.
+        """
         try:
             if not hasattr(self.parser, "metadata") or not self.parser.metadata:
                 return None
 
-            # Look for spectrum-level cvParams in the metadata
-            if hasattr(self.parser.metadata, "file_description"):
-                file_desc = self.parser.metadata.file_description
-                if hasattr(file_desc, "param_by_name"):
-                    params = file_desc.param_by_name
-                    cv_params = []
+            file_desc = getattr(self.parser.metadata, "file_description", None)
+            if file_desc is None or not hasattr(file_desc, "cv_params"):
+                return None
 
-                    # Check for centroid spectrum in file description
-                    for name, value in params.items():
-                        cv_params.append({"name": name, "value": value})
+            cv_params = []
+            for (
+                name,
+                accession,
+                value,
+                _,
+                _,
+                unit_name,
+                unit_acc,
+            ) in file_desc.cv_params:
+                entry: Dict[str, Any] = {
+                    "name": name,
+                    "accession": accession,
+                    "value": value,
+                }
+                if unit_name:
+                    entry["unit_name"] = unit_name
+                if unit_acc:
+                    entry["unit_accession"] = unit_acc
+                cv_params.append(entry)
 
-                    return cv_params
-
-            return None
+            return cv_params or None
         except Exception as e:
             logger.debug(f"Could not extract spectrum cvParams: {e}")
             return None

--- a/thyra/metadata/schema/__init__.py
+++ b/thyra/metadata/schema/__init__.py
@@ -11,31 +11,40 @@ from .metaspace import to_metaspace
 from .models import (
     MSI_METADATA_SCHEMA_VERSION,
     MSI_METADATA_UNS_KEY,
+    MSI_VAR_REQUIRED_COLUMNS,
+    MSI_VAR_RESERVED_COLUMNS,
     MSAnalysis,
     MSIMetadata,
     OntologyTerm,
     PixelSizeUm,
+    ProcessingStep,
     Provenance,
     ResolvingPower,
     SampleInformation,
     SamplePreparation,
+    SoftwareRef,
 )
 from .store_io import deep_merge, read_msi_metadata_blocks
-from .validate import ValidationIssue, validate_document
+from .validate import ValidationIssue, check_store_var_conventions, validate_document
 
 __all__ = [
     "MSI_METADATA_SCHEMA_VERSION",
     "MSI_METADATA_UNS_KEY",
+    "MSI_VAR_REQUIRED_COLUMNS",
+    "MSI_VAR_RESERVED_COLUMNS",
     "MSAnalysis",
     "MSIMetadata",
     "OntologyTerm",
     "PixelSizeUm",
+    "ProcessingStep",
     "Provenance",
     "ResolvingPower",
     "SampleInformation",
     "SamplePreparation",
+    "SoftwareRef",
     "ValidationIssue",
     "build_msi_metadata",
+    "check_store_var_conventions",
     "deep_merge",
     "read_msi_metadata_blocks",
     "to_metaspace",

--- a/thyra/metadata/schema/__init__.py
+++ b/thyra/metadata/schema/__init__.py
@@ -1,0 +1,43 @@
+# thyra/metadata/schema/__init__.py
+"""The versioned, ontology-mapped MSI metadata schema.
+
+See :mod:`thyra.metadata.schema.models` for the schema itself,
+``docs/metadata-schema.md`` for the storage contract, and
+``thyra validate`` / ``thyra export-metaspace`` for the CLI.
+"""
+
+from .builder import build_msi_metadata
+from .metaspace import to_metaspace
+from .models import (
+    MSI_METADATA_SCHEMA_VERSION,
+    MSI_METADATA_UNS_KEY,
+    MSAnalysis,
+    MSIMetadata,
+    OntologyTerm,
+    PixelSizeUm,
+    Provenance,
+    ResolvingPower,
+    SampleInformation,
+    SamplePreparation,
+)
+from .store_io import deep_merge, read_msi_metadata_blocks
+from .validate import ValidationIssue, validate_document
+
+__all__ = [
+    "MSI_METADATA_SCHEMA_VERSION",
+    "MSI_METADATA_UNS_KEY",
+    "MSAnalysis",
+    "MSIMetadata",
+    "OntologyTerm",
+    "PixelSizeUm",
+    "Provenance",
+    "ResolvingPower",
+    "SampleInformation",
+    "SamplePreparation",
+    "ValidationIssue",
+    "build_msi_metadata",
+    "deep_merge",
+    "read_msi_metadata_blocks",
+    "to_metaspace",
+    "validate_document",
+]

--- a/thyra/metadata/schema/builder.py
+++ b/thyra/metadata/schema/builder.py
@@ -9,10 +9,10 @@ acquisition) or from vendor metadata that directly encodes the fact
 """
 
 import logging
-from typing import Any, Dict, Literal, Optional, Tuple, cast
+from typing import Any, Dict, List, Literal, Optional, Tuple, cast
 
 from ..types import ComprehensiveMetadata
-from .models import MSAnalysis, MSIMetadata, PixelSizeUm, Provenance
+from .models import MSAnalysis, MSIMetadata, PixelSizeUm, ProcessingStep, Provenance
 from .vocab import normalize_analyzer, normalize_ionisation_source, normalize_polarity
 
 logger = logging.getLogger(__name__)
@@ -99,6 +99,7 @@ def build_msi_metadata(
     pixel_size_um: Tuple[float, float],
     pixel_size_source: Optional[str] = None,
     source_format: Optional[str] = None,
+    processing: Optional[List[ProcessingStep]] = None,
 ) -> MSIMetadata:
     """Build an :class:`MSIMetadata` document from extracted metadata.
 
@@ -113,6 +114,8 @@ def build_msi_metadata(
             (``"automatic"`` / ``"manual"`` / ``"default"``).
         source_format: Detected input format name (``"imzml"``,
             ``"bruker"``, ...), when known.
+        processing: Ordered processing steps performed so far, oldest
+            first (see :class:`ProcessingStep`).
 
     Returns:
         The populated document.  Fields the source does not report are
@@ -136,6 +139,7 @@ def build_msi_metadata(
         ms_analysis=_build_ms_analysis(
             acquisition, instrument, format_specific, pixel_size_um, source_format
         ),
+        processing=list(processing or []),
         provenance=Provenance(
             thyra_version=__version__,
             source_format=source_format,

--- a/thyra/metadata/schema/builder.py
+++ b/thyra/metadata/schema/builder.py
@@ -1,0 +1,148 @@
+# thyra/metadata/schema/builder.py
+"""Build the ``msi_metadata`` block from extracted metadata.
+
+Auto-population is best-effort and honest: a field the source does not
+report is left unset rather than guessed.  The only inferences made are
+facts that follow from the format itself (a PHI raw file is a TOF-SIMS
+acquisition) or from vendor metadata that directly encodes the fact
+(a Bruker dataset with a ``MaldiFrameLaserInfo`` table is MALDI).
+"""
+
+import logging
+from typing import Any, Dict, Literal, Optional, Tuple, cast
+
+from ..types import ComprehensiveMetadata
+from .models import MSAnalysis, MSIMetadata, PixelSizeUm, Provenance
+from .vocab import normalize_analyzer, normalize_ionisation_source, normalize_polarity
+
+logger = logging.getLogger(__name__)
+
+# Facts that follow from the source format itself.  Kept deliberately
+# conservative: only entries where every dataset of that format shares
+# the value.  PHI raw files come from TOF-SIMS instruments; the Bruker
+# formats Thyra reads (.d with analysis.tsf/.tdf) are all
+# timsTOF-family, i.e. TOF analyzers.
+_FORMAT_DEFAULTS: Dict[str, Dict[str, str]] = {
+    "phi": {"ionisation_source": "SIMS", "analyzer": "TOF"},
+    "bruker": {"analyzer": "TOF"},
+    "tsf": {"analyzer": "TOF"},
+    "tdf": {"analyzer": "TOF"},
+}
+
+# Key spellings the extractors use for the instrument model, in
+# preference order (imzML: instrument_model; Bruker: instrument_name /
+# model; PHI: platform).
+_INSTRUMENT_MODEL_KEYS = (
+    "instrument_model",
+    "instrument_name",
+    "model",
+    "platform",
+)
+
+
+def _first_string(mapping: Dict[str, Any], keys: Tuple[str, ...]) -> Optional[str]:
+    """The first non-empty string value among ``keys``, if any."""
+    for key in keys:
+        value = mapping.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _build_ms_analysis(
+    acquisition: Dict[str, Any],
+    instrument: Dict[str, Any],
+    format_specific: Dict[str, Any],
+    pixel_size_um: Tuple[float, float],
+    source_format: Optional[str],
+) -> MSAnalysis:
+    """Assemble the acquisition section from what the extractors report."""
+    fields: Dict[str, Any] = {}
+
+    polarity = normalize_polarity(acquisition.get("polarity"))
+    if polarity is not None:
+        fields["polarity"], fields["polarity_term"] = polarity
+
+    source = normalize_ionisation_source(
+        _first_string(acquisition, ("ionisation_source", "ion_source", "technique"))
+    )
+    if source is None and format_specific.get("is_maldi"):
+        source = normalize_ionisation_source("maldi")
+    fmt_defaults = _FORMAT_DEFAULTS.get((source_format or "").lower(), {})
+    if source is None and "ionisation_source" in fmt_defaults:
+        source = normalize_ionisation_source(fmt_defaults["ionisation_source"])
+    if source is not None:
+        fields["ionisation_source"], fields["ionisation_source_term"] = source
+
+    analyzer = normalize_analyzer(
+        _first_string(instrument, ("analyzer", "mass_analyzer"))
+        or _first_string(acquisition, ("analyzer", "mass_analyzer"))
+    )
+    if analyzer is None and "analyzer" in fmt_defaults:
+        analyzer = normalize_analyzer(fmt_defaults["analyzer"])
+    if analyzer is not None:
+        fields["analyzer"], fields["analyzer_term"] = analyzer
+
+    instrument_model = _first_string(instrument, _INSTRUMENT_MODEL_KEYS)
+    if instrument_model is not None:
+        fields["instrument_model"] = instrument_model
+
+    return MSAnalysis(
+        pixel_size_um=PixelSizeUm(x=pixel_size_um[0], y=pixel_size_um[1]),
+        **fields,
+    )
+
+
+def build_msi_metadata(
+    comprehensive: Optional[ComprehensiveMetadata],
+    *,
+    pixel_size_um: Tuple[float, float],
+    pixel_size_source: Optional[str] = None,
+    source_format: Optional[str] = None,
+) -> MSIMetadata:
+    """Build an :class:`MSIMetadata` document from extracted metadata.
+
+    Args:
+        comprehensive: The reader's comprehensive metadata, or ``None``
+            when unavailable -- the document is still built, carrying
+            the pixel size and provenance.
+        pixel_size_um: Resolved in-plane pixel pitch ``(x_um, y_um)``.
+            Required: conversion refuses to run without one, so a block
+            without it describes no store Thyra ever wrote.
+        pixel_size_source: How the pixel size was determined
+            (``"automatic"`` / ``"manual"`` / ``"default"``).
+        source_format: Detected input format name (``"imzml"``,
+            ``"bruker"``, ...), when known.
+
+    Returns:
+        The populated document.  Fields the source does not report are
+        left unset.
+    """
+    from thyra import __version__
+
+    acquisition: Dict[str, Any] = {}
+    instrument: Dict[str, Any] = {}
+    format_specific: Dict[str, Any] = {}
+    source_path: Optional[str] = None
+    if comprehensive is not None:
+        acquisition = dict(comprehensive.acquisition_params or {})
+        instrument = dict(comprehensive.instrument_info or {})
+        format_specific = dict(comprehensive.format_specific or {})
+        essential = comprehensive.essential
+        if essential is not None:
+            source_path = str(essential.source_path)
+
+    return MSIMetadata(
+        ms_analysis=_build_ms_analysis(
+            acquisition, instrument, format_specific, pixel_size_um, source_format
+        ),
+        provenance=Provenance(
+            thyra_version=__version__,
+            source_format=source_format,
+            source_path=source_path,
+            pixel_size_source=cast(
+                Optional[Literal["default", "manual", "automatic"]],
+                pixel_size_source,
+            ),
+        ),
+    )

--- a/thyra/metadata/schema/builder.py
+++ b/thyra/metadata/schema/builder.py
@@ -49,17 +49,41 @@ def _first_string(mapping: Dict[str, Any], keys: Tuple[str, ...]) -> Optional[st
     return None
 
 
+def _polarity_from_cv_params(raw_metadata: Dict[str, Any]) -> Optional[str]:
+    """Polarity declared by the raw file's own cvParams, if unambiguous.
+
+    imzML declares polarity as MS:1000130 (positive scan) / MS:1000129
+    (negative scan) in the file description; the extractor preserves
+    those with their accessions.  A file declaring both (alternating
+    polarity) has no single truthful value and returns ``None``.
+    """
+    cv_params = raw_metadata.get("cvParams")
+    if not isinstance(cv_params, list):
+        return None
+    accessions = {
+        entry.get("accession") for entry in cv_params if isinstance(entry, dict)
+    }
+    positive = "MS:1000130" in accessions
+    negative = "MS:1000129" in accessions
+    if positive == negative:
+        return None
+    return "positive" if positive else "negative"
+
+
 def _build_ms_analysis(
     acquisition: Dict[str, Any],
     instrument: Dict[str, Any],
     format_specific: Dict[str, Any],
+    raw_metadata: Dict[str, Any],
     pixel_size_um: Tuple[float, float],
     source_format: Optional[str],
 ) -> MSAnalysis:
     """Assemble the acquisition section from what the extractors report."""
     fields: Dict[str, Any] = {}
 
-    polarity = normalize_polarity(acquisition.get("polarity"))
+    polarity = normalize_polarity(
+        acquisition.get("polarity") or _polarity_from_cv_params(raw_metadata)
+    )
     if polarity is not None:
         fields["polarity"], fields["polarity_term"] = polarity
 
@@ -126,18 +150,25 @@ def build_msi_metadata(
     acquisition: Dict[str, Any] = {}
     instrument: Dict[str, Any] = {}
     format_specific: Dict[str, Any] = {}
+    raw_metadata: Dict[str, Any] = {}
     source_path: Optional[str] = None
     if comprehensive is not None:
         acquisition = dict(comprehensive.acquisition_params or {})
         instrument = dict(comprehensive.instrument_info or {})
         format_specific = dict(comprehensive.format_specific or {})
+        raw_metadata = dict(comprehensive.raw_metadata or {})
         essential = comprehensive.essential
         if essential is not None:
             source_path = str(essential.source_path)
 
     return MSIMetadata(
         ms_analysis=_build_ms_analysis(
-            acquisition, instrument, format_specific, pixel_size_um, source_format
+            acquisition,
+            instrument,
+            format_specific,
+            raw_metadata,
+            pixel_size_um,
+            source_format,
         ),
         processing=list(processing or []),
         provenance=Provenance(

--- a/thyra/metadata/schema/cli.py
+++ b/thyra/metadata/schema/cli.py
@@ -21,7 +21,7 @@ import click
 from .metaspace import to_metaspace
 from .models import MSI_METADATA_UNS_KEY, MSIMetadata
 from .store_io import deep_merge, read_msi_metadata_blocks
-from .validate import ValidationIssue, validate_document
+from .validate import ValidationIssue, check_store_var_conventions, validate_document
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +69,16 @@ def _apply_merge(
     return {label: deep_merge(doc, overlay) for label, doc in documents.items()}
 
 
+def _store_var_issues(path: Path) -> Dict[str, List[ValidationIssue]]:
+    """Per-table var-contract issues; empty for JSON document input."""
+    if path.is_file() and path.suffix.lower() == ".json":
+        return {}
+    try:
+        return check_store_var_conventions(path)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
 def _echo_issues(label: str, issues: List[ValidationIssue]) -> None:
     """Print one document's findings in a stable, greppable layout."""
     for issue in sorted(issues, key=lambda i: (i.severity != "error", i.location)):
@@ -95,15 +105,30 @@ def validate_command(path: Path, merge_path: Optional[Path], as_json: bool) -> N
     """Validate MSI metadata against the Thyra metadata schema.
 
     PATH is a converted SpatialData .zarr store or a metadata JSON
-    document. Exit status is 0 when every document conforms (warnings
-    allowed), 1 otherwise, so it can gate CI.
+    document. For a store, the var column contract is checked too
+    ('mz' present, numeric, finite, strictly increasing). Exit status
+    is 0 when every document conforms (warnings allowed), 1 otherwise,
+    so it can gate CI.
     """
     documents = _apply_merge(_load_documents(path), merge_path)
+    var_issues = _store_var_issues(path)
 
     report: Dict[str, Any] = {}
     failed = False
-    for label, document in documents.items():
-        _, issues = validate_document(document)
+    for label in sorted(set(documents) | set(var_issues)):
+        if label in documents:
+            _, issues = validate_document(documents[label])
+        else:
+            # The table exists in the store but carries no metadata
+            # block; every table a converter writes gets one.
+            issues = [
+                ValidationIssue(
+                    "error",
+                    MSI_METADATA_UNS_KEY,
+                    "table carries no msi_metadata block",
+                )
+            ]
+        issues = list(issues) + var_issues.get(label, [])
         errors = [issue for issue in issues if issue.severity == "error"]
         failed = failed or bool(errors)
         report[label] = {

--- a/thyra/metadata/schema/cli.py
+++ b/thyra/metadata/schema/cli.py
@@ -1,0 +1,230 @@
+# thyra/metadata/schema/cli.py
+"""The ``thyra validate`` and ``thyra export-metaspace`` subcommands.
+
+Both accept either a converted SpatialData ``.zarr`` store (only the
+metadata block is read -- validating a 100 GB store is instant) or a
+standalone metadata ``.json`` document, and both take ``--merge`` to
+overlay user-supplied fields (organism, condition, matrix, ...) that
+raw files cannot provide.
+
+Exit status follows the conversion CLI's convention: 0 success,
+1 validation errors / no metadata found, 2 usage errors (click).
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import click
+
+from .metaspace import to_metaspace
+from .models import MSI_METADATA_UNS_KEY, MSIMetadata
+from .store_io import deep_merge, read_msi_metadata_blocks
+from .validate import ValidationIssue, validate_document
+
+logger = logging.getLogger(__name__)
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    """Parse a JSON file into a mapping, with a CLI-friendly error."""
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise click.ClickException(f"Could not read {path}: {exc}") from exc
+    if not isinstance(document, dict):
+        raise click.ClickException(f"{path} does not contain a JSON object")
+    return document
+
+
+def _load_documents(path: Path) -> Dict[str, Dict[str, Any]]:
+    """Load metadata documents from a store or a JSON file.
+
+    Returns a mapping of label (table name, or the file name for JSON
+    input) to document.
+    """
+    if path.is_file() and path.suffix.lower() == ".json":
+        return {path.name: _load_json(path)}
+
+    try:
+        blocks = read_msi_metadata_blocks(path)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    if not blocks:
+        raise click.ClickException(
+            f"No {MSI_METADATA_UNS_KEY} block found in {path}. Stores "
+            "written by Thyra versions without the metadata schema do not "
+            "carry one; reconvert with a current version."
+        )
+    return blocks
+
+
+def _apply_merge(
+    documents: Dict[str, Dict[str, Any]], merge_path: Optional[Path]
+) -> Dict[str, Dict[str, Any]]:
+    """Overlay a user-supplied JSON document onto every loaded document."""
+    if merge_path is None:
+        return documents
+    overlay = _load_json(merge_path)
+    return {label: deep_merge(doc, overlay) for label, doc in documents.items()}
+
+
+def _echo_issues(label: str, issues: List[ValidationIssue]) -> None:
+    """Print one document's findings in a stable, greppable layout."""
+    for issue in sorted(issues, key=lambda i: (i.severity != "error", i.location)):
+        location = issue.location or "(document)"
+        click.echo(f"  {issue.severity.upper()} {location}: {issue.message}")
+
+
+@click.command("validate")
+@click.argument("path", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--merge",
+    "merge_path",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help="JSON file overlaid onto the metadata before validation.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit a machine-readable report on stdout instead of text.",
+)
+def validate_command(path: Path, merge_path: Optional[Path], as_json: bool) -> None:
+    """Validate MSI metadata against the Thyra metadata schema.
+
+    PATH is a converted SpatialData .zarr store or a metadata JSON
+    document. Exit status is 0 when every document conforms (warnings
+    allowed), 1 otherwise, so it can gate CI.
+    """
+    documents = _apply_merge(_load_documents(path), merge_path)
+
+    report: Dict[str, Any] = {}
+    failed = False
+    for label, document in documents.items():
+        _, issues = validate_document(document)
+        errors = [issue for issue in issues if issue.severity == "error"]
+        failed = failed or bool(errors)
+        report[label] = {
+            "valid": not errors,
+            "issues": [
+                {
+                    "severity": issue.severity,
+                    "location": issue.location,
+                    "message": issue.message,
+                }
+                for issue in issues
+            ],
+        }
+        if not as_json:
+            status = "FAILED" if errors else "OK"
+            suffix = ""
+            warning_count = len(issues) - len(errors)
+            if warning_count:
+                suffix = f" ({warning_count} warning(s))"
+            click.echo(f"{label}: {status}{suffix}")
+            _echo_issues(label, issues)
+
+    if as_json:
+        click.echo(json.dumps(report, indent=2))
+
+    if failed:
+        raise SystemExit(1)
+
+
+def _select_document(
+    documents: Dict[str, Dict[str, Any]], table: Optional[str]
+) -> Tuple[str, Dict[str, Any]]:
+    """Pick the document to export when a store holds several tables."""
+    if table is not None:
+        if table not in documents:
+            raise click.ClickException(
+                f"Table {table!r} not found; available: " + ", ".join(sorted(documents))
+            )
+        return table, documents[table]
+    if len(documents) == 1:
+        return next(iter(documents.items()))
+    raise click.ClickException(
+        "The store has metadata for several tables; pick one with --table. "
+        "Available: " + ", ".join(sorted(documents))
+    )
+
+
+def _validated_model(label: str, document: Dict[str, Any]) -> MSIMetadata:
+    """Validate before export; refuse to export a non-conforming document."""
+    meta, issues = validate_document(document)
+    if meta is None:
+        click.echo(f"{label}: metadata does not conform to the schema:", err=True)
+        _echo_issues(label, [i for i in issues if i.severity == "error"])
+        raise SystemExit(1)
+    return meta
+
+
+@click.command("export-metaspace")
+@click.argument("path", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--merge",
+    "merge_path",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help="JSON file overlaid onto the metadata before export.",
+)
+@click.option(
+    "--table",
+    default=None,
+    help="Table to export when the store has several (default: the only one).",
+)
+@click.option(
+    "-o",
+    "--output",
+    "output_path",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Output file (default: <input>.metaspace.json next to the input; "
+    "'-' for stdout).",
+)
+def export_metaspace_command(
+    path: Path,
+    merge_path: Optional[Path],
+    table: Optional[str],
+    output_path: Optional[Path],
+) -> None:
+    """Write the METASPACE submission metadata JSON for a dataset.
+
+    PATH is a converted SpatialData .zarr store or a metadata JSON
+    document. Required fields the metadata does not carry are emitted
+    empty and reported as warnings on stderr; fill them via --merge or
+    on the METASPACE submission form.
+    """
+    documents = _apply_merge(_load_documents(path), merge_path)
+    label, document = _select_document(documents, table)
+    meta = _validated_model(label, document)
+
+    metaspace_document, warnings = to_metaspace(meta)
+    for warning in warnings:
+        click.echo(f"warning: {warning}", err=True)
+
+    rendered = json.dumps(metaspace_document, indent=2)
+    if output_path is not None and str(output_path) == "-":
+        click.echo(rendered)
+        return
+
+    if output_path is None:
+        output_path = path.with_name(path.stem + ".metaspace.json")
+    output_path.write_text(rendered + "\n", encoding="utf-8")
+    click.echo(f"Wrote METASPACE metadata for {label} to {output_path}")
+    if warnings:
+        click.echo(
+            f"{len(warnings)} required field(s) are still empty; complete "
+            "them before submitting.",
+            err=True,
+        )
+
+
+# Consumed by thyra.__main__ to dispatch `thyra <subcommand>` without
+# disturbing the positional `thyra INPUT OUTPUT` conversion interface.
+METADATA_SUBCOMMANDS: Dict[str, click.Command] = {
+    "validate": validate_command,
+    "export-metaspace": export_metaspace_command,
+}

--- a/thyra/metadata/schema/generate.py
+++ b/thyra/metadata/schema/generate.py
@@ -1,0 +1,34 @@
+# thyra/metadata/schema/generate.py
+"""Regenerate the committed JSON Schema artifact.
+
+The JSON Schema rendering of the pydantic models is committed next to
+the models (``msi_metadata_schema_v0_1.json``) so that non-Python
+consumers can validate documents without importing Thyra.  A unit test
+asserts the committed file matches the models; when it fails, rerun::
+
+    python -m thyra.metadata.schema.generate
+
+and commit the result together with the model change (and the version
+bump in ``MSI_METADATA_SCHEMA_VERSION`` that the change warrants).
+"""
+
+import json
+from pathlib import Path
+
+from .models import SCHEMA_JSON_FILENAME, MSIMetadata
+
+
+def main() -> None:
+    """Write the JSON Schema for the current models next to this module."""
+    schema = MSIMetadata.model_json_schema()
+    target = Path(__file__).with_name(SCHEMA_JSON_FILENAME)
+    target.write_text(
+        json.dumps(schema, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    print(f"Wrote {target}")
+
+
+if __name__ == "__main__":
+    main()

--- a/thyra/metadata/schema/metaspace.py
+++ b/thyra/metadata/schema/metaspace.py
@@ -1,0 +1,138 @@
+# thyra/metadata/schema/metaspace.py
+"""Export MSI metadata as a METASPACE submission document.
+
+METASPACE (https://metaspace2020.org) is the public platform for
+metabolite annotation of MSI data.  Its submission form requires a
+metadata JSON; the schema's base fields mirror that form, so the
+export is a straight mapping.
+
+Fields METASPACE requires but the document does not carry are emitted
+as empty strings and reported as warnings rather than fabricated --
+the output is a truthful starting point the submitter completes, not
+a pretend-complete record.  The one inference made: a matrix of
+``"none"`` for matrix-free ionisation (DESI, SIMS), which is a fact of
+the technique, not a guess.
+"""
+
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from .models import MSIMetadata
+
+METASPACE_DATA_TYPE = "Imaging MS"
+
+_MATRIX_FREE_SOURCES = ("DESI", "SIMS")
+
+
+def _number(value: float) -> Union[int, float]:
+    """Integral floats as ints, matching how the form displays them."""
+    return int(value) if float(value).is_integer() else float(value)
+
+
+def _require(value: Optional[str], label: str, warnings: List[str]) -> str:
+    """A required METASPACE field: empty string plus warning when unset."""
+    if value is None or not str(value).strip():
+        warnings.append(
+            f"{label} is required for a METASPACE submission and is not set"
+        )
+        return ""
+    return str(value)
+
+
+def _matrix_fields(meta: MSIMetadata, warnings: List[str]) -> Tuple[str, str]:
+    """``MALDI_Matrix`` and ``MALDI_Matrix_Application``.
+
+    Matrix-free sources truthfully get ``"none"``; otherwise the field
+    is required.
+    """
+    preparation = meta.preparation
+    source = meta.ms_analysis.ionisation_source
+
+    if preparation.matrix:
+        matrix = preparation.matrix
+    elif source in _MATRIX_FREE_SOURCES:
+        matrix = "none"
+    else:
+        matrix = _require(None, "Sample_Preparation.MALDI_Matrix", warnings)
+
+    if preparation.matrix_application:
+        application = preparation.matrix_application
+    elif matrix == "none":
+        application = "none"
+    else:
+        application = _require(
+            None, "Sample_Preparation.MALDI_Matrix_Application", warnings
+        )
+
+    return matrix, application
+
+
+def to_metaspace(meta: MSIMetadata) -> Tuple[Dict[str, Any], List[str]]:
+    """Render the METASPACE submission metadata document.
+
+    Args:
+        meta: A validated MSI metadata document.
+
+    Returns:
+        ``(document, warnings)`` -- the submission JSON structure, and
+        one warning per required field that had to be left empty.
+    """
+    warnings: List[str] = []
+    sample = meta.sample
+    preparation = meta.preparation
+    analysis = meta.ms_analysis
+
+    matrix, matrix_application = _matrix_fields(meta, warnings)
+
+    polarity = ""
+    if analysis.polarity is not None:
+        polarity = analysis.polarity.capitalize()
+    else:
+        _require(None, "MS_Analysis.Polarity", warnings)
+
+    document: Dict[str, Any] = {
+        "Data_Type": METASPACE_DATA_TYPE,
+        "Sample_Information": {
+            "Organism": _require(
+                sample.organism, "Sample_Information.Organism", warnings
+            ),
+            "Organism_Part": _require(
+                sample.organism_part, "Sample_Information.Organism_Part", warnings
+            ),
+            "Condition": _require(
+                sample.condition, "Sample_Information.Condition", warnings
+            ),
+            "Sample_Growth_Conditions": sample.sample_growth_conditions or "",
+        },
+        "Sample_Preparation": {
+            "Sample_Stabilisation": preparation.sample_stabilisation or "",
+            "Tissue_Modification": preparation.tissue_modification or "",
+            "MALDI_Matrix": matrix,
+            "MALDI_Matrix_Application": matrix_application,
+            "Solvent": preparation.solvent or "none",
+        },
+        "MS_Analysis": {
+            "Polarity": polarity,
+            "Ionisation_Source": _require(
+                analysis.ionisation_source, "MS_Analysis.Ionisation_Source", warnings
+            ),
+            "Analyzer": _require(analysis.analyzer, "MS_Analysis.Analyzer", warnings),
+            "Pixel_Size": {
+                "Xaxis": _number(analysis.pixel_size_um.x),
+                "Yaxis": _number(analysis.pixel_size_um.y),
+            },
+        },
+    }
+
+    resolving_power = analysis.detector_resolving_power
+    if resolving_power is not None:
+        document["MS_Analysis"]["Detector_Resolving_Power"] = {
+            "mz": _number(resolving_power.at_mz),
+            "Resolving_Power": _number(resolving_power.value),
+        }
+    else:
+        warnings.append(
+            "MS_Analysis.Detector_Resolving_Power is required for a METASPACE "
+            "submission and is not set"
+        )
+
+    return document, warnings

--- a/thyra/metadata/schema/models.py
+++ b/thyra/metadata/schema/models.py
@@ -58,6 +58,52 @@ MSI_VAR_RESERVED_COLUMNS = (
     "fdr",
 )
 
+# Imaging concepts this schema needs that have no PSI CV term yet.
+# These are the candidate terms to raise in the mzPeak / PSI-MS imaging
+# discussions, so this schema's vocabulary and the future standard's
+# converge.  Each entry: (concept, where it lives in Thyra's output).
+CANDIDATE_CV_CONCEPTS = (
+    (
+        "pixel size semantics (raster pitch vs laser spot vs binned size)",
+        "ms_analysis.pixel_size_um",
+    ),
+    (
+        "pixel size provenance (measured vs user-supplied vs default)",
+        "provenance.pixel_size_source",
+    ),
+    (
+        "coordinate origin and axis handedness",
+        "root attrs coordinate_systems.global",
+    ),
+    (
+        "stage offset of the raster origin",
+        "root attrs coordinate_systems.global.stage_offset_um",
+    ),
+    ("ROI / acquisition region identity", "uns['regions']"),
+    ("missing / empty pixel semantics", "obs row filtering"),
+    (
+        "continuous-vs-processed source provenance after conversion",
+        "uns['essential_metadata'].spectrum_type",
+    ),
+    (
+        "mass axis resampling provenance (method, axis law, target bins)",
+        "processing steps",
+    ),
+)
+
+
+def _cv(accession: str, name: str) -> Dict[str, Any]:
+    """``json_schema_extra`` payload binding a field to its PSI CV concept.
+
+    The binding is emitted into the JSON Schema artifact, so the claim
+    "this field is the CV concept MS:1000443" is machine-readable
+    without importing Thyra.  Value-level terms (which analyzer, which
+    polarity) are carried per document by the ``*_term`` fields; this
+    binds the field itself to the concept it instantiates.
+    """
+    return {"cv": {"accession": accession, "name": name}}
+
+
 _CURIE_PATTERN = r"^[A-Za-z_][A-Za-z0-9_]*:\S+$"
 _SEMVER_PATTERN = r"^\d+\.\d+\.\d+$"
 
@@ -92,8 +138,16 @@ class OntologyTerm(_SchemaModel):
 class PixelSizeUm(_SchemaModel):
     """In-plane raster pitch in micrometres."""
 
-    x: float = Field(gt=0, description="Pixel size along x in micrometres.")
-    y: float = Field(gt=0, description="Pixel size along y in micrometres.")
+    x: float = Field(
+        gt=0,
+        description="Pixel size along x in micrometres.",
+        json_schema_extra=_cv("IMS:1000046", "pixel size (x)"),
+    )
+    y: float = Field(
+        gt=0,
+        description="Pixel size along y in micrometres.",
+        json_schema_extra=_cv("IMS:1000047", "pixel size y"),
+    )
 
 
 class ResolvingPower(_SchemaModel):
@@ -160,29 +214,39 @@ class MSAnalysis(_SchemaModel):
     """
 
     polarity: Optional[Literal["positive", "negative"]] = Field(
-        default=None, description="Ion polarity mode."
+        default=None,
+        description="Ion polarity mode.",
+        json_schema_extra=_cv("MS:1000465", "scan polarity"),
     )
     polarity_term: Optional[OntologyTerm] = Field(
         default=None,
         description="PSI-MS scan polarity term (MS:1000130 / MS:1000129).",
     )
     ionisation_source: Optional[str] = Field(
-        default=None, description="E.g. 'MALDI', 'DESI', 'SIMS'."
+        default=None,
+        description="E.g. 'MALDI', 'DESI', 'SIMS'.",
+        json_schema_extra=_cv("MS:1000008", "ionization type"),
     )
     ionisation_source_term: Optional[OntologyTerm] = Field(
         default=None, description="PSI-MS ionisation type term."
     )
     analyzer: Optional[str] = Field(
-        default=None, description="E.g. 'TOF', 'Orbitrap', 'FTICR'."
+        default=None,
+        description="E.g. 'TOF', 'Orbitrap', 'FTICR'.",
+        json_schema_extra=_cv("MS:1000443", "mass analyzer type"),
     )
     analyzer_term: Optional[OntologyTerm] = Field(
         default=None, description="PSI-MS mass analyzer type term."
     )
     instrument_model: Optional[str] = Field(
-        default=None, description="Instrument model as reported by the source."
+        default=None,
+        description="Instrument model as reported by the source.",
+        json_schema_extra=_cv("MS:1000031", "instrument model"),
     )
     detector_resolving_power: Optional[ResolvingPower] = Field(
-        default=None, description="Resolving power at a reference m/z."
+        default=None,
+        description="Resolving power at a reference m/z.",
+        json_schema_extra=_cv("MS:1000800", "mass resolving power"),
     )
     pixel_size_um: PixelSizeUm = Field(
         description="In-plane raster pitch in micrometres."
@@ -320,3 +384,28 @@ class MSIMetadata(_SchemaModel):
         if "processing" in data:
             data["processing"] = json.dumps(data["processing"])
         return data
+
+
+def field_cv_bindings() -> Dict[str, Dict[str, str]]:
+    """Every field-to-CV binding, keyed by its path in the JSON Schema.
+
+    Collected from the emitted JSON Schema rather than the models, so
+    the result is exactly what an external consumer of the committed
+    artifact sees.
+    """
+    bindings: Dict[str, Dict[str, str]] = {}
+
+    def _walk(node: Any, path: str) -> None:
+        if isinstance(node, dict):
+            cv = node.get("cv")
+            if isinstance(cv, dict):
+                bindings[path] = cv
+            for key, child in node.items():
+                if key != "cv":
+                    _walk(child, f"{path}.{key}" if path else key)
+        elif isinstance(node, list):
+            for index, child in enumerate(node):
+                _walk(child, f"{path}[{index}]")
+
+    _walk(MSIMetadata.model_json_schema(), "")
+    return bindings

--- a/thyra/metadata/schema/models.py
+++ b/thyra/metadata/schema/models.py
@@ -1,0 +1,264 @@
+# thyra/metadata/schema/models.py
+"""Pydantic models for the versioned MSI metadata schema.
+
+The schema is the structured, ontology-mapped description of an MSI
+dataset that a converted SpatialData store carries in
+``table.uns["msi_metadata"]``.  Its base fields mirror the METASPACE
+submission form (organism, organ, condition, sample preparation,
+matrix, polarity, ionisation source, analyzer, resolving power, pixel
+size) so that the metadata a store carries is sufficient for a
+METASPACE submission without retyping -- see
+:mod:`thyra.metadata.schema.metaspace`.
+
+Ontology mapping: free-text fields are paired with an optional
+:class:`OntologyTerm` (``*_term``) carrying a CURIE accession --
+NCBITaxon for organism, UBERON for organism part, CHEBI for the MALDI
+matrix, and PSI-MS for polarity, ionisation source and analyzer.  The
+PSI-MS/IMS/UO accessions are resolvable against the tables shipped in
+:mod:`thyra.metadata.ontology`.
+
+Versioning: ``schema_version`` follows semantic-version rules.  A
+reader implementing major version N must reject documents with a
+different major version, accept documents with an older minor version,
+and may warn on a newer minor version.  Purely additive optional
+fields bump the minor version; anything else bumps the major version.
+The JSON Schema rendering of these models is committed next to this
+module and kept in sync by a unit test; regenerate it with
+``python -m thyra.metadata.schema.generate``.
+"""
+
+from typing import Any, Dict, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+# The schema version this code implements and writes.
+MSI_METADATA_SCHEMA_VERSION = "0.1.0"
+
+# Where the block lives inside a converted store:
+# ``table.uns["msi_metadata"]``.  This location is a stable contract
+# (like ``uns["essential_metadata"]`` and the ``coordinate_systems``
+# root attribute); consumers read it from here and nowhere else.
+MSI_METADATA_UNS_KEY = "msi_metadata"
+
+# The committed JSON Schema artifact for this schema version.
+SCHEMA_JSON_FILENAME = "msi_metadata_schema_v0_1.json"
+
+_CURIE_PATTERN = r"^[A-Za-z_][A-Za-z0-9_]*:\S+$"
+_SEMVER_PATTERN = r"^\d+\.\d+\.\d+$"
+
+
+class _SchemaModel(BaseModel):
+    """Base for all schema models.
+
+    Unknown keys are rejected rather than silently carried, so a typo
+    in a hand-authored document fails validation instead of being
+    stored as an unread field.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class OntologyTerm(_SchemaModel):
+    """A controlled-vocabulary reference: CURIE accession plus label."""
+
+    accession: str = Field(
+        pattern=_CURIE_PATTERN,
+        description=(
+            "CURIE identifier, e.g. 'MS:1000075', 'NCBITaxon:10090', "
+            "'UBERON:0002107' or 'CHEBI:90695'."
+        ),
+    )
+    name: str = Field(
+        min_length=1,
+        description="The term's primary label in its ontology.",
+    )
+
+
+class PixelSizeUm(_SchemaModel):
+    """In-plane raster pitch in micrometres."""
+
+    x: float = Field(gt=0, description="Pixel size along x in micrometres.")
+    y: float = Field(gt=0, description="Pixel size along y in micrometres.")
+
+
+class ResolvingPower(_SchemaModel):
+    """Mass resolving power quoted at a reference m/z."""
+
+    value: float = Field(gt=0, description="Resolving power (FWHM definition).")
+    at_mz: float = Field(gt=0, description="The m/z the value is quoted at.")
+
+
+class SampleInformation(_SchemaModel):
+    """What the sample is (METASPACE ``Sample_Information``)."""
+
+    organism: Optional[str] = Field(
+        default=None, description="Species, e.g. 'Mus musculus'."
+    )
+    organism_term: Optional[OntologyTerm] = Field(
+        default=None, description="NCBITaxon term for the organism."
+    )
+    organism_part: Optional[str] = Field(
+        default=None, description="Organ or organism part, e.g. 'liver'."
+    )
+    organism_part_term: Optional[OntologyTerm] = Field(
+        default=None, description="UBERON term for the organism part."
+    )
+    condition: Optional[str] = Field(
+        default=None, description="E.g. 'wildtype', 'diseased'."
+    )
+    sample_growth_conditions: Optional[str] = Field(
+        default=None, description="E.g. intervention or treatment."
+    )
+
+
+class SamplePreparation(_SchemaModel):
+    """How the sample was prepared (METASPACE ``Sample_Preparation``)."""
+
+    sample_stabilisation: Optional[str] = Field(
+        default=None, description="Preservation method, e.g. 'fresh frozen'."
+    )
+    tissue_modification: Optional[str] = Field(
+        default=None, description="Chemical modification, e.g. 'derivatised'."
+    )
+    matrix: Optional[str] = Field(
+        default=None,
+        description=(
+            "MALDI matrix, e.g. '2,5-dihydroxybenzoic acid (DHB)'. "
+            "'none' for matrix-free techniques (DESI, SIMS)."
+        ),
+    )
+    matrix_term: Optional[OntologyTerm] = Field(
+        default=None, description="CHEBI term for the matrix compound."
+    )
+    matrix_application: Optional[str] = Field(
+        default=None, description="Matrix application device or protocol."
+    )
+    solvent: Optional[str] = Field(default=None, description="Solvent used.")
+
+
+class MSAnalysis(_SchemaModel):
+    """How the data was acquired (METASPACE ``MS_Analysis``).
+
+    ``pixel_size_um`` is the one field that is always known at
+    conversion time (conversion refuses to run without a pixel size),
+    so it is the one required field of the section.
+    """
+
+    polarity: Optional[Literal["positive", "negative"]] = Field(
+        default=None, description="Ion polarity mode."
+    )
+    polarity_term: Optional[OntologyTerm] = Field(
+        default=None,
+        description="PSI-MS scan polarity term (MS:1000130 / MS:1000129).",
+    )
+    ionisation_source: Optional[str] = Field(
+        default=None, description="E.g. 'MALDI', 'DESI', 'SIMS'."
+    )
+    ionisation_source_term: Optional[OntologyTerm] = Field(
+        default=None, description="PSI-MS ionisation type term."
+    )
+    analyzer: Optional[str] = Field(
+        default=None, description="E.g. 'TOF', 'Orbitrap', 'FTICR'."
+    )
+    analyzer_term: Optional[OntologyTerm] = Field(
+        default=None, description="PSI-MS mass analyzer type term."
+    )
+    instrument_model: Optional[str] = Field(
+        default=None, description="Instrument model as reported by the source."
+    )
+    detector_resolving_power: Optional[ResolvingPower] = Field(
+        default=None, description="Resolving power at a reference m/z."
+    )
+    pixel_size_um: PixelSizeUm = Field(
+        description="In-plane raster pitch in micrometres."
+    )
+
+    @model_validator(mode="after")
+    def _polarity_and_term_agree(self) -> "MSAnalysis":
+        """A polarity string and term that contradict are worse than either alone."""
+        if self.polarity is not None and self.polarity_term is not None:
+            expected = {
+                "positive": "MS:1000130",
+                "negative": "MS:1000129",
+            }[self.polarity]
+            if self.polarity_term.accession != expected:
+                raise ValueError(
+                    f"polarity '{self.polarity}' contradicts polarity_term "
+                    f"{self.polarity_term.accession} (expected {expected})"
+                )
+        return self
+
+
+class Provenance(_SchemaModel):
+    """Who wrote the block and from what.
+
+    Deliberately small: the store's ``uns["essential_metadata"]`` and
+    root attributes already record dimensions, mass range, spectrum
+    type and conversion timestamp.  This section records only what is
+    needed to interpret the *metadata block itself*, and contains no
+    timestamps so that two conversions of the same input produce an
+    identical block (the uns parity tests rely on this).
+    """
+
+    thyra_version: str = Field(
+        min_length=1, description="Thyra version that wrote the block."
+    )
+    source_format: Optional[str] = Field(
+        default=None,
+        description="Detected input format, e.g. 'imzml', 'bruker', 'phi'.",
+    )
+    source_path: Optional[str] = Field(
+        default=None, description="Path of the source data at conversion time."
+    )
+    pixel_size_source: Optional[Literal["default", "manual", "automatic"]] = Field(
+        default=None,
+        description=(
+            "How the pixel size was determined: read from the source "
+            "metadata ('automatic'), supplied by the user ('manual'), or "
+            "the 1.0 um fallback ('default')."
+        ),
+    )
+
+
+class MSIMetadata(_SchemaModel):
+    """The versioned MSI metadata document.
+
+    ``sample`` and ``preparation`` cannot be auto-populated from raw
+    files and default to empty; ``ms_analysis`` and ``provenance`` are
+    written by the converter for every store.
+    """
+
+    schema_version: str = Field(
+        default=MSI_METADATA_SCHEMA_VERSION,
+        pattern=_SEMVER_PATTERN,
+        description="Semantic version of the schema this document conforms to.",
+    )
+    sample: SampleInformation = Field(
+        default_factory=SampleInformation,
+        description="What the sample is; user-supplied.",
+    )
+    preparation: SamplePreparation = Field(
+        default_factory=SamplePreparation,
+        description="How the sample was prepared; user-supplied.",
+    )
+    ms_analysis: MSAnalysis = Field(
+        description="How the data was acquired; auto-populated where possible."
+    )
+    provenance: Provenance = Field(
+        description="Who wrote this block and from what source."
+    )
+
+    def to_uns_dict(self) -> Dict[str, Any]:
+        """Serialise for storage in ``table.uns``.
+
+        ``None`` fields are dropped, and the ``sample`` / ``preparation``
+        sections are omitted entirely when empty -- following the store
+        convention that a section the source has nothing for is omitted
+        rather than written empty, so consumers can tell "not available"
+        from "available and empty".
+        """
+        data: Dict[str, Any] = self.model_dump(mode="json", exclude_none=True)
+        for section in ("sample", "preparation"):
+            if not data.get(section):
+                data.pop(section, None)
+        return data

--- a/thyra/metadata/schema/models.py
+++ b/thyra/metadata/schema/models.py
@@ -27,7 +27,8 @@ module and kept in sync by a unit test; regenerate it with
 ``python -m thyra.metadata.schema.generate``.
 """
 
-from typing import Any, Dict, Literal, Optional
+import json
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -42,6 +43,20 @@ MSI_METADATA_UNS_KEY = "msi_metadata"
 
 # The committed JSON Schema artifact for this schema version.
 SCHEMA_JSON_FILENAME = "msi_metadata_schema_v0_1.json"
+
+# Fixed var column conventions for the MSI table.  ``mz`` is required
+# and written by every converter; the remaining names are reserved for
+# annotation results so downstream consumers can rely on one spelling
+# (see docs/metadata-schema.md).  Nothing may reuse these names with a
+# different meaning; ``thyra validate`` checks the ``mz`` contract.
+MSI_VAR_REQUIRED_COLUMNS = ("mz",)
+MSI_VAR_RESERVED_COLUMNS = (
+    "mz",
+    "formula",
+    "adduct",
+    "annotation_source",
+    "fdr",
+)
 
 _CURIE_PATTERN = r"^[A-Za-z_][A-Za-z0-9_]*:\S+$"
 _SEMVER_PATTERN = r"^\d+\.\d+\.\d+$"
@@ -189,6 +204,38 @@ class MSAnalysis(_SchemaModel):
         return self
 
 
+class SoftwareRef(_SchemaModel):
+    """A software agent, the way mzQC records analysis software."""
+
+    name: str = Field(min_length=1, description="Software name, e.g. 'thyra'.")
+    version: str = Field(min_length=1, description="Software version.")
+    uri: Optional[str] = Field(default=None, description="Homepage or repository URL.")
+
+
+class ProcessingStep(_SchemaModel):
+    """One processing action between the raw data and this store.
+
+    Modeled on mzQC provenance: an ordered list of steps, each naming
+    the software that performed it and the parameters it ran with.  The
+    converter records its own steps (conversion, mass axis resampling);
+    downstream tools append theirs (normalisation, peak picking,
+    annotation) when they modify the store.
+    """
+
+    name: str = Field(
+        min_length=1,
+        description=(
+            "What was done, e.g. 'conversion', 'mass axis resampling', "
+            "'normalisation', 'peak picking', 'annotation'."
+        ),
+    )
+    software: SoftwareRef = Field(description="The software that did it.")
+    parameters: Dict[str, Union[str, int, float, bool]] = Field(
+        default_factory=dict,
+        description="The parameters the step ran with.",
+    )
+
+
 class Provenance(_SchemaModel):
     """Who wrote the block and from what.
 
@@ -244,6 +291,10 @@ class MSIMetadata(_SchemaModel):
     ms_analysis: MSAnalysis = Field(
         description="How the data was acquired; auto-populated where possible."
     )
+    processing: List[ProcessingStep] = Field(
+        default_factory=list,
+        description="Ordered processing history, oldest first (mzQC-style).",
+    )
     provenance: Provenance = Field(
         description="Who wrote this block and from what source."
     )
@@ -252,13 +303,20 @@ class MSIMetadata(_SchemaModel):
         """Serialise for storage in ``table.uns``.
 
         ``None`` fields are dropped, and the ``sample`` / ``preparation``
-        sections are omitted entirely when empty -- following the store
-        convention that a section the source has nothing for is omitted
-        rather than written empty, so consumers can tell "not available"
-        from "available and empty".
+        / ``processing`` sections are omitted entirely when empty --
+        following the store convention that a section the source has
+        nothing for is omitted rather than written empty, so consumers
+        can tell "not available" from "available and empty".
+
+        ``processing`` is stored as a JSON string: it is a list of
+        objects, which AnnData/zarr cannot round-trip (the same reason
+        ``uns["regions"]`` is JSON).  ``read_msi_metadata_blocks`` and
+        ``validate_document`` both decode it transparently.
         """
         data: Dict[str, Any] = self.model_dump(mode="json", exclude_none=True)
-        for section in ("sample", "preparation"):
+        for section in ("sample", "preparation", "processing"):
             if not data.get(section):
                 data.pop(section, None)
+        if "processing" in data:
+            data["processing"] = json.dumps(data["processing"])
         return data

--- a/thyra/metadata/schema/msi_metadata.linkml.yaml
+++ b/thyra/metadata/schema/msi_metadata.linkml.yaml
@@ -1,0 +1,165 @@
+# Draft LinkML rendering of the Thyra MSI metadata schema.
+#
+# STATUS: groundwork, not yet the source of truth.  The pydantic models
+# in models.py remain authoritative for what Thyra writes and validates.
+# This file exists so the schema can be discussed and evolved in
+# LinkML-native settings (the mzPeak / PSI-MS imaging discussions, the
+# planned thyra-spec repository) and so a later migration to
+# LinkML-as-source changes no field names.  A unit test keeps the class
+# and slot inventory, required flags, CV bindings and enum meanings in
+# step with the pydantic models; edit both together.
+id: https://github.com/M4i-Imaging-Mass-Spectrometry/thyra/metadata-schema
+name: thyra-msi-metadata
+description: >-
+  Versioned, ontology-mapped metadata for mass spectrometry imaging
+  datasets converted to SpatialData.  Stored in
+  table.uns["msi_metadata"]; base fields mirror the METASPACE
+  submission form.
+version: 0.1.0
+prefixes:
+  linkml: https://w3id.org/linkml/
+  MS: http://purl.obolibrary.org/obo/MS_
+  IMS: http://purl.obolibrary.org/obo/IMS_
+  UO: http://purl.obolibrary.org/obo/UO_
+  NCBITaxon: http://purl.obolibrary.org/obo/NCBITaxon_
+  UBERON: http://purl.obolibrary.org/obo/UBERON_
+  CHEBI: http://purl.obolibrary.org/obo/CHEBI_
+default_range: string
+
+enums:
+  PolarityEnum:
+    description: Ion polarity mode.
+    permissible_values:
+      positive:
+        meaning: MS:1000130
+      negative:
+        meaning: MS:1000129
+  PixelSizeSourceEnum:
+    description: How the pixel size was determined.
+    permissible_values:
+      default: {}
+      manual: {}
+      automatic: {}
+
+classes:
+  OntologyTerm:
+    description: A controlled-vocabulary reference (CURIE plus label).
+    attributes:
+      accession:
+        required: true
+      name:
+        required: true
+  PixelSizeUm:
+    description: In-plane raster pitch in micrometres.
+    attributes:
+      x:
+        range: float
+        required: true
+        slot_uri: IMS:1000046
+      y:
+        range: float
+        required: true
+        slot_uri: IMS:1000047
+  ResolvingPower:
+    description: Mass resolving power quoted at a reference m/z.
+    attributes:
+      value:
+        range: float
+        required: true
+      at_mz:
+        range: float
+        required: true
+  SampleInformation:
+    description: What the sample is (METASPACE Sample_Information).
+    attributes:
+      organism: {}
+      organism_term:
+        range: OntologyTerm
+      organism_part: {}
+      organism_part_term:
+        range: OntologyTerm
+      condition: {}
+      sample_growth_conditions: {}
+  SamplePreparation:
+    description: How the sample was prepared (METASPACE Sample_Preparation).
+    attributes:
+      sample_stabilisation: {}
+      tissue_modification: {}
+      matrix: {}
+      matrix_term:
+        range: OntologyTerm
+      matrix_application: {}
+      solvent: {}
+  MSAnalysis:
+    description: How the data was acquired (METASPACE MS_Analysis).
+    attributes:
+      polarity:
+        range: PolarityEnum
+        slot_uri: MS:1000465
+      polarity_term:
+        range: OntologyTerm
+      ionisation_source:
+        slot_uri: MS:1000008
+      ionisation_source_term:
+        range: OntologyTerm
+      analyzer:
+        slot_uri: MS:1000443
+      analyzer_term:
+        range: OntologyTerm
+      instrument_model:
+        slot_uri: MS:1000031
+      detector_resolving_power:
+        range: ResolvingPower
+        slot_uri: MS:1000800
+      pixel_size_um:
+        range: PixelSizeUm
+        required: true
+  SoftwareRef:
+    description: A software agent, the way mzQC records analysis software.
+    attributes:
+      name:
+        required: true
+      version:
+        required: true
+      uri: {}
+  ProcessingStep:
+    description: One processing action between the raw data and this store.
+    attributes:
+      name:
+        required: true
+      software:
+        range: SoftwareRef
+        required: true
+      # Free-form mapping of parameter name to scalar value; the exact
+      # LinkML rendering is one of the questions for the working group.
+      parameters: {}
+  Provenance:
+    description: Who wrote the block and from what.
+    attributes:
+      thyra_version:
+        required: true
+      source_format: {}
+      source_path: {}
+      pixel_size_source:
+        range: PixelSizeSourceEnum
+  MSIMetadata:
+    description: The versioned MSI metadata document.
+    tree_root: true
+    attributes:
+      # Required on disk; the pydantic model fills it on construction.
+      schema_version:
+        required: true
+      sample:
+        range: SampleInformation
+      preparation:
+        range: SamplePreparation
+      ms_analysis:
+        range: MSAnalysis
+        required: true
+      processing:
+        range: ProcessingStep
+        multivalued: true
+        inlined_as_list: true
+      provenance:
+        range: Provenance
+        required: true

--- a/thyra/metadata/schema/msi_metadata_schema_v0_1.json
+++ b/thyra/metadata/schema/msi_metadata_schema_v0_1.json
@@ -166,6 +166,49 @@
       "title": "PixelSizeUm",
       "type": "object"
     },
+    "ProcessingStep": {
+      "additionalProperties": false,
+      "description": "One processing action between the raw data and this store.\n\nModeled on mzQC provenance: an ordered list of steps, each naming\nthe software that performed it and the parameters it ran with.  The\nconverter records its own steps (conversion, mass axis resampling);\ndownstream tools append theirs (normalisation, peak picking,\nannotation) when they modify the store.",
+      "properties": {
+        "name": {
+          "description": "What was done, e.g. 'conversion', 'mass axis resampling', 'normalisation', 'peak picking', 'annotation'.",
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "parameters": {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          },
+          "description": "The parameters the step ran with.",
+          "title": "Parameters",
+          "type": "object"
+        },
+        "software": {
+          "$ref": "#/$defs/SoftwareRef",
+          "description": "The software that did it."
+        }
+      },
+      "required": [
+        "name",
+        "software"
+      ],
+      "title": "ProcessingStep",
+      "type": "object"
+    },
     "Provenance": {
       "additionalProperties": false,
       "description": "Who wrote the block and from what.\n\nDeliberately small: the store's ``uns[\"essential_metadata\"]`` and\nroot attributes already record dimensions, mass range, spectrum\ntype and conversion timestamp.  This section records only what is\nneeded to interpret the *metadata block itself*, and contains no\ntimestamps so that two conversions of the same input produce an\nidentical block (the uns parity tests rely on this).",
@@ -419,6 +462,43 @@
       },
       "title": "SamplePreparation",
       "type": "object"
+    },
+    "SoftwareRef": {
+      "additionalProperties": false,
+      "description": "A software agent, the way mzQC records analysis software.",
+      "properties": {
+        "name": {
+          "description": "Software name, e.g. 'thyra'.",
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "uri": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Homepage or repository URL.",
+          "title": "Uri"
+        },
+        "version": {
+          "description": "Software version.",
+          "minLength": 1,
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "version"
+      ],
+      "title": "SoftwareRef",
+      "type": "object"
     }
   },
   "additionalProperties": false,
@@ -431,6 +511,14 @@
     "preparation": {
       "$ref": "#/$defs/SamplePreparation",
       "description": "How the sample was prepared; user-supplied."
+    },
+    "processing": {
+      "description": "Ordered processing history, oldest first (mzQC-style).",
+      "items": {
+        "$ref": "#/$defs/ProcessingStep"
+      },
+      "title": "Processing",
+      "type": "array"
     },
     "provenance": {
       "$ref": "#/$defs/Provenance",

--- a/thyra/metadata/schema/msi_metadata_schema_v0_1.json
+++ b/thyra/metadata/schema/msi_metadata_schema_v0_1.json
@@ -13,6 +13,10 @@
               "type": "null"
             }
           ],
+          "cv": {
+            "accession": "MS:1000443",
+            "name": "mass analyzer type"
+          },
           "default": null,
           "description": "E.g. 'TOF', 'Orbitrap', 'FTICR'.",
           "title": "Analyzer"
@@ -38,6 +42,10 @@
               "type": "null"
             }
           ],
+          "cv": {
+            "accession": "MS:1000800",
+            "name": "mass resolving power"
+          },
           "default": null,
           "description": "Resolving power at a reference m/z."
         },
@@ -50,6 +58,10 @@
               "type": "null"
             }
           ],
+          "cv": {
+            "accession": "MS:1000031",
+            "name": "instrument model"
+          },
           "default": null,
           "description": "Instrument model as reported by the source.",
           "title": "Instrument Model"
@@ -63,6 +75,10 @@
               "type": "null"
             }
           ],
+          "cv": {
+            "accession": "MS:1000008",
+            "name": "ionization type"
+          },
           "default": null,
           "description": "E.g. 'MALDI', 'DESI', 'SIMS'.",
           "title": "Ionisation Source"
@@ -95,6 +111,10 @@
               "type": "null"
             }
           ],
+          "cv": {
+            "accession": "MS:1000465",
+            "name": "scan polarity"
+          },
           "default": null,
           "description": "Ion polarity mode.",
           "title": "Polarity"
@@ -147,12 +167,20 @@
       "description": "In-plane raster pitch in micrometres.",
       "properties": {
         "x": {
+          "cv": {
+            "accession": "IMS:1000046",
+            "name": "pixel size (x)"
+          },
           "description": "Pixel size along x in micrometres.",
           "exclusiveMinimum": 0,
           "title": "X",
           "type": "number"
         },
         "y": {
+          "cv": {
+            "accession": "IMS:1000047",
+            "name": "pixel size y"
+          },
           "description": "Pixel size along y in micrometres.",
           "exclusiveMinimum": 0,
           "title": "Y",

--- a/thyra/metadata/schema/msi_metadata_schema_v0_1.json
+++ b/thyra/metadata/schema/msi_metadata_schema_v0_1.json
@@ -1,0 +1,457 @@
+{
+  "$defs": {
+    "MSAnalysis": {
+      "additionalProperties": false,
+      "description": "How the data was acquired (METASPACE ``MS_Analysis``).\n\n``pixel_size_um`` is the one field that is always known at\nconversion time (conversion refuses to run without a pixel size),\nso it is the one required field of the section.",
+      "properties": {
+        "analyzer": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "E.g. 'TOF', 'Orbitrap', 'FTICR'.",
+          "title": "Analyzer"
+        },
+        "analyzer_term": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OntologyTerm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "PSI-MS mass analyzer type term."
+        },
+        "detector_resolving_power": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ResolvingPower"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Resolving power at a reference m/z."
+        },
+        "instrument_model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Instrument model as reported by the source.",
+          "title": "Instrument Model"
+        },
+        "ionisation_source": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "E.g. 'MALDI', 'DESI', 'SIMS'.",
+          "title": "Ionisation Source"
+        },
+        "ionisation_source_term": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OntologyTerm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "PSI-MS ionisation type term."
+        },
+        "pixel_size_um": {
+          "$ref": "#/$defs/PixelSizeUm"
+        },
+        "polarity": {
+          "anyOf": [
+            {
+              "enum": [
+                "positive",
+                "negative"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Ion polarity mode.",
+          "title": "Polarity"
+        },
+        "polarity_term": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OntologyTerm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "PSI-MS scan polarity term (MS:1000130 / MS:1000129)."
+        }
+      },
+      "required": [
+        "pixel_size_um"
+      ],
+      "title": "MSAnalysis",
+      "type": "object"
+    },
+    "OntologyTerm": {
+      "additionalProperties": false,
+      "description": "A controlled-vocabulary reference: CURIE accession plus label.",
+      "properties": {
+        "accession": {
+          "description": "CURIE identifier, e.g. 'MS:1000075', 'NCBITaxon:10090', 'UBERON:0002107' or 'CHEBI:90695'.",
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*:\\S+$",
+          "title": "Accession",
+          "type": "string"
+        },
+        "name": {
+          "description": "The term's primary label in its ontology.",
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "accession",
+        "name"
+      ],
+      "title": "OntologyTerm",
+      "type": "object"
+    },
+    "PixelSizeUm": {
+      "additionalProperties": false,
+      "description": "In-plane raster pitch in micrometres.",
+      "properties": {
+        "x": {
+          "description": "Pixel size along x in micrometres.",
+          "exclusiveMinimum": 0,
+          "title": "X",
+          "type": "number"
+        },
+        "y": {
+          "description": "Pixel size along y in micrometres.",
+          "exclusiveMinimum": 0,
+          "title": "Y",
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y"
+      ],
+      "title": "PixelSizeUm",
+      "type": "object"
+    },
+    "Provenance": {
+      "additionalProperties": false,
+      "description": "Who wrote the block and from what.\n\nDeliberately small: the store's ``uns[\"essential_metadata\"]`` and\nroot attributes already record dimensions, mass range, spectrum\ntype and conversion timestamp.  This section records only what is\nneeded to interpret the *metadata block itself*, and contains no\ntimestamps so that two conversions of the same input produce an\nidentical block (the uns parity tests rely on this).",
+      "properties": {
+        "pixel_size_source": {
+          "anyOf": [
+            {
+              "enum": [
+                "default",
+                "manual",
+                "automatic"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "How the pixel size was determined: read from the source metadata ('automatic'), supplied by the user ('manual'), or the 1.0 um fallback ('default').",
+          "title": "Pixel Size Source"
+        },
+        "source_format": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Detected input format, e.g. 'imzml', 'bruker', 'phi'.",
+          "title": "Source Format"
+        },
+        "source_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Path of the source data at conversion time.",
+          "title": "Source Path"
+        },
+        "thyra_version": {
+          "description": "Thyra version that wrote the block.",
+          "minLength": 1,
+          "title": "Thyra Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "thyra_version"
+      ],
+      "title": "Provenance",
+      "type": "object"
+    },
+    "ResolvingPower": {
+      "additionalProperties": false,
+      "description": "Mass resolving power quoted at a reference m/z.",
+      "properties": {
+        "at_mz": {
+          "description": "The m/z the value is quoted at.",
+          "exclusiveMinimum": 0,
+          "title": "At Mz",
+          "type": "number"
+        },
+        "value": {
+          "description": "Resolving power (FWHM definition).",
+          "exclusiveMinimum": 0,
+          "title": "Value",
+          "type": "number"
+        }
+      },
+      "required": [
+        "value",
+        "at_mz"
+      ],
+      "title": "ResolvingPower",
+      "type": "object"
+    },
+    "SampleInformation": {
+      "additionalProperties": false,
+      "description": "What the sample is (METASPACE ``Sample_Information``).",
+      "properties": {
+        "condition": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "E.g. 'wildtype', 'diseased'.",
+          "title": "Condition"
+        },
+        "organism": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Species, e.g. 'Mus musculus'.",
+          "title": "Organism"
+        },
+        "organism_part": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Organ or organism part, e.g. 'liver'.",
+          "title": "Organism Part"
+        },
+        "organism_part_term": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OntologyTerm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "UBERON term for the organism part."
+        },
+        "organism_term": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OntologyTerm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "NCBITaxon term for the organism."
+        },
+        "sample_growth_conditions": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "E.g. intervention or treatment.",
+          "title": "Sample Growth Conditions"
+        }
+      },
+      "title": "SampleInformation",
+      "type": "object"
+    },
+    "SamplePreparation": {
+      "additionalProperties": false,
+      "description": "How the sample was prepared (METASPACE ``Sample_Preparation``).",
+      "properties": {
+        "matrix": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "MALDI matrix, e.g. '2,5-dihydroxybenzoic acid (DHB)'. 'none' for matrix-free techniques (DESI, SIMS).",
+          "title": "Matrix"
+        },
+        "matrix_application": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Matrix application device or protocol.",
+          "title": "Matrix Application"
+        },
+        "matrix_term": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OntologyTerm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "CHEBI term for the matrix compound."
+        },
+        "sample_stabilisation": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Preservation method, e.g. 'fresh frozen'.",
+          "title": "Sample Stabilisation"
+        },
+        "solvent": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Solvent used.",
+          "title": "Solvent"
+        },
+        "tissue_modification": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Chemical modification, e.g. 'derivatised'.",
+          "title": "Tissue Modification"
+        }
+      },
+      "title": "SamplePreparation",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "The versioned MSI metadata document.\n\n``sample`` and ``preparation`` cannot be auto-populated from raw\nfiles and default to empty; ``ms_analysis`` and ``provenance`` are\nwritten by the converter for every store.",
+  "properties": {
+    "ms_analysis": {
+      "$ref": "#/$defs/MSAnalysis",
+      "description": "How the data was acquired; auto-populated where possible."
+    },
+    "preparation": {
+      "$ref": "#/$defs/SamplePreparation",
+      "description": "How the sample was prepared; user-supplied."
+    },
+    "provenance": {
+      "$ref": "#/$defs/Provenance",
+      "description": "Who wrote this block and from what source."
+    },
+    "sample": {
+      "$ref": "#/$defs/SampleInformation",
+      "description": "What the sample is; user-supplied."
+    },
+    "schema_version": {
+      "default": "0.1.0",
+      "description": "Semantic version of the schema this document conforms to.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "title": "Schema Version",
+      "type": "string"
+    }
+  },
+  "required": [
+    "ms_analysis",
+    "provenance"
+  ],
+  "title": "MSIMetadata",
+  "type": "object"
+}

--- a/thyra/metadata/schema/store_io.py
+++ b/thyra/metadata/schema/store_io.py
@@ -1,0 +1,73 @@
+# thyra/metadata/schema/store_io.py
+"""Read the ``msi_metadata`` block back out of a converted store.
+
+Deliberately memory-bounded: only the ``uns/msi_metadata`` group of
+each table is read, never the intensity matrix, so validating or
+exporting metadata from a 100+ GB store costs nothing.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, Union
+
+from .models import MSI_METADATA_UNS_KEY
+
+logger = logging.getLogger(__name__)
+
+
+def read_msi_metadata_blocks(store_path: Union[str, Path]) -> Dict[str, Dict[str, Any]]:
+    """Read every table's ``msi_metadata`` block from a SpatialData store.
+
+    Args:
+        store_path: Path to a converted ``.zarr`` store.
+
+    Returns:
+        Mapping of table name to the block as a plain dict.  Tables
+        without a block are skipped; a store written by a Thyra version
+        that predates the schema therefore returns an empty mapping.
+
+    Raises:
+        ValueError: If the path is not a SpatialData store (no
+            ``tables`` group).
+    """
+    import anndata as ad
+    import zarr
+
+    root = zarr.open_group(str(store_path), mode="r")
+    if "tables" not in root:
+        raise ValueError(
+            f"{store_path} does not look like a SpatialData store: "
+            "it has no 'tables' group"
+        )
+
+    tables = root["tables"]
+    blocks: Dict[str, Dict[str, Any]] = {}
+    for name in sorted(tables.keys()):
+        try:
+            uns = tables[name]["uns"]
+        except KeyError:
+            logger.debug("Table %s has no uns group", name)
+            continue
+        if MSI_METADATA_UNS_KEY not in uns:
+            logger.debug("Table %s has no %s block", name, MSI_METADATA_UNS_KEY)
+            continue
+        blocks[name] = dict(ad.io.read_elem(uns[MSI_METADATA_UNS_KEY]))
+
+    return blocks
+
+
+def deep_merge(base: Dict[str, Any], overlay: Dict[str, Any]) -> Dict[str, Any]:
+    """Return ``base`` with ``overlay`` merged over it, recursively.
+
+    Nested dicts merge key-by-key; any other overlay value replaces the
+    base value.  Neither input is modified.  Used to overlay
+    user-supplied metadata (organism, condition, matrix, ...) onto the
+    auto-populated block at validation or export time.
+    """
+    merged = dict(base)
+    for key, value in overlay.items():
+        if key in merged and isinstance(merged[key], dict) and isinstance(value, dict):
+            merged[key] = deep_merge(merged[key], value)
+        else:
+            merged[key] = value
+    return merged

--- a/thyra/metadata/schema/store_io.py
+++ b/thyra/metadata/schema/store_io.py
@@ -6,6 +6,7 @@ each table is read, never the intensity matrix, so validating or
 exporting metadata from a 100+ GB store costs nothing.
 """
 
+import json
 import logging
 from pathlib import Path
 from typing import Any, Dict, Union
@@ -51,7 +52,15 @@ def read_msi_metadata_blocks(store_path: Union[str, Path]) -> Dict[str, Dict[str
         if MSI_METADATA_UNS_KEY not in uns:
             logger.debug("Table %s has no %s block", name, MSI_METADATA_UNS_KEY)
             continue
-        blocks[name] = dict(ad.io.read_elem(uns[MSI_METADATA_UNS_KEY]))
+        block = dict(ad.io.read_elem(uns[MSI_METADATA_UNS_KEY]))
+        # `processing` is stored as JSON (a list of objects cannot
+        # round-trip through AnnData/zarr); hand callers the parsed form.
+        if isinstance(block.get("processing"), str):
+            try:
+                block["processing"] = json.loads(block["processing"])
+            except json.JSONDecodeError:
+                logger.warning("Table %s has an unparseable processing section", name)
+        blocks[name] = block
 
     return blocks
 

--- a/thyra/metadata/schema/validate.py
+++ b/thyra/metadata/schema/validate.py
@@ -1,0 +1,209 @@
+# thyra/metadata/schema/validate.py
+"""Validate MSI metadata documents against the schema.
+
+Validation happens in three layers:
+
+1. ``schema_version`` compatibility (semantic-version rules),
+2. structural validation through the pydantic models, and
+3. ontology checks: PSI-MS/IMS/UO accessions must exist in the shipped
+   tables with a matching label; fields with a designated ontology
+   (NCBITaxon, UBERON, CHEBI) warn when the accession's prefix is not
+   the designated one.
+
+Errors mean the document does not conform; warnings mean it conforms
+but says something suspicious.  ``thyra validate`` exits non-zero only
+on errors, so warnings do not break CI pipelines that gate on it.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+from pydantic import ValidationError
+
+from ..ontology.cache import ONTOLOGY
+from .models import MSI_METADATA_SCHEMA_VERSION, MSIMetadata, OntologyTerm
+
+logger = logging.getLogger(__name__)
+
+# Prefixes checked against the locally shipped ontology tables.
+_LOCAL_PREFIXES = ("MS", "IMS", "UO")
+
+# The designated ontology for each ``*_term`` field, as
+# (section, field) -> accepted prefixes.  A term from another ontology
+# is a warning, not an error: EFO and friends legitimately cover some
+# of the same ground.
+EXPECTED_TERM_PREFIXES: Dict[Tuple[str, str], Tuple[str, ...]] = {
+    ("sample", "organism_term"): ("NCBITaxon",),
+    ("sample", "organism_part_term"): ("UBERON",),
+    ("preparation", "matrix_term"): ("CHEBI",),
+    ("ms_analysis", "polarity_term"): ("MS",),
+    ("ms_analysis", "ionisation_source_term"): ("MS",),
+    ("ms_analysis", "analyzer_term"): ("MS",),
+}
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    """One finding from validation.
+
+    Attributes:
+        severity: ``"error"`` (does not conform) or ``"warning"``
+            (conforms but suspicious).
+        location: Dotted path into the document, e.g.
+            ``"ms_analysis.pixel_size_um.x"``.
+        message: Human-readable description.
+    """
+
+    severity: str
+    location: str
+    message: str
+
+
+def _check_schema_version(doc: Dict[str, Any]) -> List[ValidationIssue]:
+    """Semantic-version compatibility of ``schema_version``."""
+    issues: List[ValidationIssue] = []
+    version = doc.get("schema_version")
+    if version is None:
+        issues.append(
+            ValidationIssue(
+                "error",
+                "schema_version",
+                "schema_version is missing; a stored document must state "
+                "which schema version it conforms to",
+            )
+        )
+        return issues
+    if not isinstance(version, str) or version.count(".") != 2:
+        issues.append(
+            ValidationIssue(
+                "error",
+                "schema_version",
+                f"schema_version {version!r} is not a MAJOR.MINOR.PATCH string",
+            )
+        )
+        return issues
+
+    try:
+        major, minor, _ = (int(part) for part in version.split("."))
+    except ValueError:
+        issues.append(
+            ValidationIssue(
+                "error",
+                "schema_version",
+                f"schema_version {version!r} is not a MAJOR.MINOR.PATCH string",
+            )
+        )
+        return issues
+
+    impl_major, impl_minor, _ = (
+        int(part) for part in MSI_METADATA_SCHEMA_VERSION.split(".")
+    )
+    if major != impl_major:
+        issues.append(
+            ValidationIssue(
+                "error",
+                "schema_version",
+                f"document is schema major version {major}, this Thyra "
+                f"implements {MSI_METADATA_SCHEMA_VERSION}",
+            )
+        )
+    elif minor > impl_minor:
+        issues.append(
+            ValidationIssue(
+                "warning",
+                "schema_version",
+                f"document is schema {version}, newer than the implemented "
+                f"{MSI_METADATA_SCHEMA_VERSION}; fields added since may be "
+                "rejected as unknown",
+            )
+        )
+    return issues
+
+
+def _check_term(
+    term: Optional[OntologyTerm], location: str, prefixes: Tuple[str, ...]
+) -> List[ValidationIssue]:
+    """Ontology checks for one ``*_term`` field."""
+    if term is None:
+        return []
+
+    issues: List[ValidationIssue] = []
+    prefix = term.accession.split(":", 1)[0]
+
+    if prefix not in prefixes:
+        issues.append(
+            ValidationIssue(
+                "warning",
+                location,
+                f"accession {term.accession} is from '{prefix}'; the "
+                f"designated ontology here is {' / '.join(prefixes)}",
+            )
+        )
+
+    if prefix in _LOCAL_PREFIXES:
+        entry = ONTOLOGY.terms.get(term.accession)
+        if entry is None:
+            issues.append(
+                ValidationIssue(
+                    "error",
+                    location,
+                    f"accession {term.accession} is not a known {prefix} term",
+                )
+            )
+        elif entry[0].lower() != term.name.lower():
+            issues.append(
+                ValidationIssue(
+                    "warning",
+                    location,
+                    f"name {term.name!r} does not match the {prefix} label "
+                    f"{entry[0]!r} for {term.accession}",
+                )
+            )
+    return issues
+
+
+def _check_ontology_terms(meta: MSIMetadata) -> List[ValidationIssue]:
+    """Ontology checks across every ``*_term`` field of the document."""
+    issues: List[ValidationIssue] = []
+    for (section, field), prefixes in EXPECTED_TERM_PREFIXES.items():
+        term = getattr(getattr(meta, section), field)
+        issues.extend(_check_term(term, f"{section}.{field}", prefixes))
+    return issues
+
+
+def validate_document(
+    doc: Any,
+) -> Tuple[Optional[MSIMetadata], List[ValidationIssue]]:
+    """Validate one metadata document.
+
+    Args:
+        doc: The parsed document (normally a dict read from a store's
+            ``uns["msi_metadata"]`` or from a JSON file).
+
+    Returns:
+        ``(model, issues)``.  The model is ``None`` when structural
+        validation failed; issues carry everything found, errors first
+        is not guaranteed -- filter on ``severity``.
+    """
+    if not isinstance(doc, dict):
+        return None, [
+            ValidationIssue(
+                "error", "", f"document must be a mapping, got {type(doc).__name__}"
+            )
+        ]
+
+    issues = _check_schema_version(doc)
+    if any(issue.severity == "error" for issue in issues):
+        return None, issues
+
+    try:
+        meta = MSIMetadata.model_validate(doc)
+    except ValidationError as exc:
+        for error in exc.errors():
+            location = ".".join(str(part) for part in error["loc"])
+            issues.append(ValidationIssue("error", location, error["msg"]))
+        return None, issues
+
+    issues.extend(_check_ontology_terms(meta))
+    return meta, issues

--- a/thyra/metadata/schema/validate.py
+++ b/thyra/metadata/schema/validate.py
@@ -15,9 +15,11 @@ but says something suspicious.  ``thyra validate`` exits non-zero only
 on errors, so warnings do not break CI pipelines that gate on it.
 """
 
+import json
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from pydantic import ValidationError
 
@@ -193,6 +195,18 @@ def validate_document(
             )
         ]
 
+    # On disk, `processing` is a JSON string (a list of objects cannot
+    # round-trip through AnnData/zarr); accept both spellings so a raw
+    # uns dict validates without going through read_msi_metadata_blocks.
+    if isinstance(doc.get("processing"), str):
+        doc = dict(doc)
+        try:
+            doc["processing"] = json.loads(doc["processing"])
+        except json.JSONDecodeError as exc:
+            return None, [
+                ValidationIssue("error", "processing", f"not valid JSON: {exc}")
+            ]
+
     issues = _check_schema_version(doc)
     if any(issue.severity == "error" for issue in issues):
         return None, issues
@@ -207,3 +221,71 @@ def validate_document(
 
     issues.extend(_check_ontology_terms(meta))
     return meta, issues
+
+
+def check_store_var_conventions(
+    store_path: Union[str, Path],
+) -> Dict[str, List[ValidationIssue]]:
+    """Check every table's ``var`` against the fixed column conventions.
+
+    The spec fixes ``var`` column names (see ``MSI_VAR_RESERVED_COLUMNS``)
+    and requires ``mz``: present, numeric, finite, strictly increasing.
+    Only the ``var`` group is read -- never the intensity matrix -- so
+    this stays cheap on stores of any size.
+
+    Args:
+        store_path: Path to a converted ``.zarr`` store.
+
+    Returns:
+        Mapping of table name to the issues found for it (empty list
+        when the table conforms).
+
+    Raises:
+        ValueError: If the path is not a SpatialData store (no
+            ``tables`` group).
+    """
+    import numpy as np
+    import zarr
+
+    root = zarr.open_group(str(store_path), mode="r")
+    if "tables" not in root:
+        raise ValueError(
+            f"{store_path} does not look like a SpatialData store: "
+            "it has no 'tables' group"
+        )
+
+    results: Dict[str, List[ValidationIssue]] = {}
+    for name in sorted(root["tables"].keys()):
+        issues: List[ValidationIssue] = []
+        results[name] = issues
+        try:
+            var_group = root["tables"][name]["var"]
+        except KeyError:
+            issues.append(ValidationIssue("error", "var", "table has no var group"))
+            continue
+        if "mz" not in var_group:
+            issues.append(
+                ValidationIssue(
+                    "error", "var.mz", "required var column 'mz' is missing"
+                )
+            )
+            continue
+
+        mz = np.asarray(var_group["mz"])
+        if not np.issubdtype(mz.dtype, np.number):
+            issues.append(
+                ValidationIssue(
+                    "error",
+                    "var.mz",
+                    f"'mz' must be numeric, found dtype {mz.dtype}",
+                )
+            )
+        elif mz.size and not bool(np.isfinite(mz).all()):
+            issues.append(
+                ValidationIssue("error", "var.mz", "'mz' contains non-finite values")
+            )
+        elif mz.size > 1 and not bool((np.diff(mz) > 0).all()):
+            issues.append(
+                ValidationIssue("error", "var.mz", "'mz' is not strictly increasing")
+            )
+    return results

--- a/thyra/metadata/schema/vocab.py
+++ b/thyra/metadata/schema/vocab.py
@@ -1,0 +1,155 @@
+# thyra/metadata/schema/vocab.py
+"""Controlled-vocabulary normalisation for MSI metadata fields.
+
+Vendor files spell the same fact many ways ("positive", "POS", "+",
+"positive scan").  These helpers map the spellings the readers actually
+produce onto a canonical label plus the PSI-MS term for it, so that the
+``msi_metadata`` block is comparable across formats.
+
+Term names are always resolved from the ontology tables shipped in
+:mod:`thyra.metadata.ontology`, never hardcoded here, so a label in a
+written block matches the local table by construction.
+
+Unrecognised input normalises to ``None`` rather than guessing: an
+absent field is honest, a wrong ontology term is not.
+"""
+
+from typing import Dict, Optional, Tuple
+
+from ..ontology.cache import ONTOLOGY
+from .models import OntologyTerm
+
+POLARITY_ACCESSIONS: Dict[str, str] = {
+    "positive": "MS:1000130",  # positive scan
+    "negative": "MS:1000129",  # negative scan
+}
+
+_POLARITY_ALIASES: Dict[str, str] = {
+    "positive": "positive",
+    "pos": "positive",
+    "+": "positive",
+    "positive scan": "positive",
+    "positive polarity": "positive",
+    "positive ion mode": "positive",
+    "negative": "negative",
+    "neg": "negative",
+    "-": "negative",
+    "negative scan": "negative",
+    "negative polarity": "negative",
+    "negative ion mode": "negative",
+}
+
+IONISATION_SOURCE_ACCESSIONS: Dict[str, str] = {
+    "MALDI": "MS:1000075",  # matrix-assisted laser desorption ionization
+    "ESI": "MS:1000073",  # electrospray ionization
+    "DESI": "MS:1002011",  # desorption electrospray ionization
+    "SIMS": "MS:1000402",  # secondary ionization
+}
+
+_IONISATION_SOURCE_ALIASES: Dict[str, str] = {
+    "maldi": "MALDI",
+    "matrix-assisted laser desorption ionization": "MALDI",
+    "matrix assisted laser desorption ionization": "MALDI",
+    "esi": "ESI",
+    "electrospray": "ESI",
+    "electrospray ionization": "ESI",
+    "electrospray ionisation": "ESI",
+    "desi": "DESI",
+    "desorption electrospray ionization": "DESI",
+    "desorption electrospray ionisation": "DESI",
+    "sims": "SIMS",
+    "tof-sims": "SIMS",
+    "tof sims": "SIMS",
+    "secondary ionization": "SIMS",
+    "secondary ionisation": "SIMS",
+    "secondary ion mass spectrometry": "SIMS",
+}
+
+ANALYZER_ACCESSIONS: Dict[str, str] = {
+    "TOF": "MS:1000084",  # time-of-flight
+    "Orbitrap": "MS:1000484",  # orbitrap
+    "FTICR": "MS:1000079",  # fourier transform ion cyclotron resonance MS
+    "Ion trap": "MS:1000264",  # ion trap
+}
+
+_ANALYZER_ALIASES: Dict[str, str] = {
+    "tof": "TOF",
+    "time-of-flight": "TOF",
+    "time of flight": "TOF",
+    "qtof": "TOF",
+    "q-tof": "TOF",
+    "linear tof": "TOF",
+    "reflector tof": "TOF",
+    "orbitrap": "Orbitrap",
+    "fticr": "FTICR",
+    "ft-icr": "FTICR",
+    "fourier transform ion cyclotron resonance mass spectrometer": "FTICR",
+    "ion trap": "Ion trap",
+}
+
+
+def term_from_accession(accession: str) -> OntologyTerm:
+    """Build an :class:`OntologyTerm` from the local ontology tables.
+
+    Args:
+        accession: A PSI-MS / IMS / UO accession, e.g. ``"MS:1000075"``.
+
+    Returns:
+        The term with its name taken from the shipped table.
+
+    Raises:
+        KeyError: If the accession is not in the local tables.  The
+            vocabularies in this module only reference accessions that
+            are, so hitting this means the tables and this module have
+            drifted.
+    """
+    entry = ONTOLOGY.terms.get(accession)
+    if entry is None:
+        raise KeyError(f"Accession {accession} is not in the local ontology tables")
+    return OntologyTerm(accession=accession, name=entry[0])
+
+
+def _normalize(value: object) -> Optional[str]:
+    """Lower-cased, stripped string form of a raw metadata value."""
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip().lower()
+    return stripped or None
+
+
+def normalize_polarity(value: object) -> Optional[Tuple[str, OntologyTerm]]:
+    """Map a raw polarity value to ``("positive"|"negative", term)``.
+
+    Returns ``None`` for anything unrecognised, including mixed-mode
+    values -- a dataset alternating polarities has no single truthful
+    value for this field.
+    """
+    key = _normalize(value)
+    if key is None:
+        return None
+    canonical = _POLARITY_ALIASES.get(key)
+    if canonical is None:
+        return None
+    return canonical, term_from_accession(POLARITY_ACCESSIONS[canonical])
+
+
+def normalize_ionisation_source(value: object) -> Optional[Tuple[str, OntologyTerm]]:
+    """Map a raw ionisation source value to ``(label, term)``."""
+    key = _normalize(value)
+    if key is None:
+        return None
+    canonical = _IONISATION_SOURCE_ALIASES.get(key)
+    if canonical is None:
+        return None
+    return canonical, term_from_accession(IONISATION_SOURCE_ACCESSIONS[canonical])
+
+
+def normalize_analyzer(value: object) -> Optional[Tuple[str, OntologyTerm]]:
+    """Map a raw mass analyzer value to ``(label, term)``."""
+    key = _normalize(value)
+    if key is None:
+        return None
+    canonical = _ANALYZER_ALIASES.get(key)
+    if canonical is None:
+        return None
+    return canonical, term_from_accession(ANALYZER_ACCESSIONS[canonical])

--- a/thyra/tools/check_ontology.py
+++ b/thyra/tools/check_ontology.py
@@ -24,7 +24,7 @@ def _setup_logging(verbose: bool):
         logging.basicConfig(level=logging.INFO)
 
 
-def _print_file_results(results: dict, args, unknown_terms: list):
+def _print_file_results(results: dict, args, unknown_list: list):
     """Print results for single file validation."""
     if not args.output:
         if args.verbose and "summary" in results:
@@ -35,10 +35,10 @@ def _print_file_results(results: dict, args, unknown_terms: list):
             print("Test summary for file")
             print()
 
-        if unknown_terms:
-            print(f"Found {len(unknown_terms)} unknown terms:")
-            for term in unknown_terms[:20]:
-                print(f"  - {term}")
+        if unknown_list:
+            print(f"Found {len(unknown_list)} unknown terms:")
+            for term in unknown_list[:20]:
+                print(f"  - {term['accession']}: {term['name']}")
         else:
             print("No unknown terms encountered.")
         print()
@@ -80,8 +80,10 @@ def main():
 
     if input_path.is_file():
         results = validator.validate_file(input_path)
-        unknown_terms = results.get("unknown_terms", [])
-        _print_file_results(results, args, unknown_terms)
+        # validate_file reports `unknown_terms` as a count; the terms
+        # themselves are in `unknown_list`.
+        unknown_list = results.get("unknown_list", [])
+        _print_file_results(results, args, unknown_list)
     else:
         results = validator.validate_directory(input_path)
         _print_directory_results(results)

--- a/uv.lock
+++ b/uv.lock
@@ -3827,7 +3827,7 @@ wheels = [
 
 [[package]]
 name = "thyra"
-version = "3.4.0"
+version = "3.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "anndata" },
@@ -3841,6 +3841,7 @@ dependencies = [
     { name = "ome-zarr" },
     { name = "pandas" },
     { name = "psutil" },
+    { name = "pydantic" },
     { name = "pyimzml" },
     { name = "scipy" },
     { name = "shapely" },
@@ -3895,6 +3896,7 @@ requires-dist = [
     { name = "ome-zarr", specifier = ">=0.16.0,<0.19" },
     { name = "pandas", specifier = ">=2.0.0,<4" },
     { name = "psutil", specifier = ">=5.0.0" },
+    { name = "pydantic", specifier = ">=2.7,<3" },
     { name = "pyimzml", specifier = ">=1.4.0" },
     { name = "scipy", specifier = ">=1.7.0" },
     { name = "shapely", specifier = ">=2.0.0" },


### PR DESCRIPTION
## What this adds

MSI has had no structured metadata convention the way other spatial omics modalities do. This PR gives every converted store a versioned, ontology-mapped metadata block, a validator that can gate CI, one-command METASPACE export, mzQC-style processing provenance, a fixed `var` column contract, and PSI CV alignment down to the field level.

### The schema (`thyra/metadata/schema/`)

- Every store now carries `table.uns["msi_metadata"]`: schema version, METASPACE-form base fields (organism, organ, condition, preparation, matrix, polarity, ionisation source, analyzer, resolving power, pixel size), each mapped to ontology terms (PSI-MS, NCBITaxon, UBERON, CHEBI).
- Auto-populated from what the readers already extract, and only that: pixel size always; polarity from PHI headers and from imzML's own file-level cvParams (MS:1000130/MS:1000129); MALDI from Bruker laser tables; SIMS/TOF where the format itself implies them. Nothing is guessed.
- Written identically by all four converter write paths through the existing `build_uns_metadata()` funnel; the uns parity suite asserts the new block too. The block carries no timestamps, so converting the same input twice produces the same bytes.
- Defined as pydantic models; the JSON Schema artifact is committed beside them, ships in the wheel, and a unit test keeps the two in sync.

### PSI CV alignment

- Every schema field that instantiates a PSI CV concept carries the concept's accession in the JSON Schema itself: pixel size x/y (`IMS:1000046`/`47`), scan polarity (`MS:1000465`), ionization type (`MS:1000008`), mass analyzer type (`MS:1000443`), instrument model (`MS:1000031`), mass resolving power (`MS:1000800`). A test resolves every binding against the shipped CV tables, label included.
- imzML file-description cvParams are preserved **with their accessions** (and unit accessions) instead of name/value pairs, so the converted store is annotated with the same PSI CV terms as the raw file it came from -- and that claim is machine-checkable.
- Imaging concepts with no CV term yet (pixel size semantics, stage offset, region identity, missing pixels, resampling provenance, ...) are tracked in `CANDIDATE_CV_CONCEPTS`.
- The schema is additionally rendered as LinkML (`msi_metadata.linkml.yaml`, `slot_uri` CV bindings, enum `meaning:` accessions) as the interchange artifact for spec discussions; a sync test pins it to the pydantic models so the two cannot drift.

### Processing provenance, var contract, placement attrs

- `processing`: mzQC-modeled processing history. The converter records `conversion` always and `mass axis resampling` with the resolved parameters when resampling ran; downstream tools append their own steps. Stored as JSON in uns (a list of objects cannot round-trip through AnnData/zarr -- same reason `regions` is JSON); reading and validation decode it transparently.
- Fixed `var` column conventions: `mz` required; `formula` / `adduct` / `annotation_source` / `fdr` reserved for annotation results. `thyra validate` checks the `mz` contract (present, numeric, finite, strictly increasing) on every table and flags tables that carry no metadata block.
- `coordinate_systems.global` gains additive keys (`convention_version` stays 1): `raster_to_global_affine`, `coordinate_offsets_px`, and `stage_offset_um` (micrometer variant only).

### New CLI subcommands

Dispatched by first argument; the positional `thyra INPUT OUTPUT` interface is untouched.

- `thyra validate PATH` -- validates a store or a metadata JSON document: structure, schema version (semver rules), ontology accessions, and the var contract. Reads only metadata, never spectra, so it is instant on stores of any size. Exit 0/1/2.
- `thyra export-metaspace PATH` -- writes the METASPACE submission metadata JSON. Required fields the store cannot know are emitted empty and warned on stderr, never fabricated; matrix-free sources (DESI, SIMS) truthfully get `MALDI_Matrix: "none"`. Both commands take `--merge user.json` for the fields only the submitter can know.

### Also fixed

`thyra-check-ontology` crashed on any file containing an unknown CV term: it read `unknown_terms` (a count) where it needed `unknown_list`. The test mocks had encoded the bug; they now follow the validator's actual contract and a regression test covers the previously crashing path.

## Docs

New [Metadata Schema](https://M4i-Imaging-Mass-Spectrometry.github.io/thyra/metadata-schema/) page (storage contract, field reference, PSI CV alignment, candidate terms, versioning policy, CLI, overlay workflow), plus CLI reference, output-format, coordinate-systems, API reference and README updates.

## Verification

- Full unit suite: 1588 passed, 0 failed.
- The four-path uns parity suite asserts the block is identical across in-memory, streaming-COO, streaming-PCS and 3D writes, and `read_lazy` sees it.
- Round-trip tests convert a mock store, read the block back, validate it, and export the METASPACE JSON from it; var-contract failure shapes are covered by fabricated zarr stores.
- `mkdocs build --strict` passes; all pre-commit hooks green.
- pydantic was already in the resolved set (via ome-zarr-models); declaring it changes no resolved versions.
