### PR TITLE
perf: cut per-spectrum recompute across the conversion hot loops

### DIFF
--- a/tests/unit/converters/test_nn_shared_axis_cache.py
+++ b/tests/unit/converters/test_nn_shared_axis_cache.py
@@ -1,0 +1,187 @@
+# tests/unit/converters/test_nn_shared_axis_cache.py
+"""The shared-axis nearest-neighbor cache must be an invisible optimization.
+
+``_nearest_neighbor_resample`` caches the peak-to-bin mapping the first time
+it sees a spectrum and reuses it for every later spectrum carrying the same
+m/z array -- which is every spectrum, on a shared-axis reader (continuous
+imzML, Rapiflex, Waters, PHI). The cache must never change a result:
+
+* a hit must return exactly what the generic path returns;
+* an array with different values must miss and take the generic path,
+  never receive the stale mapping;
+* repeated misses (processed-mode data) must disable the cache;
+* out-of-range peaks must be counted identically through both routes.
+
+The bit-parity claim is load-bearing: the streaming PCS route resamples
+every spectrum twice and requires pass 2 to reproduce pass 1 exactly, and
+mixed hit/miss sequences within one conversion would otherwise let the two
+passes disagree.
+"""
+
+from types import MethodType, SimpleNamespace
+
+import numpy as np
+
+from thyra.converters.spatialdata.base_spatialdata_converter import (
+    BaseSpatialDataConverter,
+)
+
+
+def _stub(axis, cache_enabled=True):
+    """A converter stand-in with just enough state for the resample path."""
+    stub = SimpleNamespace(
+        _common_mass_axis=np.asarray(axis, float),
+        _nn_shared_cache=None if cache_enabled else False,
+        _nn_cache_misses=0,
+        _out_of_range_peaks=0,
+        _out_of_range_warned=True,  # count, but stay quiet
+    )
+    for name in (
+        "_nearest_neighbor_resample",
+        "_nn_resample_via_cache",
+        "_build_nn_shared_cache",
+        "_count_out_of_range",
+    ):
+        setattr(stub, name, MethodType(getattr(BaseSpatialDataConverter, name), stub))
+    return stub
+
+
+def _spectra(rng, mzs, n):
+    """n intensity vectors over one shared m/z array, zeros included."""
+    out = []
+    for _ in range(n):
+        ints = rng.lognormal(np.log(50), 1.0, mzs.size)
+        ints[rng.random(mzs.size) < 0.4] = 0.0
+        out.append(ints)
+    return out
+
+
+class TestHitsMatchTheGenericPath:
+    def test_shared_array_bit_parity(self):
+        rng = np.random.default_rng(3)
+        axis = np.linspace(100.0, 1000.0, 5_000)
+        mzs = np.sort(rng.uniform(100.0, 1000.0, 2_000))
+
+        cached = _stub(axis)
+        generic = _stub(axis, cache_enabled=False)
+
+        for ints in _spectra(rng, mzs, 6):
+            got = cached._nearest_neighbor_resample(mzs, ints)
+            want = generic._nearest_neighbor_resample(mzs, ints)
+            np.testing.assert_array_equal(got[0], want[0])
+            np.testing.assert_array_equal(got[1], want[1])  # exact, not approx
+            assert got[0].dtype == want[0].dtype
+            assert got[1].dtype == want[1].dtype
+
+        assert cached._nn_shared_cache not in (None, False), "cache never built"
+
+    def test_equal_valued_copy_hits(self):
+        rng = np.random.default_rng(4)
+        axis = np.linspace(100.0, 1000.0, 3_000)
+        mzs = np.sort(rng.uniform(100.0, 1000.0, 500))
+        ints = rng.exponential(10.0, mzs.size)
+
+        stub = _stub(axis)
+        first = stub._nearest_neighbor_resample(mzs, ints)
+        # A fresh, equal-valued array (what continuous imzML yields when the
+        # block is re-decoded) must hit, not rebuild or miss.
+        again = stub._nearest_neighbor_resample(mzs.copy(), ints)
+        np.testing.assert_array_equal(first[0], again[0])
+        np.testing.assert_array_equal(first[1], again[1])
+        assert stub._nn_cache_misses == 0
+
+    def test_out_of_range_counting_is_identical(self):
+        axis = np.linspace(400.0, 800.0, 1_000)
+        # Two below, one inside, one above.
+        mzs = np.array([300.0, 350.0, 500.0, 900.0])
+        ints = np.array([1.0, 2.0, 3.0, 4.0])
+
+        cached = _stub(axis)
+        generic = _stub(axis, cache_enabled=False)
+        for _ in range(3):
+            got = cached._nearest_neighbor_resample(mzs, ints)
+            want = generic._nearest_neighbor_resample(mzs, ints)
+            np.testing.assert_array_equal(got[0], want[0])
+            np.testing.assert_array_equal(got[1], want[1])
+
+        assert cached._out_of_range_peaks == generic._out_of_range_peaks == 9
+
+
+class TestMissesStayCorrect:
+    def test_different_values_take_the_generic_path(self):
+        rng = np.random.default_rng(5)
+        axis = np.linspace(100.0, 1000.0, 3_000)
+        first = np.sort(rng.uniform(100.0, 1000.0, 400))
+        other = np.sort(rng.uniform(100.0, 1000.0, 400))  # same size, new values
+        ints = np.ones(400)
+
+        stub = _stub(axis)
+        stub._nearest_neighbor_resample(first, ints)  # builds the cache
+        got = stub._nearest_neighbor_resample(other, ints)
+        want = _stub(axis, cache_enabled=False)._nearest_neighbor_resample(other, ints)
+        np.testing.assert_array_equal(got[0], want[0])
+        np.testing.assert_array_equal(got[1], want[1])
+        assert stub._nn_cache_misses == 1
+
+    def test_processed_mode_disables_the_cache(self):
+        rng = np.random.default_rng(6)
+        axis = np.linspace(100.0, 1000.0, 3_000)
+        stub = _stub(axis)
+
+        for _ in range(8):
+            n = int(rng.integers(50, 200))
+            mzs = np.sort(rng.uniform(100.0, 1000.0, n))
+            stub._nearest_neighbor_resample(mzs, np.ones(n))
+
+        assert stub._nn_shared_cache is False, "five misses must disable it"
+
+    def test_unsorted_mzs_are_not_cached(self):
+        axis = np.linspace(100.0, 1000.0, 1_000)
+        mzs = np.array([500.0, 300.0, 700.0])  # descending start: not ascending
+        ints = np.array([1.0, 2.0, 3.0])
+
+        stub = _stub(axis)
+        got = stub._nearest_neighbor_resample(mzs, ints)
+        want = _stub(axis, cache_enabled=False)._nearest_neighbor_resample(mzs, ints)
+        np.testing.assert_array_equal(got[0], want[0])
+        np.testing.assert_array_equal(got[1], want[1])
+        assert stub._nn_shared_cache is False
+
+
+class TestIdentityMassIndices:
+    """_map_mass_to_indices short-circuits mzs == axis to an arange."""
+
+    def _converter_stub(self, axis):
+        stub = SimpleNamespace(
+            _common_mass_axis=np.asarray(axis),
+            _identity_mass_indices=None,
+            _axis_strictly_increasing=None,
+        )
+        from thyra.core.base_converter import BaseMSIConverter
+
+        stub._map_mass_to_indices = MethodType(
+            BaseMSIConverter._map_mass_to_indices, stub
+        )
+        return stub
+
+    def test_identity_on_equal_array(self):
+        axis = np.linspace(100.0, 1000.0, 4_000)
+        stub = self._converter_stub(axis)
+        got = stub._map_mass_to_indices(axis.copy())
+        np.testing.assert_array_equal(got, np.arange(axis.size))
+
+    def test_duplicate_axis_keeps_searchsorted_semantics(self):
+        # searchsorted maps a duplicated value to its first occurrence, so
+        # the arange shortcut is NOT valid here and must not fire.
+        axis = np.array([100.0, 200.0, 200.0, 300.0])
+        stub = self._converter_stub(axis)
+        got = stub._map_mass_to_indices(axis.copy())
+        expected = np.searchsorted(axis, axis)  # [0, 1, 1, 3]
+        np.testing.assert_array_equal(got, expected)
+
+    def test_subset_still_maps_exactly(self):
+        axis = np.linspace(100.0, 1000.0, 4_000)
+        stub = self._converter_stub(axis)
+        subset = axis[::7]
+        got = stub._map_mass_to_indices(subset)
+        np.testing.assert_array_equal(got, np.arange(0, axis.size, 7))

