### PR TITLE
fix: refuse silent peak drops in _map_mass_to_indices

### DIFF
--- a/tests/unit/converters/test_mass_to_indices_alignment.py
+++ b/tests/unit/converters/test_mass_to_indices_alignment.py
@@ -1,0 +1,108 @@
+"""``_map_mass_to_indices`` must stay parallel to the intensity array.
+
+``BaseMSIConverter._map_mass_to_indices`` used to validate its
+``searchsorted`` result against a 1e-6 tolerance and return only the
+indices that passed -- but every caller pairs the returned indices with
+the ORIGINAL, unfiltered intensity array.  The streaming converter's
+``_process_spectrum`` returns ``(mz_indices, intensities)`` straight into
+the PCS/COO passes, which do ``np.add.at(total_intensity, mz_indices,
+ints)`` and positional row writes on the assumption that the two arrays
+are parallel.  Had the tolerance mask ever fired, the arrays would have
+desynced: a length mismatch crash in some paths, intensities summed into
+the wrong m/z bins in others.
+
+The mask never fired on well-formed data (continuous mode yields the
+axis itself; a processed-mode raw axis is the union of every spectrum's
+m/z values, so every lookup matches exactly), which is why the desync
+was never observed.  These tests pin the corrected contract:
+
+- the returned index array is always parallel to the input ``mzs``;
+- a value with no axis entry within tolerance raises ``ValueError``
+  instead of being dropped silently (a near-miss means the axis and the
+  data have diverged -- that is corrupt input, not something to paper
+  over);
+- a value within tolerance maps to its NEAREST axis entry, even when
+  ``searchsorted`` lands on the far side of it.
+
+Contrast ``BaseMSIReader.map_mz_to_common_axis``, which filters indices
+and intensities together and so was never affected.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from tests.fixtures.mock_msi_generator import MockMSIConfig, MockMSIReader
+from thyra.converters.spatialdata.streaming_converter import (
+    SPATIALDATA_AVAILABLE,
+    StreamingSpatialDataConverter,
+)
+
+pytestmark = pytest.mark.skipif(
+    not SPATIALDATA_AVAILABLE,
+    reason="SpatialData dependencies not available",
+)
+
+
+@pytest.fixture
+def converter(tmp_path: Path) -> StreamingSpatialDataConverter:
+    """A streaming converter on the no-resample path with a loaded axis."""
+    reader = MockMSIReader(MockMSIConfig(n_x=3, n_y=3, n_mz_bins=1001))
+    conv = StreamingSpatialDataConverter(
+        reader=reader,
+        output_path=tmp_path / "out.zarr",
+        dataset_id="mock",
+        pixel_size_um=10.0,
+    )
+    conv._initialize_conversion()
+    assert conv._resampling_config is None
+    return conv
+
+
+class TestOffAxisMzRaises:
+    """One off-axis m/z value must abort the spectrum, not vanish."""
+
+    @pytest.mark.parametrize(
+        "off_axis",
+        [
+            pytest.param(lambda axis: (axis[200] + axis[201]) / 2, id="mid-bin"),
+            pytest.param(lambda axis: axis[0] - 1.0, id="below-range"),
+            pytest.param(lambda axis: axis[-1] + 1.0, id="above-range"),
+        ],
+    )
+    def test_streaming_no_resample_path(self, converter, off_axis):
+        axis = converter._common_mass_axis
+        mzs = np.array([axis[10], axis[50], off_axis(axis), axis[400]])
+        intensities = np.array([1.0, 2.0, 3.0, 4.0])
+
+        with pytest.raises(ValueError, match="no common mass axis entry"):
+            converter._process_spectrum(mzs, intensities)
+
+
+class TestParallelReturn:
+    """Indices come back parallel to the input arrays."""
+
+    def test_exact_matches_map_positionally(self, converter):
+        axis = converter._common_mass_axis
+        positions = np.array([0, 17, 500, 1000])
+        mzs = axis[positions]
+        intensities = np.array([10.0, 20.0, 30.0, 40.0])
+
+        mz_indices, out_intensities = converter._process_spectrum(mzs, intensities)
+
+        np.testing.assert_array_equal(mz_indices, positions)
+        np.testing.assert_array_equal(out_intensities, intensities)
+
+    def test_fp_noise_maps_to_nearest_entry(self, converter):
+        # A value a hair ABOVE an axis entry lands on the far neighbor via
+        # searchsorted; the old one-sided check dropped it silently even
+        # though it sits well within the documented 1e-6 tolerance.
+        axis = converter._common_mass_axis
+        mzs = np.array([axis[5] + 1e-9, axis[7] - 1e-9])
+        intensities = np.array([1.0, 2.0])
+
+        mz_indices, out_intensities = converter._process_spectrum(mzs, intensities)
+
+        np.testing.assert_array_equal(mz_indices, [5, 7])
+        np.testing.assert_array_equal(out_intensities, intensities)

--- a/tests/unit/converters/test_streaming_converter.py
+++ b/tests/unit/converters/test_streaming_converter.py
@@ -88,13 +88,11 @@ class MockMSIReader:
 
         Peaks are drawn from the very axis :meth:`get_common_mass_axis`
         reports, not merely from the same mass RANGE. Without resampling,
-        ``BaseMSIConverter._map_mass_to_indices`` keeps only the peaks
-        landing within 1e-6 Da of a common-axis point and silently drops
-        the rest, so m/z values that just fall inside the range map to
-        nothing: every spectrum arrives empty, the occupancy is empty,
-        and the shapes frame is built from zero pixels. A mock whose two
-        methods describe different mass axes is not a stand-in for any
-        real reader.
+        ``BaseMSIConverter._map_mass_to_indices`` requires every peak to
+        land within 1e-6 Da of a common-axis point and raises for any
+        that do not, so m/z values that just fall inside the range would
+        abort the conversion. A mock whose two methods describe
+        different mass axes is not a stand-in for any real reader.
         """
         n_x, n_y, n_z = self.dimensions
         common_mass_axis = self.get_common_mass_axis()

