### PR TITLE
fix: raise the zarr floor to 3.1.6 so auto-sharding cannot pick 1 KB chunks

### DIFF
--- a/handouts/README.md
+++ b/handouts/README.md
@@ -13,7 +13,7 @@ Everything here was investigated against `main` at **v1.27.0** on
 Windows 11, Python 3.12.7, with pandas 2.3.2 / anndata 0.12.2 /
 spatialdata 0.7.3 / zarr 3.1.3. `main` is **v3.0.0** now, and three of those
 four are below the floors `pyproject.toml` declares today -- anndata
-`>=0.13.2`, spatialdata `>=0.8.0`, zarr `>=3.1.4`. Re-measure before trusting
+`>=0.13.2`, spatialdata `>=0.8.0`, zarr `>=3.1.6`. Re-measure before trusting
 a figure below: the anndata and zarr moves in particular changed how the store
 gets written, which is the subject of half these handouts.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,16 +91,28 @@ dependencies = [
     # bit ome_zarr 0.12.x with newer dask, and spatialdata 0.8 requires >= 0.16.
     "ome-zarr>=0.16.0, <0.19",        # tested 0.18.0
     "tqdm>=4.50.0",
-    # Floor is 3.1.4, and it is load-bearing. anndata >= 0.13 writes every zarr v3
-    # array with `shards="auto"`. zarr < 3.1.4 sized the auto chunk with
-    # `max_bytes=1024` where its own comment says "aim for a 1MiB chunk" (compare
-    # `_auto_partition` in 3.1.3 vs 3.1.4), so one shard -- one FILE -- came out at
-    # ~1 KB. Measured on test_data/pea.imzML: 393,310 files for a single table and
-    # 434 s of a 445 s conversion spent in the write, against 12 files and 2.7 s on
-    # 3.1.6. Nothing in Thyra changed; the anndata 0.13 bump alone did this.
-    # 3.1.4 is also where `array.target_shard_size_bytes` arrives, which is the
-    # knob _chunking.table_write_config sets to claim the budget from anndata.
-    "zarr>=3.1.4, <3.2",              # tested 3.1.6
+    # Floor is 3.1.6, and it is load-bearing. anndata >= 0.13 writes every zarr v3
+    # array with `shards="auto"`, and `_auto_partition` sized the auto INNER chunk
+    # with `max_bytes=1024` where the line right above it says "aim for a 1MiB
+    # chunk". zarr-python#3603 changed that 1024 to 1048576; it merged six days
+    # AFTER 3.1.5 shipped, so 3.1.4 and 3.1.5 both still carry the defect
+    # (`chunk_grids.py:267` in each) and 3.1.6 is the first release without it.
+    # Do not drop the floor to 3.1.4 on the grounds that 3.1.4 is where
+    # `array.target_shard_size_bytes` arrives -- the knob _chunking.table_write_config
+    # sets to claim the budget from anndata. That knob is necessary, not sufficient.
+    #
+    # Both halves of the damage, measured on X/data of test_data/pea.imzML (60.1M
+    # nnz, f8, 481 MB):
+    #   - Below 3.1.4 the knob does not exist, so a shard is 2 auto chunks -- ~1.8 KB,
+    #     and a shard is one FILE. 393,310 files for a single table, and 434 s of a
+    #     445 s conversion spent in the write, against 12 files and 2.7 s on 3.1.6.
+    #     Nothing in Thyra changed; the anndata 0.13 bump alone did this.
+    #   - On 3.1.4/3.1.5 the 128 MiB budget IS honoured, so the file count stays sane
+    #     (4), but the chunk inside those files is 920 B: ~145,900 separately
+    #     compressed chunks per shard against 142 on 3.1.6, plus the shard index that
+    #     implies. A 3.1.5 resolve buys that silently, and the shard-level assertion
+    #     cannot see it; _chunking.MIN_TABLE_CHUNK_BYTES is what catches it.
+    "zarr>=3.1.6, <3.2",              # tested 3.1.6
     "imagecodecs>=2024.1.1",  # For reading compressed TIFF optical images
     # Floor is 0.13.2, not 0.13.0. anndata 0.13.0 imports
     # `typing_extensions.sentinel` (needs typing-extensions >= 4.16) but declares

--- a/tests/unit/converters/test_chunking_policy.py
+++ b/tests/unit/converters/test_chunking_policy.py
@@ -9,11 +9,18 @@ size.
 
 **The MSI table.** Locks the shard size the table's ``X`` arrays land in. This
 half exists because of a real, shipped regression: anndata >= 0.13 writes every
-zarr v3 array with ``shards="auto"``, and zarr < 3.1.4 sized the auto chunk with
-``max_bytes=1024`` where it meant 1 MiB. Nothing in Thyra changed -- a
-dependency bump alone was enough to turn one table into ~400,000 files of
-roughly 1 KB each, and the zarr write into 98% of conversion wall-clock
-(pea.imzML: 434 s of 445 s).
+zarr v3 array with ``shards="auto"``, and zarr < 3.1.6 sized the auto chunk with
+``max_bytes=1024`` where it meant 1 MiB (zarr-python#3603, first released in
+3.1.6). On a zarr that also predates ``array.target_shard_size_bytes`` (< 3.1.4)
+there is no budget to override that chunk, so it sizes the shard too. Nothing in
+Thyra changed -- a dependency bump alone was enough to turn one table into
+~400,000 files of roughly 1 KB each, and the zarr write into 98% of conversion
+wall-clock (pea.imzML: 434 s of 445 s).
+
+The shard, i.e. the file, is only half of it. 3.1.4 and 3.1.5 gained the budget
+knob while keeping the bad ``max_bytes=1024``, so there the file count looks fine
+and it is the chunk *inside* each file that collapses. Both halves are asserted
+below, against ``MIN_TABLE_SHARD_BYTES`` and ``MIN_TABLE_CHUNK_BYTES``.
 
 That failure is invisible to every other test in this suite. The store still
 round-trips, ``read_lazy`` still opens it, and the values are all correct --
@@ -35,6 +42,7 @@ from thyra.converters.spatialdata import _chunking
 from thyra.converters.spatialdata._chunking import (
     IMAGE_CHUNK_EDGE,
     INNER_TILE_EDGE,
+    MIN_TABLE_CHUNK_BYTES,
     MIN_TABLE_SHARD_BYTES,
     TABLE_SHARD_TARGET_BYTES,
     image_chunks,
@@ -163,21 +171,45 @@ class TestConvertedTableGeometry:
         assert file_bytes >= min(array_bytes, MIN_TABLE_SHARD_BYTES), (
             f"X/{member}: {file_bytes} B per file over {array_bytes} B of data "
             f"-> {int(np.ceil(arr.shape[0] / unit)):,} files. Below "
-            f"{MIN_TABLE_SHARD_BYTES} B this is the zarr < 3.1.4 "
-            "auto-shard defect; check the zarr floor in pyproject.toml."
+            f"{MIN_TABLE_SHARD_BYTES} B this is the pre-3.1.4 auto-shard "
+            "collapse (no array.target_shard_size_bytes to override the "
+            "1 KB auto chunk); check the zarr floor in pyproject.toml, "
+            "which is >= 3.1.6."
+        )
+
+    @pytest.mark.parametrize("member", ["data", "indices", "indptr"])
+    def test_x_arrays_are_not_kilobyte_chunked(self, converted_store, member):
+        # The other half of the same defect, and the half the shard assertion
+        # above is blind to: with Thyra's budget held open, zarr 3.1.4/3.1.5
+        # still land a large shard and only the chunk inside it collapses.
+        store, _ = converted_store
+        arr = zarr.open_group(str(store), mode="r")[f"tables/ds_z0/X/{member}"]
+
+        chunk_bytes = arr.chunks[0] * arr.dtype.itemsize
+        array_bytes = arr.shape[0] * arr.dtype.itemsize
+
+        # An array smaller than the floor can only ever be one short chunk.
+        assert chunk_bytes >= min(array_bytes, MIN_TABLE_CHUNK_BYTES), (
+            f"X/{member}: {chunk_bytes} B per chunk over {array_bytes} B of data "
+            f"-> {int(np.ceil(arr.shape[0] / arr.chunks[0])):,} chunks per array, "
+            f"each separately compressed and indexed. Below "
+            f"{MIN_TABLE_CHUNK_BYTES} B this is the zarr < 3.1.6 auto-chunk "
+            "defect (zarr-python#3603); check the zarr floor in pyproject.toml."
         )
 
     def test_data_array_is_large_enough_for_that_to_mean_anything(
         self, converted_store
     ):
-        # Guards the fixture, not the code. The assertion above is
-        # `file_bytes >= min(array_bytes, MIN_TABLE_SHARD_BYTES)`, so it says
-        # nothing at all unless X/data is bigger than the floor -- which it
-        # stops being if the converter ever drops these spectra to a handful of
-        # non-zeros. Today it is ~400 KB.
+        # Guards the fixture, not the code. Both assertions above are
+        # `<bytes> >= min(array_bytes, <floor>)`, so they say nothing at all
+        # unless X/data is bigger than the floor -- which it stops being if the
+        # converter ever drops these spectra to a handful of non-zeros. Today it
+        # is ~400 KB.
         store, _ = converted_store
         data = zarr.open_group(str(store), mode="r")["tables/ds_z0/X/data"]
-        assert data.shape[0] * data.dtype.itemsize > MIN_TABLE_SHARD_BYTES
+        assert data.shape[0] * data.dtype.itemsize > max(
+            MIN_TABLE_SHARD_BYTES, MIN_TABLE_CHUNK_BYTES
+        )
 
     def test_whole_table_stays_in_a_handful_of_files(self, converted_store):
         store, _ = converted_store

--- a/thyra/converters/spatialdata/_chunking.py
+++ b/thyra/converters/spatialdata/_chunking.py
@@ -53,12 +53,27 @@ INNER_TILE_EDGE = 512
 # began auto-sharding, so read amplification is unchanged.
 TABLE_SHARD_TARGET_BYTES = 128 * 1024 * 1024
 
-# zarr < 3.1.4 computed the auto chunk with ``max_bytes=1024`` where 1 MiB was
-# meant, so ``shards="auto"`` produced ~1 KB shards -- one file per KB of table.
-# It also predates ``array.target_shard_size_bytes``, making the budget above
-# unenforceable. pyproject pins the floor at 3.1.4 for exactly this reason;
-# this constant is what the regression test checks the floor still buys us.
+# zarr < 3.1.6 computed the auto chunk with ``max_bytes=1024`` where 1 MiB was
+# meant (zarr-python#3603, first released in 3.1.6 -- it landed after both 3.1.4
+# and 3.1.5). zarr < 3.1.4 additionally predates ``array.target_shard_size_bytes``,
+# making the budget above unenforceable, and there ``shards="auto"`` produced
+# ~1 KB SHARDS -- one file per KB of table. pyproject pins the floor at 3.1.6 for
+# both reasons.
+#
+# This constant guards the shard, i.e. the file, so it only ever catches that
+# second, pre-3.1.4 half: on 3.1.4/3.1.5 the budget above still lands large
+# shards and it is the chunk inside them that collapses. MIN_TABLE_CHUNK_BYTES
+# is the half that catches those two.
 MIN_TABLE_SHARD_BYTES = 64 * 1024
+
+# Minimum size for the INNER chunk of a table array -- the unit that sits inside
+# a shard and the unit a random read decompresses. This is the half of the defect
+# a large shard hides: on 3.1.4/3.1.5 the file count looks fine while each file
+# quietly holds ~146,000 separately compressed chunks instead of ~142, and pays
+# for all of them in the shard index. 64 KiB sits well above the ~800 B those
+# versions hand the regression-test fixture and well below the ~200 KB 3.1.6
+# hands it, so the two are never close to the threshold.
+MIN_TABLE_CHUNK_BYTES = 64 * 1024
 
 
 @contextmanager

--- a/uv.lock
+++ b/uv.lock
@@ -2651,7 +2651,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3904,7 +3904,7 @@ requires-dist = [
     { name = "tifffile", specifier = ">=2022.8.12" },
     { name = "tqdm", specifier = ">=4.50.0" },
     { name = "xarray", specifier = ">=2024.10.0" },
-    { name = "zarr", specifier = ">=3.1.4,<3.2" },
+    { name = "zarr", specifier = ">=3.1.6,<3.2" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## What is wrong

The declared floor `zarr>=3.1.4, <3.2` is one patch release too low, and the comment above it explains the defect as if 3.1.4 fixed it. It did not.

Verified at the tags, not taken on faith:

| tag | line | value |
|---|---|---|
| v3.1.3 | `chunk_grids.py:228` | `max_bytes=1024` (no `target_shard_size_bytes` at all) |
| v3.1.4 | `chunk_grids.py:267` | `max_bytes=1024` |
| v3.1.5 | `chunk_grids.py:267` | `max_bytes=1024` |
| v3.1.6 | `chunk_grids.py:272` | `max_bytes=1048576` |

In every case the literal sits directly under the comment `# aim for a 1MiB chunk`. [zarr-python#3603](https://github.com/zarr-developers/zarr-python/pull/3603) changed it, and merged 2025-11-27 -- six days *after* 3.1.5 shipped (3.1.4 and 3.1.5 both released 2025-11-21). So 3.1.6 is the first release without the defect.

The old comment conflated the fix with the release that added `array.target_shard_size_bytes` (3.1.4), which is the knob `_chunking.table_write_config` sets. That knob is necessary, not sufficient.

## Why it matters

`uv.lock` happens to hold 3.1.6, so this is latent rather than active -- but nothing stopped a fresh resolve from picking 3.1.5.

Measured with `_auto_partition` on `X/data` of `test_data/pea.imzML` (60.1M nnz, f8), with Thyra's 128 MiB budget held open:

| zarr | inner chunk | shard | files | chunks per shard |
|---|---|---|---|---|
| 3.1.4 / 3.1.5 | **920 B** | 128 MiB | 4 | **145,888** |
| 3.1.6 | 917 KiB | 127 MiB | 4 | 142 |

Note this is *not* the 393,310-file write PR #136 measured. That needed a zarr with no budget knob at all (< 3.1.4), where the shard collapses along with the chunk. On 3.1.4/3.1.5 the file count stays sane and only the chunk inside each file collapses -- so the damage is ~146,000 separately compressed chunks per shard, plus the shard index for all of them, with nothing visible from outside.

## Changes

- `pyproject.toml`: floor to `zarr>=3.1.6, <3.2`; comment block corrected to cite zarr-python#3603 and to separate the two halves of the damage with their measured numbers.
- `_chunking.py`: the `MIN_TABLE_SHARD_BYTES` note corrected, and a new `MIN_TABLE_CHUNK_BYTES = 64 KiB`.
- `test_chunking_policy.py`: docstring corrected; new `test_x_arrays_are_not_kilobyte_chunked` over `data`/`indices`/`indptr`. The existing shard-level assertion is structurally blind to this, since the shard stays large -- it kept passing on 3.1.5. The assertion message that said "zarr < 3.1.4" was left at that boundary deliberately: it is accurate for the shard collapse that assertion detects.
- `handouts/README.md`: restated the same floor as `>=3.1.4`; updated for consistency.

## Verification

- `uv lock`: no package version moves, zarr stays 3.1.6. The only other line is a marker normalization on pexpect's `ptyprocess` dependency emitted by the local uv. `uv sync --locked` accepts it.
- `pytest tests/unit/converters/test_chunking_policy.py` against **zarr 3.1.5**: 2 failed -- `X/data: 800 B per chunk over 409600 B`, `X/indices: 800 B per chunk over 204800 B`. Against **3.1.6**: 16 passed.
- Full unit suite: 1629 passed, 3 skipped.
- pre-commit: all hooks pass (black, isort, flake8, mypy, bandit, pydocstyle).