--- a/tests/unit/readers/test_imzml_continuous_fast_read.py
+++ b/tests/unit/readers/test_imzml_continuous_fast_read.py
@@ -1,0 +1,114 @@
+# tests/unit/readers/test_imzml_continuous_fast_read.py
+"""The continuous-mode fast read must be invisible next to pyimzml's reads.
+
+``_read_spectrum_arrays`` decodes the shared m/z block once and reads only
+intensity bytes per spectrum -- licensed by ``_continuous_uniform``, which
+is measured off the offset tables rather than trusted from the declared
+mode. Nothing it yields may differ from ``getspectrum``: everything a
+conversion stores flows through these arrays, twice (the streaming routes
+iterate the reader in two passes).
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from pyimzml.ImzMLParser import ImzMLParser
+from pyimzml.ImzMLWriter import ImzMLWriter
+
+from thyra.readers.imzml.imzml_reader import ImzMLReader
+
+
+def _write_processed(path: Path, n_spectra: int = 30) -> None:
+    with ImzMLWriter(str(path), mode="processed") as writer:
+        for i in range(n_spectra):
+            rng = np.random.default_rng([11, i])
+            n = int(rng.integers(5, 40))
+            mzs = np.sort(rng.uniform(100.0, 900.0, n))
+            ints = rng.exponential(50.0, n).astype(np.float32)
+            writer.addSpectrum(mzs, ints, (i % 6 + 1, i // 6 + 1, 1))
+
+
+def _write_continuous(path: Path, n_spectra: int = 20, n_points: int = 300) -> None:
+    axis = np.linspace(100.0, 900.0, n_points)
+    with ImzMLWriter(str(path), mode="continuous") as writer:
+        for i in range(n_spectra):
+            rng = np.random.default_rng([13, i])
+            ints = rng.exponential(50.0, n_points).astype(np.float32)
+            ints[rng.random(n_points) < 0.3] = 0.0
+            writer.addSpectrum(axis, ints, (i % 5 + 1, i // 5 + 1, 1))
+
+
+def _reference_spectra(path: Path):
+    """(mzs, intensities) per spectrum straight from pyimzml, no Thyra."""
+    parser = ImzMLParser(str(path), parse_lib="ElementTree")
+    try:
+        return [parser.getspectrum(i) for i in range(len(parser.coordinates))]
+    finally:
+        parser.m.close()
+
+
+@pytest.mark.parametrize("mode", ["processed", "continuous"])
+def test_iter_spectra_matches_getspectrum(tmp_path, mode):
+    path = tmp_path / f"{mode}.imzML"
+    if mode == "processed":
+        _write_processed(path)
+    else:
+        _write_continuous(path)
+    reference = _reference_spectra(path)
+
+    reader = ImzMLReader(path)
+    try:
+        got = list(reader.iter_spectra())
+        if mode == "continuous":
+            # The fast read must actually be active, or this test would
+            # silently cover the fallback instead.
+            assert reader._continuous_uniform
+        assert len(got) == len(reference)
+        for (_, mzs, ints), (ref_mzs, ref_ints) in zip(got, reference):
+            np.testing.assert_array_equal(np.asarray(mzs), ref_mzs)
+            np.testing.assert_array_equal(np.asarray(ints), ref_ints)
+            assert np.asarray(ints).dtype == ref_ints.dtype
+    finally:
+        reader.close()
+
+
+@pytest.mark.parametrize("axis_first", [True, False])
+def test_continuous_yields_one_shared_mz_object(tmp_path, axis_first):
+    """Every yielded m/z IS the common-axis object, whichever is asked first.
+
+    Identity (not mere equality) is what makes the converters' shared-axis
+    equality checks O(1) per spectrum.
+    """
+    path = tmp_path / "cont.imzML"
+    _write_continuous(path)
+
+    reader = ImzMLReader(path)
+    try:
+        if axis_first:
+            axis = reader.get_common_mass_axis()
+            spectra = list(reader.iter_spectra())
+        else:
+            spectra = list(reader.iter_spectra())
+            axis = reader.get_common_mass_axis()
+        assert all(mzs is axis for _, mzs, _ in spectra)
+    finally:
+        reader.close()
+
+
+def test_two_passes_agree(tmp_path):
+    """The streaming converters iterate twice; both passes must match."""
+    path = tmp_path / "cont.imzML"
+    _write_continuous(path)
+
+    reader = ImzMLReader(path)
+    try:
+        first = [(c, m.copy(), i.copy()) for c, m, i in reader.iter_spectra()]
+        second = list(reader.iter_spectra())
+        assert len(first) == len(second)
+        for (c1, m1, i1), (c2, m2, i2) in zip(first, second):
+            assert c1 == c2
+            np.testing.assert_array_equal(m1, np.asarray(m2))
+            np.testing.assert_array_equal(i1, np.asarray(i2))
+    finally:
+        reader.close()

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -215,6 +215,126 @@ def _calc_optical_scale_factors(
     return factors
 
 
+def _nn_map_to_bins(
+    axis: NDArray[np.float64], mzs: NDArray[np.float64]
+) -> NDArray[np.int_]:
+    """Map in-range m/z values to their nearest bin on ``axis``.
+
+    Ties (a peak exactly between two bins) resolve to the right bin,
+    matching the strict ``<`` comparison this code has always used.
+
+    A module-level function rather than a method so the unbound-call test
+    harnesses (a ``SimpleNamespace`` posing as the converter) keep working.
+
+    Args:
+        axis: The target mass axis, ascending.
+        mzs: m/z values, all within ``[axis[0], axis[-1]]``.
+
+    Returns:
+        The nearest-bin index of each m/z value, same length as ``mzs``.
+    """
+    # Find insertion points using vectorized binary search
+    indices = np.searchsorted(axis, mzs)
+
+    # Clip to valid range. Everything reaching here is inside the axis,
+    # so this only pins searchsorted's one-past-the-end result for a
+    # value equal to axis[-1]; it can no longer pull an outside peak in.
+    indices_clipped = np.clip(indices, 0, len(axis) - 1)
+
+    # For non-boundary points, check if left is closer
+    # Only check where we're not at the left edge
+    check_left = indices > 0
+    if np.any(check_left):
+        # Get distances only for points that need checking
+        mz_values = axis[indices_clipped[check_left]]
+        mz_values_left = axis[indices_clipped[check_left] - 1]
+        mz_query = mzs[check_left]
+
+        # Use left if it's closer
+        use_left = np.abs(mz_values_left - mz_query) < np.abs(mz_values - mz_query)
+        indices_clipped[check_left] = np.where(
+            use_left, indices_clipped[check_left] - 1, indices_clipped[check_left]
+        )
+    return indices_clipped
+
+
+def _nn_accumulate(
+    idx: NDArray[np.int_], intensities: NDArray[np.float64]
+) -> Tuple[NDArray[np.int_], NDArray[np.float64]]:
+    """Sum intensities per bin and return the non-zero bins, ascending.
+
+    Two equivalent routes. When ``idx`` is non-decreasing -- true whenever
+    the spectrum's m/z values are ascending, which every format seen so
+    far produces -- equal bins form contiguous runs, so the per-bin sums
+    are ``np.add.reduceat`` over the run starts. That is O(n_peaks),
+    where the ``np.bincount`` fallback is O(n_bins): for a centroid
+    spectrum of hundreds of peaks against an axis of 10^5 bins the
+    difference is roughly 7x per spectrum. Both sum left-to-right over
+    the same float64 values, so the results are bit-identical; the
+    fallback keeps unsorted input correct.
+
+    The kept-bin test is ``!= 0`` rather than ``> 0`` because a bin whose
+    accumulated value is negative is still a measurement: dropping it
+    silently raises the stored TIC above the input's. Baseline-subtracted
+    data can carry negative intensities, though every export seen so far
+    filters them out upstream.
+    """
+    # bincount always promotes its weights to float64; match it so both
+    # accumulation routes return the same dtype and the same rounding.
+    vals = intensities.astype(np.float64, copy=False)
+
+    if idx.size and bool(np.all(idx[1:] >= idx[:-1])):
+        starts = np.concatenate(([0], np.flatnonzero(np.diff(idx)) + 1))
+        if starts.size == idx.size:
+            # Every peak already sits in its own bin (the common case
+            # for both centroid and profile data): nothing to sum.
+            bins = idx
+            sums = vals
+        else:
+            bins = idx[starts]
+            sums = np.add.reduceat(vals, starts)
+        keep = sums != 0
+        return bins[keep].astype(np.int_, copy=False), sums[keep]
+
+    accumulated = np.bincount(idx, weights=vals)
+    nonzero_mask = accumulated != 0
+    nonzero_indices = np.where(nonzero_mask)[0].astype(np.int_)
+    nonzero_values = accumulated[nonzero_mask]
+    return nonzero_indices, nonzero_values.astype(np.float64)
+
+
+class _SharedAxisNNCache:
+    """Precomputed nearest-neighbor mapping for one recurring m/z array.
+
+    Built the first time :meth:`_nearest_neighbor_resample` sees a spectrum,
+    and reused for every later spectrum that carries the same m/z array.
+    ``key`` is a private copy so a caller-side mutation of the original
+    array cannot fool the equality check; ``key_ref`` keeps the original
+    object for the O(1) identity test that readers yielding one shared
+    array (Rapiflex, Waters, PHI) hit every time.
+    """
+
+    __slots__ = (
+        "key",
+        "key_ref",
+        "n_total",
+        "n_dropped",
+        "lo",
+        "hi",
+        "starts",
+        "bins",
+    )
+
+    key: NDArray[np.float64]
+    key_ref: NDArray[np.float64]
+    n_total: int
+    n_dropped: int
+    lo: int
+    hi: int
+    starts: Optional[NDArray[np.int_]]
+    bins: NDArray[np.int_]
+
+
 class BaseSpatialDataConverter(BaseMSIConverter, ABC):
     """Base converter for MSI data to SpatialData format with shared functionality."""
 
@@ -341,6 +461,15 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
 
         # Cache for dense mass axis indices (to avoid repeated np.arange calls)
         self._cached_mass_axis_indices: Optional[NDArray[np.int_]] = None
+
+        # Shared-axis nearest-neighbor cache. Continuous imzML, Rapiflex,
+        # Waters and PHI all hand every spectrum the same m/z array, so the
+        # peak-to-bin mapping is computed once and verified per spectrum by
+        # array equality instead of being re-derived by searchsorted. None
+        # means "not built yet"; False means "tried and the data does not
+        # share an axis, stop checking". See _nearest_neighbor_resample.
+        self._nn_shared_cache: Any = None
+        self._nn_cache_misses: int = 0
 
         # Optical-MSI alignment (computed from FlexImaging Area definitions)
         self._alignment_result: Optional[AreaAlignmentResult] = None
@@ -1171,6 +1300,22 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             raise ValueError("Common mass axis is not initialized")
 
         axis = self._common_mass_axis
+
+        # Shared-axis fast path: when every spectrum carries the same m/z
+        # array (continuous imzML, Rapiflex, Waters, PHI), the peak-to-bin
+        # mapping is a property of the axis pair, not of the spectrum. It is
+        # computed once; each later spectrum only proves its m/z array is
+        # the same one -- an exact array comparison, which is far cheaper
+        # than re-deriving the mapping by binary search per spectrum.
+        # ``False`` means the cache disabled itself (processed-mode data).
+        # getattr rather than a bare read: test harnesses drive this method
+        # unbound on a stub that predates the cache, and they exercise the
+        # generic path below, which is exactly what "no cache" selects.
+        if getattr(self, "_nn_shared_cache", False) is not False:
+            result = self._nn_resample_via_cache(axis, mzs, intensities)
+            if result is not None:
+                return result
+
         in_range = (mzs >= axis[0]) & (mzs <= axis[-1])
         if not in_range.all():
             self._count_out_of_range(int(mzs.size - in_range.sum()), int(mzs.size))
@@ -1179,45 +1324,101 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             if mzs.size == 0:
                 return np.array([], dtype=np.int_), np.array([], dtype=np.float64)
 
-        # Find insertion points using vectorized binary search
-        indices = np.searchsorted(axis, mzs)
+        return _nn_accumulate(_nn_map_to_bins(axis, mzs), intensities)
 
-        # OPTIMIZED: Handle boundary and nearest neighbor in one pass
-        # Clip to valid range. Everything reaching here is inside the axis,
-        # so this only pins searchsorted's one-past-the-end result for a
-        # value equal to axis[-1]; it can no longer pull an outside peak in.
-        indices_clipped = np.clip(indices, 0, len(axis) - 1)
+    def _build_nn_shared_cache(
+        self, axis: NDArray[np.float64], mzs: NDArray[np.float64]
+    ) -> Optional[_SharedAxisNNCache]:
+        """Precompute the nearest-neighbor mapping for one m/z array.
 