--- a/thyra/core/base_converter.py
+++ b/thyra/core/base_converter.py
@@ -568,11 +568,23 @@ class BaseMSIConverter(ABC):
     def _map_mass_to_indices(self, mzs: NDArray[np.float64]) -> NDArray[np.int_]:
         """Map m/z values to indices in the common mass axis with high accuracy.
 
+        The returned array is parallel to ``mzs`` (same length, same order),
+        so callers may pair it element-for-element with the spectrum's
+        intensity array.
+
         Args:
             mzs: Array of m/z values
 
         Returns:
-            Array of indices in common mass axis
+            Array of indices in common mass axis, parallel to ``mzs``
+
+        Raises:
+            ValueError: If any m/z value has no common-axis entry within
+                tolerance. Without resampling the axis is built from the
+                spectra themselves, so every value must match exactly; a
+                near-miss means the axis and the data have diverged, and
+                dropping the value silently would desync the index and
+                intensity arrays downstream.
         """
         if self._common_mass_axis is None:
             raise ValueError("Common mass axis is not initialized.")
@@ -580,18 +592,33 @@ class BaseMSIConverter(ABC):
         if mzs.size == 0:
             return np.array([], dtype=int)
 
-        # Use searchsorted for exact mapping
-        indices = np.searchsorted(self._common_mass_axis, mzs)
+        axis = self._common_mass_axis
 
-        # Ensure indices are within bounds
-        indices = np.clip(indices, 0, len(self._common_mass_axis) - 1)
+        # searchsorted returns the right-hand neighbor; the nearest axis
+        # entry may sit on either side, so compare both before validating.
+        right = np.clip(np.searchsorted(axis, mzs), 0, len(axis) - 1)
+        left = np.maximum(right - 1, 0)
+        indices = np.where(
+            np.abs(axis[right] - mzs) <= np.abs(axis[left] - mzs), right, left
+        )
 
-        # For complete accuracy, validate the indices
         # Very small tolerance threshold for floating point differences
         max_diff = 1e-6
-        mask = np.abs(self._common_mass_axis[indices] - mzs) <= max_diff
+        diffs = np.abs(axis[indices] - mzs)
+        bad = diffs > max_diff
+        if np.any(bad):
+            worst = int(np.argmax(diffs))
+            raise ValueError(
+                f"{int(np.count_nonzero(bad))} of {mzs.size} m/z values have "
+                f"no common mass axis entry within {max_diff:g} (worst: m/z "
+                f"{mzs[worst]!r} is {diffs[worst]:.6g} from nearest axis "
+                f"entry {axis[indices[worst]]!r}). The common mass axis does "
+                f"not cover this spectrum; refusing to drop values silently "
+                f"because callers pair these indices with the full intensity "
+                f"array."
+            )
 
-        return indices[mask]
+        return indices
 
     def _add_to_sparse_matrix(
         self,


### PR DESCRIPTION
## Problem

`BaseMSIConverter._map_mass_to_indices` validated its `searchsorted` result against a 1e-6 tolerance and returned only the indices that passed -- but every caller pairs the returned indices with the ORIGINAL, unfiltered intensity array. The streaming converter's `_process_spectrum` returns `(mz_indices, intensities)` straight into the PCS/COO passes, which do `np.add.at(total_intensity, mz_indices, ints)` and positional row writes assuming the two arrays are parallel; the in-memory no-resample path does the same. Had the tolerance mask ever fired, the arrays would have desynced: a length-mismatch crash in some paths, intensities summed into the wrong m/z bins in others.

The mask never fired on well-formed data -- continuous mode yields the axis itself, and a processed-mode raw axis is the union of every spectrum's m/z values, so every lookup matches exactly -- which is why this was never observed.

## Fix

Make the contract explicit:

- The returned index array is always **parallel to the input** `mzs` (same length, same order), so index/intensity pairing is safe by construction.
- Any m/z value with no axis entry within tolerance **raises `ValueError`** naming the count and worst offender. Without resampling the axis is built from the spectra themselves, so a near-miss means the axis and the data have diverged -- that is corrupt input for a data-integrity converter, not something to drop silently.
- The tolerance check now compares **both `searchsorted` neighbors** and maps to the nearest. The old one-sided check computed the distance only to the right-hand neighbor, so genuine float noise a hair above an axis entry was silently dropped even though it sat within the documented 1e-6 tolerance. On exact matches (all real data today) behavior is bit-identical to before.

`BaseMSIReader.map_mz_to_common_axis`, which filters indices and intensities together, was never affected and is unchanged. In the streaming pipeline the raise surfaces through `convert()`'s error handling as a logged error and a failed conversion instead of a corrupted store.

## Tests

New `tests/unit/converters/test_mass_to_indices_alignment.py` pins the contract through the streaming converter's no-resample path: off-axis values (mid-bin, below range, above range) raise; exact matches map positionally with intensities passed through in parallel; within-tolerance float noise maps to the nearest bin. Also refreshes the `MockMSIReader` docstring in `test_streaming_converter.py` that described the old silent-drop behavior.

Full suite: 1596 passed, 13 skipped.