-        # For non-boundary points, check if left is closer
-        # Only check where we're not at the left edge
-        check_left = indices > 0
-        if np.any(check_left):
-            # Get distances only for points that need checking
-            mz_values = axis[indices_clipped[check_left]]
-            mz_values_left = axis[indices_clipped[check_left] - 1]
-            mz_query = mzs[check_left]
+        Returns None when the array cannot be cached -- empty, or not
+        ascending, which the contiguous in-range slice below relies on.
+        The mapping itself comes from the same :meth:`_nn_map_to_bins`
+        the generic path uses, so a cache hit and a fresh computation
+        agree bin for bin.
+        """
+        if mzs.size == 0 or not bool(np.all(mzs[1:] >= mzs[:-1])):
+            return None
 
-            # Use left if it's closer
-            use_left = np.abs(mz_values_left - mz_query) < np.abs(mz_values - mz_query)
-            indices_clipped[check_left] = np.where(
-                use_left, indices_clipped[check_left] - 1, indices_clipped[check_left]
-            )
+        # Ascending m/z makes the in-range subset one contiguous slice,
+        # with the same inclusive endpoints as the generic path's mask.
+        lo = int(np.searchsorted(mzs, axis[0], side="left"))
+        hi = int(np.searchsorted(mzs, axis[-1], side="right"))
 
-        # OPTIMIZATION: Use pandas-style groupby or bincount for accumulation
-        # bincount without minlength is fastest
-        accumulated = np.bincount(indices_clipped, weights=intensities)
+        cache = _SharedAxisNNCache()
+        cache.key = mzs.copy()
+        cache.key_ref = mzs
+        cache.n_total = int(mzs.size)
+        cache.n_dropped = int(mzs.size - (hi - lo))
+        cache.lo = lo
+        cache.hi = hi
+        if hi <= lo:
+            cache.starts = None
+            cache.bins = np.array([], dtype=np.int_)
+            return cache
 
-        # Extract non-zero bins for sparse representation. The test is
-        # ``!= 0`` rather than ``> 0`` because a bin whose accumulated value is
-        # negative is still a measurement: dropping it silently raises the
-        # stored TIC above the input's. Baseline-subtracted data can carry
-        # negative intensities, though every export seen so far filters them
-        # out upstream.
-        nonzero_mask = accumulated != 0
-        nonzero_indices = np.where(nonzero_mask)[0].astype(np.int_)
-        nonzero_values = accumulated[nonzero_mask]
+        idx = _nn_map_to_bins(axis, mzs[lo:hi])
+        # Ascending m/z onto an ascending axis gives non-decreasing bins,
+        # so equal bins form contiguous runs.
+        starts = np.concatenate(([0], np.flatnonzero(np.diff(idx)) + 1))
+        if starts.size == idx.size:
+            # Every peak in its own bin: per-spectrum work reduces to a
+            # zero-filter over the raw intensities.
+            cache.starts = None
+            cache.bins = idx.astype(np.int_, copy=False)
+        else:
+            cache.starts = starts
+            cache.bins = idx[starts].astype(np.int_, copy=False)
+        return cache
 
-        return nonzero_indices, nonzero_values.astype(np.float64)
+    def _nn_resample_via_cache(
+        self,
+        axis: NDArray[np.float64],
+        mzs: NDArray[np.float64],
+        intensities: NDArray[np.float64],
+    ) -> Optional[Tuple[NDArray[np.int_], NDArray[np.float64]]]:
+        """Resample through the shared-axis cache, or return None to decline.
+
+        The cache is built from the first spectrum seen. A hit requires the
+        spectrum's m/z array to be the cached one -- same object, or equal
+        element for element -- so a lying reader cannot get a stale mapping;
+        it can only miss. After five consecutive misses the cache disables
+        itself so processed-mode data stops paying for the comparison
+        (its size check is O(1) in the common case anyway).
+        """
+        cache = self._nn_shared_cache
+        if cache is False:
+            return None
+        if cache is None:
+            cache = self._build_nn_shared_cache(axis, mzs)
+            if cache is None:
+                self._nn_shared_cache = False
+                return None
+            self._nn_shared_cache = cache
+
+        if not (
+            mzs is cache.key_ref
+            or (mzs.size == cache.n_total and bool(np.array_equal(mzs, cache.key)))
+        ):
+            self._nn_cache_misses += 1
+            if self._nn_cache_misses > 4:
+                self._nn_shared_cache = False
+            return None
+
+        if cache.n_dropped:
+            self._count_out_of_range(cache.n_dropped, cache.n_total)
+        if cache.hi <= cache.lo:
+            return np.array([], dtype=np.int_), np.array([], dtype=np.float64)
+
+        # Match bincount's float64 promotion so cached and generic results
+        # carry the same rounding.
+        vals = intensities[cache.lo : cache.hi].astype(np.float64, copy=False)
+        if cache.starts is None:
+            sums = vals
+        else:
+            sums = np.add.reduceat(vals, cache.starts)
+        keep = sums != 0
+        return cache.bins[keep], sums[keep]
 
     def _tic_preserving_resample(
         self, mzs: NDArray[np.float64], intensities: NDArray[np.float64]
@@ -1697,6 +1898,8 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 )
         else:
             # Standard physical coordinates (micrometers)
+            from shapely import box as shapely_box_vectorized
+
             x_coords: NDArray[np.float64] = adata.obs["spatial_x"].values
             y_coords: NDArray[np.float64] = adata.obs["spatial_y"].values
             half_pixel_um = self.pixel_size_um / 2
@@ -1704,12 +1907,15 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             # Footprints are flat, on every route including volumes. A
             # slice's depth lives on the TIC image's Scale and in
             # obs["spatial_z"]; see the docstring for why it is not also
-            # put on the geometry.
-            for i in range(len(adata)):
-                x, y = x_coords[i], y_coords[i]
-                x0, y0 = x - half_pixel_um, y - half_pixel_um
-                x1, y1 = x + half_pixel_um, y + half_pixel_um
-                geometries.append(box(x0, y0, x1, y1))
+            # put on the geometry. Built through shapely's vectorised box
+            # constructor -- one C call for the whole table instead of one
+            # Python-level geometry per pixel.
+            geometries = shapely_box_vectorized(
+                x_coords - half_pixel_um,
+                y_coords - half_pixel_um,
+                x_coords + half_pixel_um,
+                y_coords + half_pixel_um,
+            )
 
         # Create GeoDataFrame with appropriate index
         if valid_indices is not None:

--- a/thyra/converters/spatialdata/spatialdata_2d_converter.py
+++ b/thyra/converters/spatialdata/spatialdata_2d_converter.py
@@ -206,20 +206,30 @@ class SpatialData2DConverter(BaseSpatialDataConverter):
         # Calculate TIC for this pixel
         tic_value = float(np.sum(intensities))
 
-        # Update total intensity for average spectrum calculation using sparse indexing
-        # OPTIMIZATION: Use np.add.at for vectorized sparse accumulation
-        np.add.at(data_structures["total_intensity"], mz_indices, intensities)
+        # Update total intensity for average spectrum calculation. The dense
+        # resampling path hands the cached full-axis arange, where a plain
+        # vector add is ~5x cheaper than the scatter np.add.at performs;
+        # sparse indices keep the scatter.
+        total_intensity = data_structures["total_intensity"]
+        is_dense = (
+            mz_indices is self._cached_mass_axis_indices
+            or mz_indices is self._identity_mass_indices
+        ) and intensities.size == total_intensity.size
+        if is_dense:
+            total_intensity += intensities
+        else:
+            np.add.at(total_intensity, mz_indices, intensities)
         data_structures["pixel_count"] += 1
 
         # Per-region accumulation for multi-region datasets
         if "region_total_intensity" in data_structures:
             region_num = self._region_map.get((x, y), -1)
             if region_num in data_structures["region_total_intensity"]:
-                np.add.at(
-                    data_structures["region_total_intensity"][region_num],
-                    mz_indices,
-                    intensities,
-                )
+                region_total = data_structures["region_total_intensity"][region_num]
+                if is_dense:
+                    region_total += intensities
+                else:
+                    np.add.at(region_total, mz_indices, intensities)
                 data_structures["region_pixel_count"][region_num] += 1
 
         # Add data to the appropriate slice

--- a/thyra/converters/spatialdata/spatialdata_3d_converter.py
+++ b/thyra/converters/spatialdata/spatialdata_3d_converter.py
@@ -120,12 +120,17 @@ class SpatialData3DConverter(BaseSpatialDataConverter):
             # Resampled case - intensities match common mass axis length
             data_structures["total_intensity"] += intensities
         else:
-            # Non-resampled case - need to map to indices
-            for i, intensity in enumerate(intensities):
-                if i < len(mz_indices) and mz_indices[i] < len(
-                    data_structures["total_intensity"]
-                ):
-                    data_structures["total_intensity"][mz_indices[i]] += intensity
+            # Sparse case - scatter onto the mapped indices. Guard the
+            # lengths the way the old per-element loop did: only pairs
+            # that exist in both arrays, only in-bounds indices.
+            n = min(len(intensities), len(mz_indices))
+            idx = mz_indices[:n]
+            in_bounds = idx < len(data_structures["total_intensity"])
+            np.add.at(
+                data_structures["total_intensity"],
+                idx[in_bounds],
+                intensities[:n][in_bounds],
+            )
         data_structures["pixel_count"] += 1
 
         # Per-region accumulation for multi-region datasets

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -24,6 +24,7 @@ from numpy.typing import NDArray
 from scipy import sparse
 from tqdm import tqdm
 
+from ...resampling import ResamplingMethod
 from .base_spatialdata_converter import (
     SPATIALDATA_AVAILABLE,
     BaseSpatialDataConverter,
@@ -124,6 +125,15 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         self._use_csc = use_csc
         self._zarr_store: Optional[zarr.Group] = None
         self._temp_path: Optional[Path] = None
+
+        # Resolved once here rather than per spectrum: _process_spectrum is
+        # the hottest call in both passes, and re-importing ResamplingMethod
+        # plus re-checking the attribute there measured ~35 us per call.
+        self._nn_route: bool = (
+            self._resampling_config is not None
+            and getattr(self, "_resampling_method", None)
+            == ResamplingMethod.NEAREST_NEIGHBOR
+        )
 
     def _suppress_reader_progress(self) -> None:
         """Suppress progress output from reader during streaming passes."""
@@ -750,19 +760,17 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         all_idx = all_idx[order]
         all_dat = all_dat[order]
 
-        # Write contiguous runs in bulk
+        # Find run boundaries vectorised, then write one Zarr slice per
+        # contiguous run. The previous element-at-a-time Python walk cost
+        # ~2.5 s per 5M-entry flush against ~27 ms for the same answer.
         n = len(all_pos)
-        i = 0
-        while i < n:
-            start_pos = all_pos[i]
-            # Find end of contiguous run
-            j = i + 1
-            while j < n and all_pos[j] == all_pos[j - 1] + 1:
-                j += 1
-            # Write the contiguous block
-            indices_arr[int(start_pos) : int(start_pos) + (j - i)] = all_idx[i:j]
-            data_arr[int(start_pos) : int(start_pos) + (j - i)] = all_dat[i:j]
-            i = j
+        breaks = np.flatnonzero(np.diff(all_pos) != 1)
+        starts = np.concatenate(([0], breaks + 1))
+        ends = np.concatenate((breaks + 1, [n]))
+        for i, j in zip(starts.tolist(), ends.tolist()):
+            start_pos = int(all_pos[i])
+            indices_arr[start_pos : start_pos + (j - i)] = all_idx[i:j]
+            data_arr[start_pos : start_pos + (j - i)] = all_dat[i:j]
 
         del all_pos, all_idx, all_dat
         gc.collect()
@@ -787,21 +795,18 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
             mz_indices = self._map_mass_to_indices(mzs)
             return mz_indices, intensities
 
-        # Check for optimized nearest-neighbor path
-        if hasattr(self, "_resampling_method"):
-            from ...resampling import ResamplingMethod
-
-            if self._resampling_method == ResamplingMethod.NEAREST_NEIGHBOR:
-                mz_indices, resampled = self._nearest_neighbor_resample(
-                    mzs, intensities
-                )
-                return mz_indices, resampled
+        # Optimized nearest-neighbor path; the route is resolved once in
+        # __init__ because this runs once per spectrum per pass.
+        if self._nn_route:
+            return self._nearest_neighbor_resample(mzs, intensities)
 
         # Fallback: general resampling with zero filtering
         resampled_ints = self._resample_spectrum(mzs, intensities)
         if self._common_mass_axis is None:
             raise RuntimeError("Common mass axis not initialized")
-        mz_indices = np.arange(len(self._common_mass_axis))
+        mz_indices = self._cached_mass_axis_indices
+        if mz_indices is None or mz_indices.size != len(self._common_mass_axis):
+            mz_indices = np.arange(len(self._common_mass_axis))
         mask = resampled_ints != 0
         return mz_indices[mask], resampled_ints[mask]
 
@@ -1373,10 +1378,6 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         # Current write position for each column
         write_pos = indptr[:-1].copy()
 
-        # Periodic flush to reduce memory pressure
-        flush_interval = 100_000
-        spectra_since_flush = 0
-
         # Reset reader for second pass
         # For real readers (ImzML, Bruker), iter_spectra() is a generator factory
         # that creates a fresh iterator each time - no need to recreate the reader.
@@ -1419,15 +1420,13 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                     write_pos[mz_indices] += 1
 
                 pbar.update(1)
-                spectra_since_flush += 1
 
-                # Periodic flush
-                if spectra_since_flush >= flush_interval:
-                    mm_indices.flush()
-                    mm_data.flush()
-                    spectra_since_flush = 0
-
-        # Final flush
+        # One flush at the end. A periodic flush used to run every 100k
+        # spectra, but ``np.memmap.flush`` writes back the whole mapping
+        # synchronously, serialising disk writeback into the compute loop;
+        # the OS pager already writes dirty pages back in the background.
+        # Scatter writes each position exactly once, so nothing is dirtied
+        # twice and the deferred writeback costs the same total I/O.
         mm_indices.flush()
         mm_data.flush()
 

--- a/thyra/core/base_converter.py
+++ b/thyra/core/base_converter.py
@@ -110,6 +110,11 @@ class BaseMSIConverter(ABC):
         self.z_spacing_source = ZSpacingSource.ASSUMED_ISOTROPIC
         self.options: Dict[str, Any] = kwargs
         self._common_mass_axis: Optional[NDArray[np.float64]] = None
+        # Identity-mapping cache for _map_mass_to_indices: shared-axis
+        # readers hand every spectrum the very m/z array the common axis
+        # was built from, so the exact-match search is the identity map.
+        self._identity_mass_indices: Optional[NDArray[np.int_]] = None
+        self._axis_strictly_increasing: Optional[bool] = None
         self._dimensions: Optional[Tuple[int, int, int]] = None
         self._metadata: Optional[dict[str, Any]] = None
         from ..config import DEFAULT_BUFFER_SIZE
@@ -580,16 +585,37 @@ class BaseMSIConverter(ABC):
         if mzs.size == 0:
             return np.array([], dtype=int)
 
+        axis = self._common_mass_axis
+
+        # Identity fast path. On a shared-axis reader (continuous imzML,
+        # Rapiflex, Waters, PHI) every spectrum's m/z array is the very
+        # array the common axis was built from, so the exact-match search
+        # below returns 0..n-1 -- yet used to be re-derived by binary
+        # search per spectrum, twice per streaming conversion. Equality is
+        # proven, not assumed: an O(1) size check gates a full array
+        # comparison, and the arange shortcut is only valid when the axis
+        # is strictly increasing (searchsorted maps duplicates to their
+        # first occurrence, which is not the identity).
+        if mzs.size == axis.size and (mzs is axis or bool(np.array_equal(mzs, axis))):
+            if self._axis_strictly_increasing is None:
+                self._axis_strictly_increasing = bool(np.all(np.diff(axis) > 0))
+            if self._axis_strictly_increasing:
+                cached = self._identity_mass_indices
+                if cached is None or cached.size != axis.size:
+                    cached = np.arange(axis.size, dtype=np.intp)
+                    self._identity_mass_indices = cached
+                return cached
+
         # Use searchsorted for exact mapping
-        indices = np.searchsorted(self._common_mass_axis, mzs)
+        indices = np.searchsorted(axis, mzs)
 
         # Ensure indices are within bounds
-        indices = np.clip(indices, 0, len(self._common_mass_axis) - 1)
+        indices = np.clip(indices, 0, len(axis) - 1)
 
         # For complete accuracy, validate the indices
         # Very small tolerance threshold for floating point differences
         max_diff = 1e-6
-        mask = np.abs(self._common_mass_axis[indices] - mzs) <= max_diff
+        mask = np.abs(axis[indices] - mzs) <= max_diff
 
         return indices[mask]
 

--- a/thyra/metadata/extractors/imzml_extractor.py
+++ b/thyra/metadata/extractors/imzml_extractor.py
@@ -15,6 +15,7 @@ from ...resampling.constants import (
     SpectrumType,
     normalize_spectrum_type,
 )
+from ...utils.pyimzml_direct import read_spectrum_mzs_only
 from ..types import ComprehensiveMetadata, EssentialMetadata
 
 logger = logging.getLogger(__name__)
@@ -382,7 +383,12 @@ class ImzMLMetadataExtractor(MetadataExtractor):
             Tuple of (min_mz, max_mz, n_peaks) or None if failed.
         """
         try:
-            mzs, intensities = self.parser.getspectrum(idx)
+            # Read and decode the m/z array only. The scan needs the m/z
+            # extrema and the peak count; the intensity array -- half the
+            # bytes read per spectrum -- was fetched and immediately
+            # discarded. Parsers without pyimzml's offset tables fall back
+            # to the documented getspectrum.
+            mzs = read_spectrum_mzs_only(self.parser, idx)
             n_peaks = len(mzs)
 
             # Store per-pixel count if tracking
@@ -391,15 +397,9 @@ class ImzMLMetadataExtractor(MetadataExtractor):
                     idx, coords, dimensions, peak_counts, n_peaks
                 )
 
-            # Release references
-            del intensities
-
             if n_peaks > 0:
-                result = (float(np.min(mzs)), float(np.max(mzs)), n_peaks)
-                del mzs
-                return result
+                return (float(np.min(mzs)), float(np.max(mzs)), n_peaks)
 
-            del mzs
             return None
 
         except Exception as e:

--- a/thyra/readers/imzml/imzml_reader.py
+++ b/thyra/readers/imzml/imzml_reader.py
@@ -19,6 +19,7 @@ from ...core.base_reader import BaseMSIReader
 from ...core.registry import register_reader
 from ...metadata.extractors.imzml_extractor import ImzMLMetadataExtractor
 from ...resampling.constants import normalize_spectrum_type
+from ...utils.pyimzml_direct import read_spectrum_mzs_only
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +68,14 @@ _ZLIB_NAME = "zlib compression"
 # spec-legal, pyimzml's own writer emits it for ``intensity_dtype=np.int32``,
 # and it converts correctly today.
 _PLATFORM_DEPENDENT_PRECISIONS = frozenset({"l"})
+
+
+# A coalescing block reader for the .ibd was built and benchmarked here on
+# 2026-08-26 and then removed: with the OS page cache warm, a 120k-spectrum
+# iteration pass costs ~0.75 s whether reads are per-spectrum seek+read
+# pairs or 8 MiB windows -- small cached reads are a few microseconds, so
+# there was nothing to coalesce away. Do not re-add one without a
+# measurement on storage where it wins (cold cache, network shares).
 
 
 class _OffsetArrays(NamedTuple):
@@ -308,6 +317,13 @@ def _merge_disjoint(box_a: List[Any], box_b: List[Any]) -> NDArray[Any]:
 def _read_spectrum_mzs(parser: Any, idx: int) -> Optional[NDArray[Any]]:
     """Read one spectrum's m/z values, or None if missing or unreadable.
 
+    Reads and decodes the m/z binary array only, with the same
+    seek/read/frombuffer sequence pyimzml's ``getspectrum`` performs --
+    that call also fetches the intensity array, which this caller (the
+    processed-mode mass axis build) immediately discards, doubling the
+    bytes read per spectrum for nothing. Duck-typed parsers without
+    pyimzml's offset tables fall back to ``getspectrum``.
+
     Args:
         parser: An initialized ImzML parser.
         idx: Spectrum index.
@@ -316,14 +332,13 @@ def _read_spectrum_mzs(parser: Any, idx: int) -> Optional[NDArray[Any]]:
         The m/z array, or None when the spectrum is empty or failed to read.
     """
     try:
-        spectrum_data = parser.getspectrum(idx)
+        mzs = read_spectrum_mzs_only(parser, idx)
     except Exception as e:
         logger.warning(f"Error getting spectrum {idx}: {e}")
         return None
 
-    if spectrum_data is None or len(spectrum_data) < 1:
+    if mzs is None:
         return None
-    mzs = spectrum_data[0]
     return mzs if mzs.size else None
 
 
@@ -535,6 +550,13 @@ class ImzMLReader(BaseMSIReader):
         )
         self._z_base_value: Optional[int] = None  # See _z_base()
 
+        # Continuous-mode fast read: the shared m/z block, and whether the
+        # file really does point every spectrum at one block -- verified
+        # from the offsets, not assumed from the declared mode. See
+        # _read_spectrum_arrays.
+        self._continuous_mzs: Optional[NDArray[np.float64]] = None
+        self._continuous_uniform: bool = False
+
         # Store path but don't initialize parser yet - wait for first use
         if data_path is not None:
             self.filepath = data_path
@@ -720,6 +742,18 @@ class ImzMLReader(BaseMSIReader):
         arrays = _offset_arrays(parser)
         self._validate_offset_arrays(arrays)
         self._validate_ibd_extent(parser, arrays)
+
+        # Does every spectrum point at one shared m/z block? True for a
+        # well-formed continuous file, and the licence for the fast read in
+        # _read_spectrum_arrays -- measured off the offsets rather than
+        # trusted from the declared mode, so a file that declares
+        # continuous while writing per-spectrum m/z blocks is read the
+        # slow, correct way instead of being handed spectrum 0's axis.
+        if self.is_continuous and arrays.mz_offsets.size:
+            self._continuous_uniform = bool(
+                (arrays.mz_offsets == arrays.mz_offsets[0]).all()
+                and (arrays.mz_lengths == arrays.mz_lengths[0]).all()
+            )
 
         n_scan_settings = len(parser.metadata.scan_settings)
         if n_scan_settings != 1:
@@ -1031,15 +1065,23 @@ class ImzMLReader(BaseMSIReader):
 
             if self.is_continuous:
                 logger.info("Using m/z values from first spectrum (continuous mode)")
-                spectrum_data = parser.getspectrum(0)
-                if spectrum_data is None or len(spectrum_data) < 1:
-                    raise ValueError("Could not get first spectrum")
+                if self._continuous_mzs is not None:
+                    # Iteration already decoded the shared block; reuse the
+                    # object so axis and yielded m/z stay identity-equal
+                    # whichever is asked for first.
+                    self._common_mass_axis = self._continuous_mzs
+                else:
+                    spectrum_data = parser.getspectrum(0)
+                    if spectrum_data is None or len(spectrum_data) < 1:
+                        raise ValueError("Could not get first spectrum")
 
-                mzs = spectrum_data[0]
-                if mzs.size == 0:
-                    raise ValueError("First spectrum contains no m/z values")
+                    mzs = spectrum_data[0]
+                    if mzs.size == 0:
+                        raise ValueError("First spectrum contains no m/z values")
 
-                self._common_mass_axis = mzs
+                    self._common_mass_axis = mzs
+                    if self._continuous_uniform:
+                        self._continuous_mzs = mzs
             else:
                 self._common_mass_axis = self._extract_continuous_mass_axis(parser)
 
@@ -1164,6 +1206,53 @@ class ImzMLReader(BaseMSIReader):
             (x - 1, y - 1, z - self._z_base()),
         )
 
+    def _read_spectrum_arrays(
+        self, parser: ImzMLParser, idx: int
+    ) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
+        """Read one spectrum's arrays, reusing the shared m/z block when legal.
+
+        pyimzml's ``getspectrum`` seeks and decodes both binary arrays on
+        every call. In continuous mode every spectrum references the same
+        m/z block (verified against the offsets at init -- see
+        ``_continuous_uniform``), so re-reading it per spectrum roughly
+        triples the decode work: measured ~1.6 ms per 331k-point spectrum
+        for both arrays against ~0.5 ms for the intensities alone, paid
+        twice per streaming conversion. Here the m/z block is decoded once
+        and only the intensity bytes are read per spectrum, with the same
+        seek/read/frombuffer sequence pyimzml itself performs.
+
+        Args:
+            parser: An initialized ImzML parser.
+            idx: Spectrum index.
+
+        Returns:
+            The (m/z, intensity) arrays, exactly as ``getspectrum`` would.
+        """
+        if not self._continuous_uniform:
+            return cast(
+                Tuple[NDArray[np.float64], NDArray[np.float64]],
+                parser.getspectrum(idx),
+            )
+
+        mzs = self._continuous_mzs
+        if mzs is None:
+            # Prefer the axis object get_common_mass_axis cached, so the
+            # arrays this yields are identity-equal to the converter's
+            # common axis and its equality checks cost O(1).
+            if self._common_mass_axis is not None:
+                mzs = self._continuous_mzs = self._common_mass_axis
+            else:
+                mzs, intensities = parser.getspectrum(idx)
+                self._continuous_mzs = mzs
+                return mzs, intensities
+
+        m = parser.m
+        m.seek(parser.intensityOffsets[idx])
+        data = m.read(
+            parser.intensityLengths[idx] * parser.sizeDict[parser.intensityPrecision]
+        )
+        return mzs, np.frombuffer(data, dtype=parser.intensityPrecision)
+
     def _process_single_spectrum(
         self, parser: ImzMLParser, idx: int, pbar
     ) -> Optional[
@@ -1172,7 +1261,7 @@ class ImzMLReader(BaseMSIReader):
         """Process a single spectrum and return its data."""
         try:
             coords = self._get_spectrum_coordinates(parser, idx)
-            mzs, intensities = parser.getspectrum(idx)
+            mzs, intensities = self._read_spectrum_arrays(parser, idx)
 
             # Apply intensity threshold filtering if configured
             mzs, intensities = self._apply_intensity_filter(mzs, intensities)
@@ -1354,31 +1443,21 @@ class ImzMLReader(BaseMSIReader):
     def get_total_peak_count(self) -> int:
         """Get total number of peaks across all spectra.
 
-        For ImzML, this requires iterating through spectra to count peaks.
+        The imzML header already declares every spectrum's array length
+        (``IMS:1000103``, held in ``parser.mzLengths``), so this is a sum
+        over an in-memory list. It used to read and decode every binary
+        array in the file to count values whose count was already known.
 
         Returns:
             Total number of peaks across all spectra
         """
         self._ensure_parser_initialized()
         parser = cast(ImzMLParser, self.parser)
-        total_spectra = len(parser.coordinates)
 
-        logger.info("Counting peaks across all spectra for exact allocation...")
-        total_peaks = 0
-
-        with tqdm(
-            total=total_spectra,
-            desc="Counting peaks",
-            unit="spectrum",
-        ) as pbar:
-            for idx in range(total_spectra):
-                try:
-                    mzs, _ = parser.getspectrum(idx)
-                    total_peaks += len(mzs)
-                except Exception as e:
-                    logger.warning(f"Error getting spectrum {idx}: {e}")
-                pbar.update(1)
-
+        n = len(parser.mzLengths)
+        total_peaks = int(
+            np.sum(np.fromiter(parser.mzLengths, dtype=np.int64, count=n))
+        )
         logger.info(f"Total peak count: {total_peaks:,}")
         return total_peaks
 

--- a/thyra/utils/pyimzml_direct.py
+++ b/thyra/utils/pyimzml_direct.py
@@ -1,0 +1,72 @@
+"""Direct .ibd reads against pyimzml's offset tables, m/z array only.
+
+pyimzml's ``getspectrum`` seeks and decodes *both* binary arrays on every
+call. Two hot paths -- the processed-mode mass-axis build and the
+processed-mode metadata scan -- need only the m/z array, so going through
+``getspectrum`` doubles the bytes read and decoded per spectrum for
+nothing. The functions here perform the same seek/read/frombuffer sequence
+pyimzml itself performs, for the m/z half alone.
+
+The fast path is gated on the parser carrying pyimzml's *actual* data
+structures, checked by type rather than by presence: test doubles and
+wrappers (including ``unittest.mock.Mock``, which fabricates any attribute
+asked of it) fall back to the documented ``getspectrum`` API.
+"""
+
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def has_direct_tables(parser: Any) -> bool:
+    """Whether ``parser`` carries pyimzml's real offset tables.
+
+    Args:
+        parser: A (possibly duck-typed) ImzML parser.
+
+    Returns:
+        True when the m/z-only read in :func:`read_mzs_direct` is legal.
+    """
+    return (
+        isinstance(getattr(parser, "mzOffsets", None), (list, np.ndarray))
+        and isinstance(getattr(parser, "mzLengths", None), (list, np.ndarray))
+        and isinstance(getattr(parser, "sizeDict", None), dict)
+        and getattr(parser, "m", None) is not None
+    )
+
+
+def read_mzs_direct(parser: Any, idx: int) -> NDArray[Any]:
+    """Read one spectrum's m/z array without touching its intensities.
+
+    Callers must have checked :func:`has_direct_tables` first.
+
+    Args:
+        parser: An initialized pyimzml ImzMLParser.
+        idx: Spectrum index.
+
+    Returns:
+        The m/z array, exactly as ``getspectrum(idx)[0]`` would return it.
+    """
+    n = int(parser.mzLengths[idx])
+    if n <= 0:
+        return np.array([], dtype=np.float64)
+    parser.m.seek(parser.mzOffsets[idx])
+    data = parser.m.read(n * parser.sizeDict[parser.mzPrecision])
+    return np.frombuffer(data, dtype=parser.mzPrecision)
+
+
+def read_spectrum_mzs_only(parser: Any, idx: int) -> NDArray[Any]:
+    """Read one spectrum's m/z values by the cheapest legal route.
+
+    Args:
+        parser: A (possibly duck-typed) ImzML parser.
+        idx: Spectrum index.
+
+    Returns:
+        The m/z array. Falls back to ``getspectrum`` for parsers without
+        pyimzml's offset tables.
+    """
+    if has_direct_tables(parser):
+        return read_mzs_direct(parser, idx)
+    return parser.getspectrum(idx)[0]


### PR DESCRIPTION
## What

CPU-side optimization pass over the conversion pathway. Shared-axis data (continuous imzML, Rapiflex, Waters, PHI) hands every spectrum the same m/z array, yet the peak-to-bin mapping was re-derived by binary search per spectrum -- twice per streaming conversion -- and pyimzml re-read and re-decoded the identical m/z block from disk on every `getspectrum` call.

- **Shared-axis nearest-neighbor cache**: the mapping is computed once and each later spectrum proves its m/z array is the same one (object identity or exact array equality against a private copy); five consecutive misses disable it so processed-mode data stops paying for the comparison. Measured 339 us -> 13 us per centroid spectrum, 5.6 ms -> 0.6 ms per 190k-bin profile spectrum.
- **Run-based accumulation** for the generic path: `np.add.reduceat` over contiguous bin runs when the mapping is monotone -- O(n_peaks) instead of the O(n_bins) `bincount`, 7x per 800-peak spectrum at 190k bins, with the bincount kept as the fallback for unsorted input.
- **Identity fast path in `_map_mass_to_indices`**: the no-resample continuous case maps the axis onto itself; 28 ms of searchsorted per spectrum at 331k bins becomes one equality check and a cached arange, guarded against duplicate-valued axes where the shortcut would be wrong.
- **Continuous-mode intensity-only reads**: the shared m/z block is decoded once; legality is measured off the offset tables at init (all m/z offsets and lengths equal), not trusted from the declared mode. `get_common_mass_axis` and `iter_spectra` now share one m/z object in either call order.
- **m/z-only metadata scans**: the processed-mode mass-range scan and raw-axis build stop fetching intensity arrays they discard; `get_total_peak_count` sums `parser.mzLengths` instead of reading the whole file.
- **Hot-loop hygiene**: per-spectrum import hoisted out of the streaming dispatcher (35 us/call); COO flush run detection vectorized (2.5 s -> 27 ms per 5M-entry flush); base pixel shapes built through vectorized `shapely.box`; dense accumulation via plain vector add (5x over `add.at` on a full arange); the 3D sparse fallback's per-element Python loop replaced with `np.add.at`; the PCS scatter's periodic whole-mapping synchronous memmap flush removed (final flush kept).

## Verification

**Output is bit-identical.** Seven synthetic stores (PCS shared-axis NN/raw and centroid, COO on both readers, in-memory on both; 215 arrays) and two pyimzml-written real files (70 arrays) were converted with the pre-change and post-change code and compared element for element -- zero differences. New regression tests pin the cache's invisibility (hits match the generic path exactly, mismatched arrays miss into it, misses disable it, out-of-range counting is identical, duplicate axes keep searchsorted semantics) and the reader fast path (every yielded array compared against raw pyimzml `getspectrum`, both file modes, two-pass agreement).

Measured end to end: shared-axis profile with NN resampling 17.2 s -> 9.8 s.

## Also tried, measured, and rejected

A coalescing .ibd block reader: with a warm page cache a 120k-spectrum iteration pass costs ~0.75 s with or without it, so it was removed rather than shipped. A note in `imzml_reader.py` records what measurement would justify one.