### PR TITLE
feat: experimental mzPeak reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Full documentation: **[M4i-Imaging-Mass-Spectrometry.github.io/thyra](https://M4
 | Bruker | `.d` | Full support (timsTOF + Rapiflex) |
 | Waters | `.raw` directory | Full support |
 | PHI SmartSoft-TOF | `.raw` file | Full support (nanoTOF, ToF-SIMS) |
+| mzPeak | `.mzpeak` | Experimental (HUPO-PSI v0.9 draft, read-only) |
 | Shimadzu | `.imdx`, `.kbd` | In development (workaround: imzML export from IMAGEREVEAL MS) |
 
 PHI mosaic, MS/MS and depth-profiling acquisitions are implemented but so far

--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -1,6 +1,6 @@
 # Supported Formats
 
-Thyra reads five MSI formats and writes all of them into the same
+Thyra reads six MSI formats and writes all of them into the same
 SpatialData/Zarr layout. The input format is detected from the path -- there is
 no format flag on the CLI, and `format_type` in the Python API selects the
 *output* format, not the input.
@@ -12,6 +12,7 @@ no format flag on the CLI, and `format_type` in the Python API selects the
 | **Bruker Rapiflex** | directory | `*.dat` + `*_poslog.txt` | none |
 | **Waters MassLynx** | `.raw` **directory** | `_FUNC*.DAT` files inside | bundled DLL |
 | **PHI SmartSoft-TOF** | `.raw` **file** | `SOFH` magic in first 4 bytes | none |
+| **mzPeak** | `.mzpeak` file | ZIP magic + `mzpeak_index.json` member | none |
 
 ```bash
 thyra sample.imzML       out.zarr   # imzML
@@ -19,6 +20,7 @@ thyra sample.d           out.zarr   # Bruker timsTOF
 thyra rapiflex_folder/   out.zarr   # Bruker Rapiflex
 thyra waters_run.raw/    out.zarr   # Waters (a directory)
 thyra tofsims_run.raw    out.zarr   # PHI (a file)
+thyra sample.mzpeak      out.zarr   # mzPeak (experimental)
 ```
 
 ---
@@ -47,14 +49,14 @@ _FUNC*.DAT files, or a PHI SmartSoft-TOF file beginning with the SOFH magic.
 Not every source carries every kind of metadata. This is what Thyra can
 actually populate from each.
 
-| | imzML | timsTOF | Rapiflex | Waters | PHI |
-|---|---|---|---|---|---|
-| Pixel size from metadata | yes | yes | yes | yes | yes |
-| Optical image | -- | yes | yes | -- | -- |
-| Optical alignment | -- | yes (`.mis`) | -- | -- | -- |
-| Multi-region | -- | yes | -- | -- | mosaic tiles |
-| 3D / multi-slice | yes | yes | -- | -- | -- |
-| Native non-m/z axis kept | -- | -- | -- | -- | flight time |
+| | imzML | timsTOF | Rapiflex | Waters | PHI | mzPeak |
+|---|---|---|---|---|---|---|
+| Pixel size from metadata | yes | yes | yes | yes | yes | sometimes |
+| Optical image | -- | yes | yes | -- | -- | -- |
+| Optical alignment | -- | yes (`.mis`) | -- | -- | -- | -- |
+| Multi-region | -- | yes | -- | -- | mosaic tiles | -- |
+| 3D / multi-slice | yes | yes | -- | -- | -- | -- |
+| Native non-m/z axis kept | -- | -- | -- | -- | flight time | -- |
 
 Anything a format does not supply is simply absent from the output rather than
 guessed at. Pixel size is the one exception worth knowing about: when a source
@@ -133,6 +135,57 @@ please [open an issue](https://github.com/M4i-Imaging-Mass-Spectrometry/thyra/is
 
 See [PHI ToF-SIMS Notes](phi-tofsims-notes.md) for the file layout, the
 calibration behaviour, and why the time axis is binned the way it is.
+
+---
+
+## mzPeak (experimental)
+
+A single `.mzpeak` **file**: a ZIP of Parquet members plus an
+`mzpeak_index.json` that maps each member to a role. mzPeak is the HUPO-PSI
+working group's intended successor to mzML/imzML at the raw/archival layer.
+
+Thyra treats it as an **input only** and never writes one. Support is marked
+experimental because the container is a v0.9 draft -- column names, the index
+vocabulary and the placement of file-level metadata have all moved between
+prototype revisions and are expected to move again before v1.0. The reader
+validates what it depends on, so a drifted archive raises a named error rather
+than converting to something plausible but wrong.
+
+```bash
+thyra sample.mzpeak out.zarr
+```
+
+Data is shaped like processed imzML: one m/z per point, per-spectrum axes, and
+no shared-axis concept anywhere in the format. The resampling decision tree
+therefore treats these files exactly as it treats processed imzML.
+
+Three things are refused rather than guessed at:
+
+- The **chunked layout** (`chunk` instead of `point` in the signal member) is a
+  different physical encoding and raises `NotImplementedError` naming the file.
+- **Non-imaging archives** are rejected. Positions are optional in mzPeak --
+  the reference converter only writes them when it happens to see imaging
+  input -- and an archive without them has no pixels for Thyra to place.
+- **Unrecognised layouts** fail with the schema they actually carry.
+
+Two behaviours worth knowing:
+
+- **Pixel size is often absent.** When `IMS:1000046`/`IMS:1000047` are missing
+  the CLI falls back to `--pixel-size` exactly as it does for imzML. Terms are
+  matched on accession rather than name, because the controlled vocabulary
+  spells the two axes inconsistently.
+- **Null-pair padding is dropped.** mzPeak compresses profile spectra by
+  removing interior runs of zero intensity and marking each gap with two rows
+  whose m/z *and* intensity are both null; the reference reader regenerates the
+  missing m/z from a per-spectrum polynomial. Those regenerated values are
+  extrapolations that carry zero intensity, so in a sparse matrix they would
+  only add mass-axis channels that can never hold a value. Thyra omits them and
+  logs how many it dropped. Recorded point counts include the padding, so peak
+  totals are corrected against it.
+
+mzPeak carries no region or ROI identity of any kind, so `get_region_map()`
+returns `None`. Missing pixels are ordinary and are left missing rather than
+densified.
 
 ---
 

--- a/tests/fixtures/mzpeak_builder.py
+++ b/tests/fixtures/mzpeak_builder.py
@@ -1,0 +1,483 @@
+"""Construct minimal valid ``.mzpeak`` archives for tests.
+
+There is no mzPeak writer in Thyra and no Rust toolchain in CI, so the test
+corpus is built here, in pure Python, from ``zipfile`` and ``pyarrow``.
+
+Everything this module emits is written out literally -- the index JSON is a
+dict spelled out below, the column names are string constants, the member
+names are hardcoded -- and nothing is derived from
+:mod:`thyra.readers.mzpeak`. That separation is the point. The hand-authored
+imzML corpus in ``tests/data/fixtures`` exists because pyimzml's parser and
+writer "agree on each other's mistakes"; a builder that asked the reader how
+to spell things would reintroduce exactly that loop, and every test on top of
+it would pass while real archives failed.
+
+The shapes here were measured against the reference implementation
+(HUPO-PSI/mzPeak @ 502c3a4) and its shipped sample archives, not inferred
+from the draft prose.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+# Member names as the reference converter writes them. Real readers resolve
+# these through the index rather than by name; the fixtures use the reference
+# spelling so a reader that (wrongly) hardcodes them still sees valid input
+# and its bug shows up somewhere more informative than a missing file.
+DATA_MEMBER = "spectra_data.parquet"
+METADATA_MEMBER = "spectra_metadata.parquet"
+SCANS_MEMBER = "spectra_metadata_scans.parquet"
+INDEX_MEMBER = "mzpeak_index.json"
+
+POSITION_X_COLUMN = "opt_IMS_1000050_position_x"
+POSITION_Y_COLUMN = "opt_IMS_1000051_position_y"
+
+#: Micrometre unit accession, as the reference archive declares it.
+UNIT_MICROMETRE = "UO:0000017"
+
+
+class Spectrum:
+    """One spectrum destined for a fixture archive.
+
+    Attributes:
+        x: Position along x, in the file's own (typically 1-based) frame.
+        y: Position along y.
+        mzs: m/z values, ascending.
+        intensities: Intensity values, same length as ``mzs``.
+    """
+
+    def __init__(
+        self,
+        x: int,
+        y: int,
+        mzs: Sequence[float],
+        intensities: Sequence[float],
+    ):
+        """Store one spectrum's coordinates and arrays."""
+        self.x = int(x)
+        self.y = int(y)
+        self.mzs = np.asarray(mzs, dtype=np.float64)
+        self.intensities = np.asarray(intensities, dtype=np.float64)
+        if self.mzs.size != self.intensities.size:
+            raise ValueError("mzs and intensities must be the same length")
+
+
+def _point_table(
+    spectra: Sequence[Spectrum],
+    null_pair_after: Optional[int] = None,
+) -> pa.Table:
+    """Build the point-layout signal table.
+
+    Args:
+        spectra: Spectra in ``spectrum_index`` order.
+        null_pair_after: When given, insert a null pair (two rows whose m/z
+            and intensity are both null) after this many real points of every
+            spectrum, imitating the padding the reference converter writes
+            where it has removed a run of zeros.
+
+    Returns:
+        A table with the single struct column ``point``.
+    """
+    indices: List[int] = []
+    mzs: List[Optional[float]] = []
+    intensities: List[Optional[float]] = []
+
+    for index, spectrum in enumerate(spectra):
+        for position, (mz, intensity) in enumerate(
+            zip(spectrum.mzs, spectrum.intensities)
+        ):
+            indices.append(index)
+            mzs.append(float(mz))
+            intensities.append(float(intensity))
+            if null_pair_after is not None and position == null_pair_after - 1:
+                # A null *pair* -- the reference writer never emits a lone
+                # null, and its reader raises on an unpaired one.
+                for _ in range(2):
+                    indices.append(index)
+                    mzs.append(None)
+                    intensities.append(None)
+
+    point = pa.StructArray.from_arrays(
+        [
+            pa.array(indices, type=pa.uint64()),
+            pa.array(mzs, type=pa.float64()),
+            pa.array(intensities, type=pa.float32()),
+        ],
+        fields=[
+            pa.field("spectrum_index", pa.uint64()),
+            pa.field("mz", pa.float64()),
+            pa.field("intensity", pa.float32()),
+        ],
+    )
+    return pa.table({"point": point})
+
+
+def _chunk_table(spectra: Sequence[Spectrum]) -> pa.Table:
+    """Build a chunked-layout signal table.
+
+    Only the schema matters: this exists so a reader can be shown refusing the
+    layout by name, and no test reads the values back.
+    """
+    chunk = pa.StructArray.from_arrays(
+        [
+            pa.array(range(len(spectra)), type=pa.uint64()),
+            pa.array([float(s.mzs[0]) for s in spectra], type=pa.float64()),
+            pa.array([float(s.mzs[-1]) for s in spectra], type=pa.float64()),
+            pa.array(
+                [[float(v) for v in s.mzs] for s in spectra],
+                type=pa.large_list(pa.float64()),
+            ),
+            pa.array(["basic" for _ in spectra], type=pa.string()),
+            pa.array(
+                [[float(v) for v in s.intensities] for s in spectra],
+                type=pa.large_list(pa.float32()),
+            ),
+        ],
+        fields=[
+            pa.field("spectrum_index", pa.uint64()),
+            pa.field("mz_chunk_start", pa.float64()),
+            pa.field("mz_chunk_end", pa.float64()),
+            pa.field("mz_chunk_values", pa.large_list(pa.float64())),
+            pa.field("chunk_encoding", pa.string()),
+            pa.field("intensity", pa.large_list(pa.float32())),
+        ],
+    )
+    return pa.table({"chunk": chunk})
+
+
+def _metadata_table(
+    spectra: Sequence[Spectrum],
+    null_pair_after: Optional[int],
+    spectrum_representation: str,
+) -> pa.Table:
+    """Build the one-row-per-spectrum metadata table.
+
+    ``number_of_data_points`` counts stored rows, padding included -- which is
+    what the reference archive does, and the reason the reader has to correct
+    it before reporting a peak count.
+    """
+    padding = 0 if null_pair_after is None else 2
+    return pa.table(
+        {
+            "index": pa.array(range(len(spectra)), type=pa.uint64()),
+            "id": pa.array(
+                [f"Scan={i + 1}" for i in range(len(spectra))],
+                type=pa.large_string(),
+            ),
+            "ms_level": pa.array([1] * len(spectra), type=pa.uint8()),
+            "time": pa.array(
+                [float(i) for i in range(len(spectra))], type=pa.float64()
+            ),
+            "spectrum_representation": pa.array(
+                [spectrum_representation] * len(spectra), type=pa.string()
+            ),
+            "lowest_observed_mz": pa.array(
+                [float(s.mzs.min()) for s in spectra], type=pa.float64()
+            ),
+            "highest_observed_mz": pa.array(
+                [float(s.mzs.max()) for s in spectra], type=pa.float64()
+            ),
+            "number_of_data_points": pa.array(
+                [int(s.mzs.size) + padding for s in spectra], type=pa.uint64()
+            ),
+            "total_ion_current": pa.array(
+                [float(s.intensities.sum()) for s in spectra], type=pa.float32()
+            ),
+        }
+    )
+
+
+def _scans_table(spectra: Sequence[Spectrum], include_positions: bool) -> pa.Table:
+    """Build the scans table, with or without the imaging position columns.
+
+    ``source_index`` is the join key back to the spectrum; ``scan_index``
+    numbers scans within a spectrum and is deliberately not the same column,
+    because a reader that joins on row order passes until it meets a file
+    where they differ.
+    """
+    columns: Dict[str, pa.Array] = {
+        "source_index": pa.array(range(len(spectra)), type=pa.uint64()),
+        "scan_index": pa.array([0] * len(spectra), type=pa.uint64()),
+        "scan_start_time": pa.array(
+            [float(i) for i in range(len(spectra))], type=pa.float32()
+        ),
+    }
+    if include_positions:
+        columns[POSITION_X_COLUMN] = pa.array([s.x for s in spectra], type=pa.uint32())
+        columns[POSITION_Y_COLUMN] = pa.array([s.y for s in spectra], type=pa.uint32())
+    return pa.table(columns)
+
+
+def _scan_settings(
+    pixel_size: Optional[Tuple[float, float]],
+    grid: Optional[Tuple[int, int]],
+    unit: Optional[str],
+) -> List[dict]:
+    """Build ``scan_settings_list``, imitating the reference spelling.
+
+    The CV names are copied verbatim from the reference archive, parentheses
+    and all: IMS:1000046 is written ``"pixel size (x)"`` and IMS:1000047
+    ``"pixel size y"``. A reader matching on name rather than accession finds
+    one axis and misses the other, and these fixtures are what makes that
+    visible.
+    """
+    parameters: List[dict] = []
+    if grid is not None:
+        parameters += [
+            {
+                "name": "max count of pixels x",
+                "accession": "IMS:1000042",
+                "value": grid[0],
+                "unit": None,
+            },
+            {
+                "name": "max count of pixels y",
+                "accession": "IMS:1000043",
+                "value": grid[1],
+                "unit": None,
+            },
+        ]
+    if pixel_size is not None:
+        parameters += [
+            {
+                "name": "pixel size (x)",
+                "accession": "IMS:1000046",
+                "value": pixel_size[0],
+                "unit": unit,
+            },
+            {
+                "name": "pixel size y",
+                "accession": "IMS:1000047",
+                "value": pixel_size[1],
+                "unit": unit,
+            },
+        ]
+    if not parameters:
+        return []
+    return [
+        {
+            "id": "scansettings1",
+            "source_file_refs": [],
+            "targets": [],
+            "parameters": parameters,
+        }
+    ]
+
+
+def _index_document(
+    include_positions: bool,
+    data_kind: str,
+    column_mapping_key: Optional[str],
+    index_metadata: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Spell out ``mzpeak_index.json``.
+
+    Args:
+        include_positions: Whether the scans entry binds the position terms.
+        data_kind: How to spell the signal member's kind. The reference
+            parser accepts ``"data_arrays"`` and ``"data arrays"`` alike, so
+            both must resolve.
+        column_mapping_key: Which key carries the CV bindings --
+            ``"column_mapping"``, its serde alias ``"metadata_mapping"``, or
+            ``None`` to omit the bindings entirely, which the reference
+            struct permits via ``serde(default)``.
+        index_metadata: Contents of the index's ``metadata`` object. The
+            reference imaging archive leaves this empty and puts everything
+            in the Parquet footer; other archives populate both.
+    """
+    scans_bindings = [
+        {
+            "name": "scan start time",
+            "path": "scan_start_time",
+            "accession": "MS:1000016",
+            "unit": "UO:0000031",
+        }
+    ]
+    if include_positions:
+        scans_bindings += [
+            {
+                "name": "position x",
+                "path": POSITION_X_COLUMN,
+                "accession": "IMS:1000050",
+                "unit": None,
+            },
+            {
+                "name": "position y",
+                "path": POSITION_Y_COLUMN,
+                "accession": "IMS:1000051",
+                "unit": None,
+            },
+        ]
+
+    def entry(name: str, kind: str, bindings: List[dict]) -> Dict[str, Any]:
+        item: Dict[str, Any] = {
+            "name": name,
+            "entity_type": "spectrum",
+            "data_kind": kind,
+        }
+        if column_mapping_key is not None:
+            item[column_mapping_key] = bindings
+        item["parameters"] = []
+        return item
+
+    return {
+        "files": [
+            entry(DATA_MEMBER, data_kind, []),
+            entry(METADATA_MEMBER, "metadata", []),
+            entry(SCANS_MEMBER, "scans", scans_bindings),
+        ],
+        "metadata": dict(index_metadata) if index_metadata else {},
+    }
+
+
+def build_mzpeak(
+    path: Path,
+    spectra: Sequence[Spectrum],
+    *,
+    pixel_size: Optional[Tuple[float, float]] = (25.0, 25.0),
+    pixel_size_unit: Optional[str] = UNIT_MICROMETRE,
+    grid: Optional[Tuple[int, int]] = None,
+    include_positions: bool = True,
+    row_group_size: Optional[int] = None,
+    layout: str = "point",
+    data_kind: str = "data_arrays",
+    column_mapping_key: Optional[str] = "column_mapping",
+    index_metadata: Optional[Dict[str, Any]] = None,
+    null_pair_after: Optional[int] = None,
+    spectrum_representation: str = "profile spectrum",
+    footer_metadata: bool = True,
+) -> Path:
+    """Write one ``.mzpeak`` archive and return its path.
+
+    Args:
+        path: Destination file. Parent directories must exist.
+        spectra: Spectra, in the order they should be indexed.
+        pixel_size: ``(x, y)`` pixel size, or ``None`` to omit the terms and
+            exercise the "pixel size not found" path.
+        pixel_size_unit: Unit accession for the pixel size terms.
+        grid: Declared grid extent (IMS:1000042/43), or ``None`` to omit.
+        include_positions: When ``False``, the scans member carries no
+            position columns, which is what a non-imaging archive looks like.
+        row_group_size: Rows per Parquet row group. Set this below a
+            spectrum's point count to force spectra across row-group
+            boundaries.
+        layout: ``"point"`` or ``"chunk"``.
+        data_kind: Spelling for the signal member's ``data_kind``.
+        column_mapping_key: Key carrying the CV bindings, or ``None``.
+        index_metadata: Contents of the index ``metadata`` object.
+        null_pair_after: Insert a null pair after this many points of each
+            spectrum.
+        spectrum_representation: Value for the per-spectrum column.
+        footer_metadata: Whether to write the file-level JSON blobs into the
+            metadata member's Parquet key-value footer. ``False`` leaves the
+            index ``metadata`` object as the only source, which is how a
+            reader that reads just one of the two gets caught.
+
+    Returns:
+        ``path``, for convenience.
+    """
+    if layout == "point":
+        data_table = _point_table(spectra, null_pair_after)
+    elif layout == "chunk":
+        data_table = _chunk_table(spectra)
+    else:  # pragma: no cover - programming error in a test
+        raise ValueError(f"unknown layout {layout!r}")
+
+    scan_settings = _scan_settings(pixel_size, grid, pixel_size_unit)
+    file_metadata = {
+        "file_description": {
+            "contents": [
+                {
+                    "name": spectrum_representation,
+                    "accession": (
+                        "MS:1000127"
+                        if spectrum_representation == "centroid spectrum"
+                        else "MS:1000128"
+                    ),
+                    "value": None,
+                    "unit": None,
+                }
+            ],
+            "source_files": [],
+        },
+        "scan_settings_list": scan_settings,
+        "instrument_configuration_list": [],
+        "software_list": [],
+        "run": {"id": "fixture", "start_time": None},
+    }
+
+    metadata_table = _metadata_table(spectra, null_pair_after, spectrum_representation)
+    if footer_metadata:
+        metadata_table = metadata_table.replace_schema_metadata(
+            {key: json.dumps(value) for key, value in file_metadata.items()}
+        )
+
+    path = Path(path)
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_STORED) as archive:
+        for member, table, group_size in (
+            (DATA_MEMBER, data_table, row_group_size),
+            (METADATA_MEMBER, metadata_table, None),
+            (SCANS_MEMBER, _scans_table(spectra, include_positions), None),
+        ):
+            sink = pa.BufferOutputStream()
+            kwargs: Dict[str, Any] = {"write_statistics": True}
+            if group_size is not None:
+                kwargs["row_group_size"] = group_size
+            pq.write_table(table, sink, **kwargs)
+            archive.writestr(member, sink.getvalue().to_pybytes())
+
+        archive.writestr(
+            INDEX_MEMBER,
+            json.dumps(
+                _index_document(
+                    include_positions,
+                    data_kind,
+                    column_mapping_key,
+                    index_metadata,
+                ),
+                indent=2,
+            ),
+        )
+    return path
+
+
+def grid_spectra(
+    n_x: int,
+    n_y: int,
+    n_points: int = 8,
+    *,
+    base: int = 1,
+    skip: Sequence[Tuple[int, int]] = (),
+) -> List[Spectrum]:
+    """Generate a rectangular acquisition with deterministic arrays.
+
+    Args:
+        n_x: Pixels along x.
+        n_y: Pixels along y.
+        n_points: Points per spectrum.
+        base: Coordinate origin as written into the file. The reference
+            archives are 1-based; ``0`` exercises the normalisation.
+        skip: Positions to leave unacquired, so the grid is sparse.
+
+    Returns:
+        Spectra in raster order.
+    """
+    skipped = {(int(x), int(y)) for x, y in skip}
+    spectra: List[Spectrum] = []
+    for y in range(n_y):
+        for x in range(n_x):
+            if (x + base, y + base) in skipped:
+                continue
+            offset = y * n_x + x
+            mzs = 100.0 + np.arange(n_points, dtype=np.float64) * 0.5
+            intensities = np.arange(1, n_points + 1, dtype=np.float64) + offset * 10.0
+            spectra.append(Spectrum(x + base, y + base, mzs, intensities))
+    return spectra

--- a/tests/integration/test_convert_mzpeak.py
+++ b/tests/integration/test_convert_mzpeak.py
@@ -1,0 +1,299 @@
+"""End-to-end conversion of mzPeak archives, and parity against imzML.
+
+The parity test is the acceptance gate for this reader: the same spectra,
+written once as imzML and once as mzPeak, must convert to the same store.
+Anything the reader gets wrong about coordinates, ordering, the mass axis or
+the payload shows up as a difference here rather than as a plausible-looking
+store nobody checks.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from tests.fixtures.mzpeak_builder import build_mzpeak, grid_spectra
+from thyra.convert import convert_msi
+
+spatialdata = pytest.importorskip("spatialdata", reason="SpatialData not installed")
+
+DATASET_ID = "parity"
+TABLE = f"{DATASET_ID}_z0"
+PIXEL_SIZE_UM = 25.0
+
+
+def _write_imzml(path: Path, spectra) -> Path:
+    """Write the same spectra as a processed-mode imzML."""
+    from pyimzml.ImzMLWriter import ImzMLWriter
+
+    with ImzMLWriter(str(path), mode="processed") as writer:
+        for spectrum in spectra:
+            writer.addSpectrum(
+                spectrum.mzs,
+                spectrum.intensities,
+                (spectrum.x, spectrum.y, 1),
+            )
+    return path
+
+
+def _matching_mzpeak(path: Path, spectra, **kwargs) -> Path:
+    """Build the mzPeak counterpart of an imzML written from ``spectra``.
+
+    The representation is declared centroid because that is what the imzML
+    side reports: pyimzml's processed mode is detected as ``centroid
+    spectrum``. Representation feeds the resampling decision tree, so leaving
+    the two files disagreeing about it would compare a linear axis against a
+    nonlinear one and call the reader wrong for it.
+    """
+    kwargs.setdefault("spectrum_representation", "centroid spectrum")
+    return build_mzpeak(path, spectra, **kwargs)
+
+
+def _assert_same_representation(imzml: Path, mzpeak: Path) -> None:
+    """Fail early, and legibly, if the two inputs disagree on representation.
+
+    Spectrum representation selects the mass-axis law, so a mismatch shows up
+    downstream as two axes of different shape -- a wall of unequal floats that
+    says nothing about the cause. Checking it here names the problem.
+    """
+    from thyra.readers.imzml import ImzMLReader
+    from thyra.readers.mzpeak import MzPeakReader
+
+    with ImzMLReader(imzml) as reader:
+        expected = reader.get_essential_metadata().spectrum_type
+    with MzPeakReader(mzpeak) as reader:
+        actual = reader.get_essential_metadata().spectrum_type
+
+    assert actual == expected, (
+        f"fixtures disagree on spectrum representation: imzML says "
+        f"{expected!r}, mzPeak says {actual!r}; the resampled axis law is "
+        f"chosen from this, so the stores cannot match"
+    )
+
+
+def _convert(source: Path, output: Path, resampling_config=None) -> None:
+    """Convert one input, asserting the conversion reported success."""
+    assert (
+        convert_msi(
+            str(source),
+            str(output),
+            format_type="spatialdata",
+            dataset_id=DATASET_ID,
+            pixel_size_um=PIXEL_SIZE_UM,
+            resampling_config=resampling_config,
+        )
+        is True
+    )
+
+
+def _table(store: Path):
+    """Load the single table out of a converted store."""
+    return spatialdata.SpatialData.read(str(store)).tables[TABLE]
+
+
+def _dense(table):
+    """Densify X for comparison; the fixtures are deliberately tiny."""
+    matrix = table.X
+    return matrix.toarray() if hasattr(matrix, "toarray") else np.asarray(matrix)
+
+
+@pytest.mark.integration
+class TestImzMLParity:
+    """The same data through two readers must land in the same store."""
+
+    @pytest.mark.parametrize(
+        "resampling_config",
+        [
+            pytest.param(None, id="native-axis"),
+            pytest.param(
+                {"method": "nearest_neighbor", "target_bins": 64},
+                id="resampled",
+            ),
+        ],
+    )
+    def test_stores_match(self, tmp_path, resampling_config):
+        """X, obs coordinates and the m/z axis all agree.
+
+        Run twice: once on the native union axis, where any disagreement
+        about which m/z values exist is visible directly, and once through
+        resampling, where the axis is rebuilt and the test instead pins the
+        binned intensities.
+        """
+        spectra = grid_spectra(3, 2, n_points=6)
+
+        imzml = _write_imzml(tmp_path / "source.imzML", spectra)
+        mzpeak = _matching_mzpeak(tmp_path / "source.mzpeak", spectra)
+        _assert_same_representation(imzml, mzpeak)
+
+        imzml_store = tmp_path / "from_imzml.zarr"
+        mzpeak_store = tmp_path / "from_mzpeak.zarr"
+        _convert(imzml, imzml_store, resampling_config)
+        _convert(mzpeak, mzpeak_store, resampling_config)
+
+        reference = _table(imzml_store)
+        candidate = _table(mzpeak_store)
+
+        assert candidate.n_obs == reference.n_obs
+        assert candidate.n_vars == reference.n_vars
+        np.testing.assert_allclose(
+            candidate.var["mz"].to_numpy(),
+            reference.var["mz"].to_numpy(),
+            rtol=0,
+            atol=0,
+        )
+        for column in ("spatial_x", "spatial_y"):
+            np.testing.assert_array_equal(
+                candidate.obs[column].to_numpy(),
+                reference.obs[column].to_numpy(),
+            )
+        np.testing.assert_allclose(
+            _dense(candidate), _dense(reference), rtol=1e-12, atol=0
+        )
+
+    def test_sparse_acquisition_matches(self, tmp_path):
+        """Missing pixels land in the same places from both formats.
+
+        Neither reader may densify: an unacquired position must stay
+        unacquired rather than becoming a row of zeros.
+        """
+        spectra = grid_spectra(3, 3, n_points=5, skip=[(2, 2), (3, 1)])
+
+        imzml = _write_imzml(tmp_path / "sparse.imzML", spectra)
+        mzpeak = _matching_mzpeak(tmp_path / "sparse.mzpeak", spectra)
+
+        imzml_store = tmp_path / "sparse_imzml.zarr"
+        mzpeak_store = tmp_path / "sparse_mzpeak.zarr"
+        _convert(imzml, imzml_store)
+        _convert(mzpeak, mzpeak_store)
+
+        reference = _table(imzml_store)
+        candidate = _table(mzpeak_store)
+
+        assert candidate.n_obs == reference.n_obs == 7
+        np.testing.assert_array_equal(
+            candidate.obs[["spatial_x", "spatial_y"]].to_numpy(),
+            reference.obs[["spatial_x", "spatial_y"]].to_numpy(),
+        )
+        np.testing.assert_allclose(_dense(candidate), _dense(reference))
+
+    def test_row_group_split_does_not_change_the_store(self, tmp_path):
+        """Writer row-group choices are invisible in the output.
+
+        Spectra straddling row-group boundaries are the one place the reader
+        does non-trivial bookkeeping, so this pins it end to end rather than
+        only at the iteration layer.
+        """
+        spectra = grid_spectra(3, 2, n_points=7)
+
+        whole = _matching_mzpeak(tmp_path / "whole.mzpeak", spectra)
+        split = _matching_mzpeak(tmp_path / "split.mzpeak", spectra, row_group_size=2)
+
+        whole_store = tmp_path / "whole.zarr"
+        split_store = tmp_path / "split.zarr"
+        _convert(whole, whole_store)
+        _convert(split, split_store)
+
+        np.testing.assert_allclose(
+            _dense(_table(split_store)), _dense(_table(whole_store))
+        )
+
+
+@pytest.mark.integration
+class TestConversion:
+    """Conversion behaviour specific to mzPeak inputs."""
+
+    def test_pixel_size_is_detected_from_the_archive(self, tmp_path):
+        """An archive declaring IMS:1000046/47 needs no --pixel-size."""
+        archive = build_mzpeak(
+            tmp_path / "sized.mzpeak",
+            grid_spectra(2, 2, n_points=4),
+            pixel_size=(12.0, 12.0),
+        )
+        output = tmp_path / "sized.zarr"
+
+        assert (
+            convert_msi(
+                str(archive),
+                str(output),
+                format_type="spatialdata",
+                dataset_id=DATASET_ID,
+            )
+            is True
+        )
+        assert output.exists()
+
+    def test_declared_grid_extent_is_writable_provenance(self, tmp_path):
+        """An archive declaring IMS:1000042/43 still saves.
+
+        The extent is recorded in ``uns``, and zarr writes a dict key as a
+        directory name. Keying it by accession made the store unwritable on
+        Windows, where a colon is not legal in a path -- and no fixture that
+        stopped at the metadata object could see it, because the failure is
+        in the save.
+        """
+        archive = build_mzpeak(
+            tmp_path / "extent.mzpeak",
+            grid_spectra(2, 2, n_points=4),
+            grid=(32, 32),
+            spectrum_representation="centroid spectrum",
+        )
+        output = tmp_path / "extent.zarr"
+        _convert(archive, output)
+
+        table = _table(output)
+        extent = table.uns["acquisition_params"]["declared_grid_extent"]
+        assert extent["max_count_of_pixels_x"] == 32
+        assert extent["max_count_of_pixels_y"] == 32
+
+    def test_null_padded_archive_converts(self, tmp_path):
+        """Null-pair padding does not reach the stored matrix.
+
+        A NaN surviving into X would poison every downstream statistic, so
+        this asserts the stored values are finite as well as correct.
+        """
+        spectra = grid_spectra(2, 2, n_points=6)
+        archive = build_mzpeak(tmp_path / "padded.mzpeak", spectra, null_pair_after=3)
+        output = tmp_path / "padded.zarr"
+        _convert(archive, output)
+
+        table = _table(output)
+        values = _dense(table)
+        assert np.isfinite(values).all()
+        assert np.isfinite(table.var["mz"].to_numpy()).all()
+        assert table.n_vars == 6
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("THYRA_MZPEAK_REFERENCE_ARCHIVE"),
+    reason=(
+        "Set THYRA_MZPEAK_REFERENCE_ARCHIVE to an archive written by the "
+        "HUPO-PSI reference converter to run the interoperability check"
+    ),
+)
+def test_reference_archive_converts(tmp_path):
+    """Convert an archive written by the reference implementation.
+
+    The constructed fixtures pin the schema this reader was written against,
+    but only a file produced by someone else's writer can show the two agree.
+    The reference sample archives are not vendored: that repository publishes
+    no licence, so redistributing its data in a package that ships to PyPI
+    would not be ours to do. The check therefore runs opt-in, against a path
+    the operator supplies.
+    """
+    archive = Path(os.environ["THYRA_MZPEAK_REFERENCE_ARCHIVE"])
+    if not archive.exists():
+        pytest.skip(f"reference archive not found: {archive}")
+
+    output = tmp_path / "reference.zarr"
+    _convert(archive, output)
+
+    table = _table(output)
+    assert table.n_obs > 0
+    assert table.n_vars > 0
+    values = _dense(table)
+    assert np.isfinite(values).all()
+    assert np.isfinite(table.var["mz"].to_numpy()).all()

--- a/tests/unit/metadata/extractors/test_mzpeak_extractor.py
+++ b/tests/unit/metadata/extractors/test_mzpeak_extractor.py
@@ -1,0 +1,239 @@
+"""Metadata extraction from mzPeak archives."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.fixtures.mzpeak_builder import Spectrum, build_mzpeak, grid_spectra
+from thyra.readers.mzpeak import MzPeakReader
+
+
+def _essential(path):
+    """Read essential metadata and close the archive."""
+    with MzPeakReader(path) as reader:
+        return reader.get_essential_metadata()
+
+
+class TestPixelSize:
+    """Pixel size is matched on accession and normalised to micrometres."""
+
+    def test_micrometre_pixel_size_is_read(self, tmp_path):
+        """The common case: IMS:1000046/47 in UO:0000017."""
+        archive = build_mzpeak(
+            tmp_path / "um.mzpeak", grid_spectra(2, 2), pixel_size=(30.0, 40.0)
+        )
+        assert _essential(archive).pixel_size == (30.0, 40.0)
+
+    @pytest.mark.parametrize(
+        ("unit", "value", "expected"),
+        [
+            ("UO:0000017", 25.0, 25.0),  # micrometre
+            ("UO:0000018", 4406.25, 4.40625),  # nanometre
+            ("UO:0000016", 0.05, 50.0),  # millimetre
+        ],
+    )
+    def test_units_are_converted(self, tmp_path, unit, value, expected):
+        """Everything downstream is micrometres, so units are folded here.
+
+        The nanometre case is the one that bit the imzML reader: a 4.40625 um
+        pixel read as 4406.25 um if the unit is dropped.
+        """
+        archive = build_mzpeak(
+            tmp_path / f"unit_{unit.replace(':', '_')}.mzpeak",
+            grid_spectra(2, 2),
+            pixel_size=(value, value),
+            pixel_size_unit=unit,
+        )
+        pixel_size = _essential(archive).pixel_size
+        assert pixel_size is not None
+        assert pixel_size[0] == pytest.approx(expected)
+        assert pixel_size[1] == pytest.approx(expected)
+
+    def test_missing_pixel_size_returns_none(self, tmp_path):
+        """Real Bruker exports carry no scan-settings block at all.
+
+        The converter then falls through to ``--pixel-size``, exactly as it
+        does for an imzML that omits the terms.
+        """
+        archive = build_mzpeak(
+            tmp_path / "nopixel.mzpeak", grid_spectra(2, 2), pixel_size=None
+        )
+        essential = _essential(archive)
+        assert essential.pixel_size is None
+        assert essential.has_pixel_size is False
+
+    def test_unsupported_unit_is_refused_not_assumed(self, tmp_path):
+        """An unknown unit yields no pixel size rather than a silent scale.
+
+        Passing the number through unconverted would be a scale error that
+        nothing downstream could detect.
+        """
+        archive = build_mzpeak(
+            tmp_path / "badunit.mzpeak",
+            grid_spectra(2, 2),
+            pixel_size=None,
+            footer_metadata=False,
+            index_metadata={
+                "scan_settings_list": [
+                    {
+                        "id": "scansettings1",
+                        "parameters": [
+                            {
+                                "name": "pixel size (x)",
+                                "accession": "IMS:1000046",
+                                "value": 25.0,
+                                "unit": "UO:9999999",
+                            }
+                        ],
+                    }
+                ]
+            },
+        )
+        assert _essential(archive).pixel_size is None
+
+    def test_single_declared_axis_is_treated_as_square(self, tmp_path):
+        """A file declaring only IMS:1000046 describes a square pixel."""
+        archive = build_mzpeak(
+            tmp_path / "oneaxis.mzpeak",
+            grid_spectra(2, 2),
+            pixel_size=None,
+            footer_metadata=False,
+            index_metadata={
+                "scan_settings_list": [
+                    {
+                        "id": "scansettings1",
+                        "parameters": [
+                            {
+                                "name": "pixel size (x)",
+                                "accession": "IMS:1000046",
+                                "value": 12.5,
+                                "unit": "UO:0000017",
+                            }
+                        ],
+                    }
+                ]
+            },
+        )
+        assert _essential(archive).pixel_size == (12.5, 12.5)
+
+
+class TestMetadataPlacement:
+    """File-level metadata lives in two places and either may be empty."""
+
+    def test_read_from_the_parquet_footer(self, tmp_path):
+        """The reference imaging archive puts everything here."""
+        archive = build_mzpeak(
+            tmp_path / "footer.mzpeak",
+            grid_spectra(2, 2),
+            pixel_size=(15.0, 15.0),
+            index_metadata=None,
+            footer_metadata=True,
+        )
+        assert _essential(archive).pixel_size == (15.0, 15.0)
+
+    def test_read_from_the_index_metadata_object(self, tmp_path):
+        """Other reference archives populate the index instead.
+
+        A reader that consults only one of the two locations finds nothing on
+        half the corpus, which is why both are merged.
+        """
+        archive = build_mzpeak(
+            tmp_path / "indexmeta.mzpeak",
+            grid_spectra(2, 2),
+            pixel_size=None,
+            footer_metadata=False,
+            index_metadata={
+                "version": "0.9.0",
+                "scan_settings_list": [
+                    {
+                        "id": "scansettings1",
+                        "parameters": [
+                            {
+                                "name": "pixel size (x)",
+                                "accession": "IMS:1000046",
+                                "value": 18.0,
+                                "unit": "UO:0000017",
+                            },
+                            {
+                                "name": "pixel size y",
+                                "accession": "IMS:1000047",
+                                "value": 18.0,
+                                "unit": "UO:0000017",
+                            },
+                        ],
+                    }
+                ],
+            },
+        )
+        assert _essential(archive).pixel_size == (18.0, 18.0)
+
+    def test_container_version_is_reported(self, tmp_path):
+        """The draft version appears only in the index metadata object."""
+        archive = build_mzpeak(
+            tmp_path / "version.mzpeak",
+            grid_spectra(2, 2),
+            index_metadata={"version": "0.9.0"},
+        )
+        with MzPeakReader(archive) as reader:
+            comprehensive = reader.get_comprehensive_metadata()
+        assert comprehensive.format_specific["container_version"] == "0.9.0"
+
+
+class TestEssentialShape:
+    """Dimensions, bounds, counts and representation."""
+
+    def test_dimensions_and_bounds(self, tmp_path):
+        """Grid comes from the positions actually present."""
+        archive = build_mzpeak(tmp_path / "shape.mzpeak", grid_spectra(4, 3))
+        essential = _essential(archive)
+
+        assert essential.dimensions == (4, 3, 1)
+        assert essential.coordinate_bounds == (1.0, 4.0, 1.0, 3.0)
+        assert essential.n_spectra == 12
+
+    def test_declared_extent_does_not_override_observed_positions(self, tmp_path):
+        """A declared grid larger than the data does not pad the output.
+
+        IMS:1000042/43 are kept as provenance only: trusting them would size
+        the grid from an assertion rather than from the pixels present.
+        """
+        archive = build_mzpeak(
+            tmp_path / "extent.mzpeak", grid_spectra(2, 2), grid=(64, 64)
+        )
+        with MzPeakReader(archive) as reader:
+            essential = reader.get_essential_metadata()
+            comprehensive = reader.get_comprehensive_metadata()
+
+        assert essential.dimensions == (2, 2, 1)
+        # Plain names, not accessions: these become uns keys and zarr writes
+        # a dict key as a directory name, where a colon is illegal on Windows.
+        assert comprehensive.acquisition_params["declared_grid_extent"] == {
+            "max_count_of_pixels_x": 64,
+            "max_count_of_pixels_y": 64,
+        }
+
+    def test_mass_range_spans_every_spectrum(self, tmp_path):
+        """Range is the min of the lows and the max of the highs."""
+        spectra = [
+            Spectrum(1, 1, [100.0, 150.0], [1.0, 2.0]),
+            Spectrum(2, 1, [120.0, 900.0], [3.0, 4.0]),
+        ]
+        archive = build_mzpeak(tmp_path / "range.mzpeak", spectra)
+        assert _essential(archive).mass_range == (100.0, 900.0)
+
+    @pytest.mark.parametrize(
+        "representation", ["profile spectrum", "centroid spectrum"]
+    )
+    def test_spectrum_type_is_reported(self, tmp_path, representation):
+        """Representation drives the resampling decision tree."""
+        archive = build_mzpeak(
+            tmp_path / f"rep_{representation.split()[0]}.mzpeak",
+            grid_spectra(2, 2),
+            spectrum_representation=representation,
+        )
+        assert _essential(archive).spectrum_type == representation
+
+    def test_source_path_is_the_archive(self, tmp_path):
+        """Provenance points at the file that was read."""
+        archive = build_mzpeak(tmp_path / "source.mzpeak", grid_spectra(2, 2))
+        assert _essential(archive).source_path == str(archive)

--- a/tests/unit/readers/test_mzpeak_detection.py
+++ b/tests/unit/readers/test_mzpeak_detection.py
@@ -1,0 +1,119 @@
+"""Format detection for ``.mzpeak`` archives.
+
+Detection is deliberately container-level: extension, ZIP signature, index
+member. It does not open the Parquet members, so a non-imaging or
+chunked-layout archive still detects as mzPeak and is refused later by the
+reader, with an error that can say which of the two it was.
+"""
+
+from __future__ import annotations
+
+import zipfile
+
+import pytest
+
+from tests.fixtures.mzpeak_builder import build_mzpeak, grid_spectra
+from thyra.core.registry import MSIRegistry
+
+
+@pytest.fixture
+def registry():
+    """A registry instance for detection calls."""
+    return MSIRegistry()
+
+
+class TestAccepts:
+    """Archives that should be recognised."""
+
+    def test_detects_a_valid_archive(self, registry, tmp_path):
+        """Extension, ZIP magic and index member all present."""
+        archive = build_mzpeak(tmp_path / "valid.mzpeak", grid_spectra(2, 2))
+        assert registry.detect_format(archive) == "mzpeak"
+
+    def test_detection_is_case_insensitive(self, registry, tmp_path):
+        """``.MZPEAK`` is the same extension."""
+        archive = build_mzpeak(tmp_path / "upper.MZPEAK", grid_spectra(2, 2))
+        assert registry.detect_format(archive) == "mzpeak"
+
+    def test_non_imaging_archive_still_detects(self, registry, tmp_path):
+        """Detection identifies the container; the reader judges the content.
+
+        Refusing here would report "unsupported format" for a file that is a
+        perfectly valid mzPeak archive, which is a worse diagnosis than the
+        reader's "not an imaging archive".
+        """
+        archive = build_mzpeak(
+            tmp_path / "nonimaging.mzpeak",
+            grid_spectra(2, 1),
+            include_positions=False,
+        )
+        assert registry.detect_format(archive) == "mzpeak"
+
+
+class TestRejects:
+    """Things wearing the extension that are not mzPeak archives."""
+
+    def test_rejects_a_file_that_is_not_a_zip(self, registry, tmp_path):
+        """The extension alone is not evidence."""
+        impostor = tmp_path / "impostor.mzpeak"
+        impostor.write_bytes(b"this is not a zip archive at all")
+
+        with pytest.raises(ValueError, match="missing ZIP signature"):
+            registry.detect_format(impostor)
+
+    def test_rejects_a_zip_without_the_index_member(self, registry, tmp_path):
+        """A ZIP of Parquet files is not an archive without its index.
+
+        The index is what maps members to roles; without it there is nothing
+        to resolve against and hardcoding filenames would be a guess.
+        """
+        bare = tmp_path / "bare.mzpeak"
+        with zipfile.ZipFile(bare, "w", compression=zipfile.ZIP_STORED) as handle:
+            handle.writestr("spectra_data.parquet", b"not really parquet")
+
+        with pytest.raises(ValueError, match="no mzpeak_index.json member"):
+            registry.detect_format(bare)
+
+    def test_rejects_a_directory(self, registry, tmp_path):
+        """mzPeak is a single file; the loose Parquet layout is not it."""
+        directory = tmp_path / "unpacked.mzpeak"
+        directory.mkdir()
+
+        with pytest.raises(ValueError, match="requires a .mzpeak archive file"):
+            registry.detect_format(directory)
+
+    def test_rejects_a_missing_path(self, registry, tmp_path):
+        """A path that does not exist fails before any format guessing."""
+        with pytest.raises(ValueError, match="does not exist"):
+            registry.detect_format(tmp_path / "absent.mzpeak")
+
+
+class TestRegistration:
+    """The reader is wired into the registry under its format name."""
+
+    def test_reader_class_is_registered(self):
+        """``convert_msi`` resolves the reader through this lookup.
+
+        Deliberately the module-level accessor rather than a fresh registry:
+        the decorator registers against the singleton, so a new instance
+        would prove nothing about what conversion actually sees.
+        """
+        from thyra.core.registry import get_reader_class
+        from thyra.readers.mzpeak import MzPeakReader
+
+        assert get_reader_class("mzpeak") is MzPeakReader
+
+    def test_extractor_is_registered_for_the_format(self):
+        """The dynamic extractor lookup knows the format too."""
+        from thyra.metadata.extractors import get_extractor_for_format
+        from thyra.metadata.extractors.mzpeak_extractor import MzPeakMetadataExtractor
+
+        assert get_extractor_for_format("mzpeak") is MzPeakMetadataExtractor
+
+    def test_unsupported_format_message_lists_mzpeak(self, registry, tmp_path):
+        """A user with an unreadable file is told mzPeak is an option."""
+        unknown = tmp_path / "mystery.xyz"
+        unknown.write_bytes(b"\x00\x01\x02")
+
+        with pytest.raises(ValueError, match=r"\.mzpeak"):
+            registry.detect_format(unknown)

--- a/tests/unit/readers/test_mzpeak_reader.py
+++ b/tests/unit/readers/test_mzpeak_reader.py
@@ -1,0 +1,325 @@
+"""Reader-level tests for the experimental mzPeak reader.
+
+Every archive here is built by :mod:`tests.fixtures.mzpeak_builder`, which
+spells the container out literally rather than asking the reader how to write
+it -- see that module's docstring for why that separation matters.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from tests.fixtures.mzpeak_builder import Spectrum, build_mzpeak, grid_spectra
+from thyra.readers.mzpeak import MzPeakReader
+
+
+@pytest.fixture
+def simple_archive(tmp_path):
+    """A 3x2 acquisition, 1-based positions, eight points per spectrum."""
+    return build_mzpeak(tmp_path / "simple.mzpeak", grid_spectra(3, 2))
+
+
+class TestIteration:
+    """Coordinates, payloads and ordering coming out of iter_spectra."""
+
+    def test_yields_every_spectrum_in_index_order(self, simple_archive):
+        """All spectra arrive, ascending, with 0-based coordinates."""
+        with MzPeakReader(simple_archive) as reader:
+            emitted = list(reader.iter_spectra())
+
+        assert len(emitted) == 6
+        assert [coords for coords, _, _ in emitted] == [
+            (0, 0, 0),
+            (1, 0, 0),
+            (2, 0, 0),
+            (0, 1, 0),
+            (1, 1, 0),
+            (2, 1, 0),
+        ]
+
+    def test_payload_matches_what_was_written(self, tmp_path):
+        """m/z and intensity survive the round trip, as float64."""
+        spectra = [Spectrum(1, 1, [100.0, 200.5, 300.25], [7.0, 8.0, 9.0])]
+        archive = build_mzpeak(tmp_path / "one.mzpeak", spectra)
+
+        with MzPeakReader(archive) as reader:
+            ((_, mzs, intensities),) = list(reader.iter_spectra())
+
+        np.testing.assert_array_equal(mzs, [100.0, 200.5, 300.25])
+        np.testing.assert_allclose(intensities, [7.0, 8.0, 9.0])
+        assert mzs.dtype == np.float64
+        assert intensities.dtype == np.float64
+
+    def test_spectrum_straddling_row_groups_is_emitted_once(self, tmp_path):
+        """A spectrum split across row groups is reassembled, not duplicated.
+
+        Row groups cut at a fixed row count with no regard for spectrum
+        boundaries, so with eight points per spectrum and three rows per group
+        every spectrum spans several groups.
+        """
+        archive = build_mzpeak(
+            tmp_path / "straddle.mzpeak",
+            grid_spectra(2, 2, n_points=8),
+            row_group_size=3,
+        )
+
+        with MzPeakReader(archive) as reader:
+            emitted = list(reader.iter_spectra())
+
+        assert len(emitted) == 4
+        assert [coords for coords, _, _ in emitted] == [
+            (0, 0, 0),
+            (1, 0, 0),
+            (0, 1, 0),
+            (1, 1, 0),
+        ]
+        for _, mzs, intensities in emitted:
+            assert mzs.size == 8
+            assert intensities.size == 8
+            # Ascending within the spectrum proves the pieces were joined in
+            # order rather than concatenated arbitrarily.
+            assert np.all(np.diff(mzs) > 0)
+
+    def test_row_group_size_does_not_change_the_result(self, tmp_path):
+        """Reading is invariant to how the writer chose its row groups."""
+        spectra = grid_spectra(3, 2, n_points=7)
+        whole = build_mzpeak(tmp_path / "whole.mzpeak", spectra)
+        split = build_mzpeak(tmp_path / "split.mzpeak", spectra, row_group_size=2)
+
+        with MzPeakReader(whole) as reader:
+            reference = list(reader.iter_spectra())
+        with MzPeakReader(split) as reader:
+            candidate = list(reader.iter_spectra())
+
+        assert len(reference) == len(candidate)
+        for (coords_a, mz_a, int_a), (coords_b, mz_b, int_b) in zip(
+            reference, candidate
+        ):
+            assert coords_a == coords_b
+            np.testing.assert_array_equal(mz_a, mz_b)
+            np.testing.assert_array_equal(int_a, int_b)
+
+    def test_zero_based_positions_are_normalised(self, tmp_path):
+        """A 0-based file lands on the same grid as a 1-based one.
+
+        Normalisation subtracts the observed minimum rather than a constant,
+        because the format promises nothing about the origin.
+        """
+        archive = build_mzpeak(tmp_path / "zero.mzpeak", grid_spectra(2, 2, base=0))
+
+        with MzPeakReader(archive) as reader:
+            coords = [c for c, _, _ in reader.iter_spectra()]
+
+        assert coords == [(0, 0, 0), (1, 0, 0), (0, 1, 0), (1, 1, 0)]
+
+    def test_offset_positions_are_normalised(self, tmp_path):
+        """A file whose positions start at 5 still converts to a 0-based grid."""
+        spectra = [
+            Spectrum(5, 9, [100.0, 101.0], [1.0, 2.0]),
+            Spectrum(6, 9, [100.0, 101.0], [3.0, 4.0]),
+            Spectrum(5, 10, [100.0, 101.0], [5.0, 6.0]),
+        ]
+        archive = build_mzpeak(tmp_path / "offset.mzpeak", spectra)
+
+        with MzPeakReader(archive) as reader:
+            coords = [c for c, _, _ in reader.iter_spectra()]
+            essential = reader.get_essential_metadata()
+
+        assert coords == [(0, 0, 0), (1, 0, 0), (0, 1, 0)]
+        assert essential.coordinate_offsets == (5, 9, 0)
+
+    def test_missing_pixels_are_left_missing(self, tmp_path):
+        """A sparse acquisition yields only acquired pixels.
+
+        Missing pixels are ordinary in imaging mzPeak -- they were 38% of the
+        real dataset this reader was designed against -- and the converter's
+        sparse grid handles the gaps. Densifying here would invent spectra.
+        """
+        spectra = grid_spectra(3, 3, skip=[(2, 2), (3, 1)])
+        archive = build_mzpeak(tmp_path / "sparse.mzpeak", spectra)
+
+        with MzPeakReader(archive) as reader:
+            coords = [c for c, _, _ in reader.iter_spectra()]
+            essential = reader.get_essential_metadata()
+
+        assert len(coords) == 7
+        assert (1, 1, 0) not in coords  # the skipped (2, 2) in file frame
+        assert (2, 0, 0) not in coords  # the skipped (3, 1) in file frame
+        assert essential.dimensions == (3, 3, 1)
+        assert essential.n_spectra == 7
+
+
+class TestMassAxis:
+    """The reader's view of the m/z axis."""
+
+    def test_never_claims_a_shared_axis(self, simple_archive):
+        """mzPeak has no shared-axis concept anywhere in the format."""
+        with MzPeakReader(simple_archive) as reader:
+            assert reader.has_shared_mass_axis is False
+
+    def test_common_axis_is_the_sorted_union(self, tmp_path):
+        """Per-spectrum axes combine into one ascending, deduplicated axis."""
+        spectra = [
+            Spectrum(1, 1, [100.0, 102.0], [1.0, 2.0]),
+            Spectrum(2, 1, [101.0, 102.0], [3.0, 4.0]),
+        ]
+        archive = build_mzpeak(tmp_path / "union.mzpeak", spectra)
+
+        with MzPeakReader(archive) as reader:
+            axis = reader.get_common_mass_axis()
+
+        np.testing.assert_array_equal(axis, [100.0, 101.0, 102.0])
+
+
+class TestNullPairPadding:
+    """Null pairs mark removed zero runs and must not reach the converter."""
+
+    def test_padding_is_dropped_from_the_payload(self, tmp_path):
+        """Rows whose m/z and intensity are both null never surface."""
+        spectra = grid_spectra(2, 1, n_points=6)
+        archive = build_mzpeak(tmp_path / "padded.mzpeak", spectra, null_pair_after=3)
+
+        with MzPeakReader(archive) as reader:
+            emitted = list(reader.iter_spectra())
+
+        for _, mzs, intensities in emitted:
+            assert mzs.size == 6
+            assert intensities.size == 6
+            assert not np.isnan(mzs).any()
+            assert not np.isnan(intensities).any()
+
+    def test_padding_is_excluded_from_the_mass_axis(self, tmp_path):
+        """The axis holds only channels that can take a value."""
+        spectra = grid_spectra(2, 1, n_points=6)
+        archive = build_mzpeak(
+            tmp_path / "padded_axis.mzpeak", spectra, null_pair_after=3
+        )
+
+        with MzPeakReader(archive) as reader:
+            axis = reader.get_common_mass_axis()
+
+        assert not np.isnan(axis).any()
+        assert np.all(np.diff(axis) > 0)
+
+    def test_peak_counts_are_corrected_for_padding(self, tmp_path):
+        """Recorded point counts include padding; the reported total does not.
+
+        ``number_of_data_points`` counts stored rows, so a file with a null
+        pair per spectrum records two more per spectrum than it can deliver.
+        Reporting the recorded figure would have the converter pre-allocate
+        for points that never arrive.
+        """
+        spectra = grid_spectra(2, 1, n_points=6)
+        archive = build_mzpeak(
+            tmp_path / "padded_counts.mzpeak", spectra, null_pair_after=3
+        )
+
+        with MzPeakReader(archive) as reader:
+            essential = reader.get_essential_metadata()
+            delivered = sum(mzs.size for _, mzs, _ in reader.iter_spectra())
+
+        assert essential.total_peaks == delivered == 12
+
+    def test_per_pixel_counts_declined_when_padded(self, tmp_path):
+        """Per-pixel counts are withheld rather than reported inflated.
+
+        The padding cannot be attributed to individual spectra without a full
+        pass over the point data, which is the pass these counts exist to
+        avoid, so the reader declines and the converter measures instead.
+        """
+        spectra = grid_spectra(2, 1, n_points=6)
+        padded = build_mzpeak(
+            tmp_path / "padded_ppp.mzpeak", spectra, null_pair_after=3
+        )
+        clean = build_mzpeak(tmp_path / "clean_ppp.mzpeak", spectra)
+
+        with MzPeakReader(padded) as reader:
+            assert reader.get_peak_counts_per_pixel() is None
+        with MzPeakReader(clean) as reader:
+            counts = reader.get_peak_counts_per_pixel()
+
+        assert counts is not None
+        np.testing.assert_array_equal(counts, [6, 6])
+
+
+class TestIndexTolerance:
+    """The index vocabulary is parsed as tolerantly as the reference parser."""
+
+    @pytest.mark.parametrize("spelling", ["data_arrays", "data arrays", "DATA ARRAYS"])
+    def test_data_kind_spellings_all_resolve(self, tmp_path, spelling):
+        """Underscore, space and case variants name the same role.
+
+        ``DataKind::from_str`` lowercases and trims before matching and
+        carries ``data arrays`` as an explicit alias, so a reader that
+        compares the raw string rejects valid archives.
+        """
+        archive = build_mzpeak(
+            tmp_path / f"kind_{abs(hash(spelling))}.mzpeak",
+            grid_spectra(2, 1),
+            data_kind=spelling,
+        )
+
+        with MzPeakReader(archive) as reader:
+            assert len(list(reader.iter_spectra())) == 2
+
+    def test_metadata_mapping_alias_is_accepted(self, tmp_path):
+        """``metadata_mapping`` is a serde alias for ``column_mapping``."""
+        archive = build_mzpeak(
+            tmp_path / "alias.mzpeak",
+            grid_spectra(2, 1),
+            column_mapping_key="metadata_mapping",
+        )
+
+        with MzPeakReader(archive) as reader:
+            assert len(list(reader.iter_spectra())) == 2
+
+    def test_absent_column_mapping_falls_back_to_conventional_names(self, tmp_path):
+        """Bindings are ``serde(default)``, so an archive may omit them."""
+        archive = build_mzpeak(
+            tmp_path / "nomapping.mzpeak",
+            grid_spectra(2, 1),
+            column_mapping_key=None,
+        )
+
+        with MzPeakReader(archive) as reader:
+            assert [c for c, _, _ in reader.iter_spectra()] == [
+                (0, 0, 0),
+                (1, 0, 0),
+            ]
+
+
+class TestRefusals:
+    """Layouts and acquisitions the reader will not pretend to handle."""
+
+    def test_chunked_layout_is_refused_by_name(self, tmp_path):
+        """The chunked encoding is a different layout, not a variant."""
+        archive = build_mzpeak(
+            tmp_path / "chunked.mzpeak", grid_spectra(2, 1), layout="chunk"
+        )
+
+        with pytest.raises(NotImplementedError, match="chunked layout"):
+            with MzPeakReader(archive) as reader:
+                reader.get_essential_metadata()
+
+    def test_non_imaging_archive_is_refused(self, tmp_path):
+        """No positions means no pixels, and Thyra is MSI-only.
+
+        A valid mzPeak file can carry no positions at all -- the reference
+        converter only emits them when it happens to see imaging input.
+        """
+        archive = build_mzpeak(
+            tmp_path / "nonimaging.mzpeak",
+            grid_spectra(2, 1),
+            include_positions=False,
+        )
+
+        with pytest.raises(ValueError, match="not an imaging mzPeak archive"):
+            with MzPeakReader(archive) as reader:
+                reader.get_essential_metadata()
+
+    def test_region_map_is_none(self, simple_archive):
+        """mzPeak carries no region or ROI identity of any kind."""
+        with MzPeakReader(simple_archive) as reader:
+            assert reader.get_region_map() is None
+            assert reader.get_region_info() is None

--- a/thyra/core/registry.py
+++ b/thyra/core/registry.py
@@ -1,6 +1,7 @@
 # thyra/core/registry.py
 import logging
 import re
+import zipfile
 from pathlib import Path
 from threading import RLock
 from typing import Dict, NoReturn, Type
@@ -154,6 +155,8 @@ class MSIRegistry:
         extension = input_path.suffix.lower()
         if extension == ".imzml":
             return "imzml"
+        if extension == ".mzpeak":
+            return self._detect_mzpeak_format(input_path)
         if extension == ".d":
             return self._detect_bruker_d_format(input_path)
         if extension == ".raw":
@@ -174,6 +177,53 @@ class MSIRegistry:
         if bruker_format:
             return bruker_format
         raise ValueError("Bruker .d directory missing analysis " f"files: {input_path}")
+
+    def _detect_mzpeak_format(self, input_path: Path) -> str:
+        """Validate that a ``.mzpeak`` path really is an mzPeak archive.
+
+        Three checks, cheapest first: the extension (already matched by the
+        caller), the ZIP local-file-header magic, and the presence of the
+        index member. The extension alone is not enough -- it is a young
+        format and the name gets attached to loose Parquet directories -- and
+        a file failing here should say so rather than failing later inside
+        pyarrow with a message about a corrupt footer.
+
+        Args:
+            input_path: Path with a ``.mzpeak`` extension.
+
+        Returns:
+            ``"mzpeak"``.
+
+        Raises:
+            ValueError: If the file is not a ZIP or carries no index member.
+        """
+        if input_path.is_dir():
+            raise ValueError(
+                f"mzPeak format requires a .mzpeak archive file, got "
+                f"directory: {input_path}"
+            )
+        try:
+            with input_path.open("rb") as handle:
+                magic = handle.read(4)
+        except (OSError, PermissionError) as exc:
+            raise ValueError(f"Cannot read {input_path}: {exc}") from exc
+
+        if magic != b"PK\x03\x04":
+            raise ValueError(
+                f"Not an mzPeak archive (missing ZIP signature): {input_path}"
+            )
+
+        if not zipfile.is_zipfile(input_path):
+            raise ValueError(
+                f"Not an mzPeak archive (unreadable ZIP container): " f"{input_path}"
+            )
+        with zipfile.ZipFile(input_path) as archive:
+            if "mzpeak_index.json" not in archive.namelist():
+                raise ValueError(
+                    f"Not an mzPeak archive (no mzpeak_index.json member): "
+                    f"{input_path}"
+                )
+        return "mzpeak"
 
     def _detect_raw_format(self, input_path: Path) -> str:
         """Resolve a .raw path to the vendor that wrote it.
@@ -224,6 +274,7 @@ class MSIRegistry:
         """Raise error for unsupported format."""
         available = [
             ".imzml",
+            ".mzpeak (HUPO-PSI, experimental)",
             ".d (timsTOF)",
             "folder (Rapiflex)",
             ".raw directory (Waters)",

--- a/thyra/metadata/extractors/__init__.py
+++ b/thyra/metadata/extractors/__init__.py
@@ -30,6 +30,7 @@ Example usage:
 
 from .bruker_extractor import BrukerMetadataExtractor
 from .imzml_extractor import ImzMLMetadataExtractor
+from .mzpeak_extractor import MzPeakMetadataExtractor
 from .phi_extractor import PhiMetadataExtractor
 from .waters_extractor import WatersMetadataExtractor
 
@@ -37,6 +38,7 @@ from .waters_extractor import WatersMetadataExtractor
 __all__ = [
     "BrukerMetadataExtractor",
     "ImzMLMetadataExtractor",
+    "MzPeakMetadataExtractor",
     "PhiMetadataExtractor",
     "WatersMetadataExtractor",
 ]
@@ -49,6 +51,7 @@ FORMAT_EXTRACTORS = {
     "tdf": BrukerMetadataExtractor,
     "waters": WatersMetadataExtractor,
     "phi": PhiMetadataExtractor,
+    "mzpeak": MzPeakMetadataExtractor,
 }
 
 

--- a/thyra/metadata/extractors/mzpeak_extractor.py
+++ b/thyra/metadata/extractors/mzpeak_extractor.py
@@ -33,8 +33,15 @@ logger = logging.getLogger(__name__)
 #: size. Not used to size the grid -- the observed positions are, so that a
 #: dataset whose declared extent disagrees with its own pixels converts to
 #: what it actually contains -- but recorded as provenance.
-IMS_MAX_COUNT_PIXELS_X = "IMS:1000042"
-IMS_MAX_COUNT_PIXELS_Y = "IMS:1000043"
+#:
+#: Mapped to plain names rather than kept as accessions because these become
+#: keys in the store's ``uns``, and zarr turns a dict key into a directory
+#: name. A colon is not a legal path character on Windows, so accession-keyed
+#: provenance makes the whole store unwritable there.
+GRID_EXTENT_TERMS = {
+    "IMS:1000042": "max_count_of_pixels_x",
+    "IMS:1000043": "max_count_of_pixels_y",
+}
 
 
 class MzPeakMetadataExtractor(MetadataExtractor):
@@ -334,9 +341,9 @@ class MzPeakMetadataExtractor(MetadataExtractor):
         parameters = self._scan_settings_parameters()
         declared: Dict[str, Any] = {}
         for parameter in parameters:
-            accession = parameter.get("accession")
-            if accession in (IMS_MAX_COUNT_PIXELS_X, IMS_MAX_COUNT_PIXELS_Y):
-                declared[str(accession)] = parameter.get("value")
+            name = GRID_EXTENT_TERMS.get(str(parameter.get("accession")))
+            if name is not None:
+                declared[name] = parameter.get("value")
         return {
             "scan_settings": parameters,
             "declared_grid_extent": declared or None,

--- a/thyra/metadata/extractors/mzpeak_extractor.py
+++ b/thyra/metadata/extractors/mzpeak_extractor.py
@@ -1,0 +1,353 @@
+﻿# thyra/metadata/extractors/mzpeak_extractor.py
+"""Metadata extraction for mzPeak archives.
+
+Everything here comes from two places: the per-spectrum columns of
+``spectra_metadata.parquet``, and the file-level JSON blobs the archive
+carries (Parquet key-value footer, merged with the index's ``metadata``
+object -- see :meth:`MzPeakArchive.file_level_metadata`).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+
+import numpy as np
+
+from ...core.base_extractor import MetadataExtractor
+from ...resampling.constants import ImzMLAccessions, SpectrumType
+from ..types import ComprehensiveMetadata, EssentialMetadata
+from .imzml_extractor import UM_PER_UNIT
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    # Imported for typing only. A runtime import here would be a cycle:
+    # thyra.metadata.extractors is imported while thyra.core.base_reader is
+    # still initialising, and reaching into thyra.readers from this module
+    # pulls every reader package in on top of that half-built module.
+    from ...readers.mzpeak.mzpeak_reader import MzPeakArchive
+
+logger = logging.getLogger(__name__)
+
+#: Grid extent terms, reported by the reference converter alongside pixel
+#: size. Not used to size the grid -- the observed positions are, so that a
+#: dataset whose declared extent disagrees with its own pixels converts to
+#: what it actually contains -- but recorded as provenance.
+IMS_MAX_COUNT_PIXELS_X = "IMS:1000042"
+IMS_MAX_COUNT_PIXELS_Y = "IMS:1000043"
+
+
+class MzPeakMetadataExtractor(MetadataExtractor):
+    """Metadata extractor for mzPeak imaging archives."""
+
+    def __init__(self, archive: "MzPeakArchive", data_path: Path):
+        """Initialise the extractor.
+
+        Args:
+            archive: An open archive, already validated as imaging.
+            data_path: Path to the ``.mzpeak`` file, reported as the source.
+        """
+        super().__init__(archive)
+        self.archive = archive
+        self.data_path = Path(data_path)
+
+    # ------------------------------------------------------------------
+    # Essential
+    # ------------------------------------------------------------------
+
+    def _extract_essential_impl(self) -> EssentialMetadata:
+        """Extract the metadata the converter needs to make decisions."""
+        index = self.archive.spatial_index()
+        coordinates = index.coordinates
+        raw = index.raw_positions
+
+        # Grid is sized from what the file actually contains. mzPeak also
+        # declares IMS:1000042/43, but a declared extent that disagrees with
+        # the positions would silently pad or clip the output, so the
+        # declaration is kept as provenance only.
+        dimensions = (
+            int(coordinates[:, 0].max()) + 1,
+            int(coordinates[:, 1].max()) + 1,
+            1,
+        )
+        coordinate_bounds = (
+            float(raw[:, 0].min()),
+            float(raw[:, 0].max()),
+            float(raw[:, 1].min()),
+            float(raw[:, 1].max()),
+        )
+
+        n_spectra = int(index.spectrum_indices.size)
+        total_peaks = self._total_peaks()
+
+        return EssentialMetadata(
+            dimensions=dimensions,
+            coordinate_bounds=coordinate_bounds,
+            mass_range=self._mass_range(),
+            pixel_size=self._pixel_size(),
+            n_spectra=n_spectra,
+            total_peaks=total_peaks,
+            estimated_memory_gb=self._estimated_memory_gb(dimensions, total_peaks),
+            source_path=str(self.data_path),
+            coordinate_offsets=(index.offsets[0], index.offsets[1], 0),
+            spectrum_type=self._spectrum_type(),
+            peak_counts_per_pixel=self._peak_counts_per_pixel(dimensions),
+        )
+
+    def _mass_range(self) -> Tuple[float, float]:
+        """Observed m/z range across the archive.
+
+        Read from the per-spectrum ``lowest_observed_mz`` /
+        ``highest_observed_mz`` columns rather than by scanning the point
+        data: the metadata member has one row per spectrum, so this is a
+        9-row read on a 36k-point file and stays a one-row-per-spectrum read
+        at any scale.
+        """
+        table = self.archive.parquet("spectrum", "metadata").read(
+            columns=["lowest_observed_mz", "highest_observed_mz"]
+        )
+        low = np.asarray(table.column("lowest_observed_mz").to_numpy(), dtype=float)
+        high = np.asarray(table.column("highest_observed_mz").to_numpy(), dtype=float)
+        low = low[np.isfinite(low)]
+        high = high[np.isfinite(high)]
+        if low.size == 0 or high.size == 0:
+            raise ValueError(
+                f"{self.data_path} declares no observed m/z range in its "
+                f"spectrum metadata."
+            )
+        return (float(low.min()), float(high.max()))
+
+    def _scan_settings_parameters(self) -> List[dict]:
+        """Flatten every parameter of every scan-settings block."""
+        settings = self.archive.file_level_metadata().get("scan_settings_list")
+        if not isinstance(settings, list):
+            return []
+        parameters: List[dict] = []
+        for block in settings:
+            if not isinstance(block, dict):
+                continue
+            for parameter in block.get("parameters", []) or []:
+                if isinstance(parameter, dict):
+                    parameters.append(parameter)
+        return parameters
+
+    def _pixel_size(self) -> Optional[Tuple[float, float]]:
+        """Pixel size in micrometres, or ``None`` when the file omits it.
+
+        Matched on accession, never on name: the reference archive spells
+        IMS:1000046 ``"pixel size (x)"`` with parentheses and IMS:1000047
+        ``"pixel size y"`` without, so a name match finds one axis and misses
+        the other.
+
+        Absent far more often than present -- real Bruker exports carry no
+        scan-settings block at all -- in which case this returns ``None`` and
+        the converter falls through to ``--pixel-size`` exactly as it does
+        for imzML.
+        """
+        values: Dict[str, float] = {}
+        for parameter in self._scan_settings_parameters():
+            accession = parameter.get("accession")
+            if accession not in (
+                ImzMLAccessions.PIXEL_SIZE_X,
+                ImzMLAccessions.PIXEL_SIZE_Y,
+            ):
+                continue
+            converted = self._to_micrometres(parameter, accession)
+            if converted is not None:
+                values.setdefault(accession, converted)
+
+        x = values.get(ImzMLAccessions.PIXEL_SIZE_X)
+        y = values.get(ImzMLAccessions.PIXEL_SIZE_Y)
+        if x is None and y is None:
+            logger.info("Pixel size not found in metadata of %s", self.data_path.name)
+            return None
+        # A file declaring only one axis is describing a square pixel; imzML
+        # writers do this too, and refusing it would reject valid data.
+        if x is None:
+            x = y
+        if y is None:
+            y = x
+        return (float(x), float(y))
+
+    def _to_micrometres(self, parameter: dict, accession: str) -> Optional[float]:
+        """Convert one pixel-size parameter to micrometres.
+
+        A unit outside the known table is refused rather than passed through:
+        everything downstream of the extractor is micrometres, so an
+        unrecognised unit would become a silent scale error.
+        """
+        value = parameter.get("value")
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
+            logger.warning(
+                "%s in %s has non-numeric value %r; ignoring it",
+                accession,
+                self.data_path.name,
+                value,
+            )
+            return None
+
+        unit = parameter.get("unit")
+        if unit is None:
+            # imzML files routinely omit the unit and mean micrometres.
+            return float(value)
+        if unit not in UM_PER_UNIT:
+            logger.warning(
+                "%s in %s declares unsupported unit %r; ignoring the pixel "
+                "size rather than assuming a scale",
+                accession,
+                self.data_path.name,
+                unit,
+            )
+            return None
+        return float(value) * UM_PER_UNIT[unit]
+
+    def _spectrum_type(self) -> Optional[str]:
+        """Spectrum representation, from the file description or the columns.
+
+        ``file_description.contents`` carries MS:1000127/MS:1000128 for the
+        run as a whole. When it does not, the per-spectrum
+        ``spectrum_representation`` column is consulted, which the reference
+        writer fills with the CV name.
+        """
+        description = self.archive.file_level_metadata().get("file_description")
+        if isinstance(description, dict):
+            for parameter in description.get("contents", []) or []:
+                if not isinstance(parameter, dict):
+                    continue
+                accession = parameter.get("accession")
+                if accession == ImzMLAccessions.CENTROID_SPECTRUM:
+                    return SpectrumType.CENTROID
+                if accession == ImzMLAccessions.PROFILE_SPECTRUM:
+                    return SpectrumType.PROFILE
+
+        try:
+            table = self.archive.parquet("spectrum", "metadata").read(
+                columns=["spectrum_representation"]
+            )
+        except (KeyError, ValueError):
+            return None
+        values = {
+            str(value).strip().lower()
+            for value in table.column("spectrum_representation").to_pylist()
+            if value
+        }
+        if SpectrumType.CENTROID in values:
+            return SpectrumType.CENTROID
+        if SpectrumType.PROFILE in values:
+            return SpectrumType.PROFILE
+        return None
+
+    def _total_peaks(self) -> int:
+        """Points that actually carry a value, across the whole archive.
+
+        ``number_of_data_points`` counts the null-pair padding too, so on the
+        reference imaging archive it over-reports by 36%. The padding count
+        comes free from Parquet statistics, so the correction costs nothing
+        and keeps the converter's pre-allocation honest.
+        """
+        index = self.archive.spatial_index()
+        declared = int(index.point_counts.sum())
+        nulls = self.archive.null_count()
+        if not nulls:
+            return declared
+        return max(0, declared - int(nulls))
+
+    def _peak_counts_per_pixel(
+        self, dimensions: Tuple[int, int, int]
+    ) -> Optional[np.ndarray]:
+        """Per-pixel point counts for the streaming converter's CSR indptr.
+
+        Returns ``None`` when the archive contains null-pair padding. The
+        per-spectrum counts the file records include that padding, and
+        attributing it back to individual spectra would need a full pass over
+        the point data -- which is exactly the pass this method exists to
+        avoid. Handing the converter counts that are too high would size the
+        CSR ``indptr`` wrongly, so the honest answer is to decline and let it
+        take its two-pass path.
+        """
+        if self.archive.null_count():
+            logger.info(
+                "%s uses null-pair padding, so its per-spectrum point counts "
+                "include points that carry no value; declining to supply "
+                "per-pixel counts so the converter measures them itself",
+                self.data_path.name,
+            )
+            return None
+
+        index = self.archive.spatial_index()
+        n_x = dimensions[0]
+        counts = np.zeros(n_x * dimensions[1], dtype=np.int32)
+        flat = index.coordinates[:, 1] * n_x + index.coordinates[:, 0]
+        counts[flat] = index.point_counts.astype(np.int32, copy=False)
+        return counts
+
+    @staticmethod
+    def _estimated_memory_gb(
+        dimensions: Tuple[int, int, int], total_peaks: int
+    ) -> float:
+        """Rough dense footprint, used only to pick a conversion strategy."""
+        del dimensions
+        # 8 bytes of m/z plus 8 of intensity per stored point.
+        return float(total_peaks * 16) / (1024.0**3)
+
+    # ------------------------------------------------------------------
+    # Comprehensive
+    # ------------------------------------------------------------------
+
+    def _extract_comprehensive_impl(self) -> ComprehensiveMetadata:
+        """Extract everything the archive records, for provenance."""
+        metadata = self.archive.file_level_metadata()
+        return ComprehensiveMetadata(
+            essential=self.get_essential(),
+            format_specific=self._format_specific(metadata),
+            acquisition_params=self._acquisition_params(),
+            instrument_info=self._instrument_info(metadata),
+            raw_metadata=dict(metadata),
+        )
+
+    def _format_specific(self, metadata: Dict[str, Any]) -> Dict[str, Any]:
+        """Container facts worth keeping beside the data."""
+        entries = self.archive.index.get("files")
+        members = (
+            [
+                {
+                    "name": entry.get("name"),
+                    "entity_type": entry.get("entity_type"),
+                    "data_kind": entry.get("data_kind"),
+                }
+                for entry in entries
+                if isinstance(entry, dict)
+            ]
+            if isinstance(entries, list)
+            else []
+        )
+        return {
+            "container_version": metadata.get("version"),
+            "layout": self.archive.layout(),
+            "members": members,
+            "run": metadata.get("run"),
+            "sample_list": metadata.get("sample_list"),
+        }
+
+    def _acquisition_params(self) -> Dict[str, Any]:
+        """Scan-settings terms, including the declared grid extent."""
+        parameters = self._scan_settings_parameters()
+        declared: Dict[str, Any] = {}
+        for parameter in parameters:
+            accession = parameter.get("accession")
+            if accession in (IMS_MAX_COUNT_PIXELS_X, IMS_MAX_COUNT_PIXELS_Y):
+                declared[str(accession)] = parameter.get("value")
+        return {
+            "scan_settings": parameters,
+            "declared_grid_extent": declared or None,
+        }
+
+    def _instrument_info(self, metadata: Dict[str, Any]) -> Dict[str, Any]:
+        """Instrument and software lists, as the archive records them."""
+        return {
+            "instrument_configuration_list": metadata.get(
+                "instrument_configuration_list"
+            ),
+            "software_list": metadata.get("software_list"),
+            "data_processing_method_list": metadata.get("data_processing_method_list"),
+        }

--- a/thyra/readers/__init__.py
+++ b/thyra/readers/__init__.py
@@ -3,6 +3,7 @@
 
 This package provides reader implementations for different MSI data formats:
 - ImzML: Open format for MSI data
+- mzPeak: HUPO-PSI Parquet-in-ZIP archive (experimental, read-only)
 - Bruker: timsTOF and Rapiflex data
 - Waters: MassLynx .raw imaging data
 - PHI: SmartSoft-TOF .raw ToF-SIMS data
@@ -10,6 +11,7 @@ This package provides reader implementations for different MSI data formats:
 Reader organization:
 - bruker/: All Bruker formats (timsTOF, Rapiflex)
 - imzml/: ImzML format reader
+- mzpeak/: mzPeak archive reader (pyarrow, lazily imported)
 - waters/: Waters .raw format reader (native DLL via ctypes)
 - phi/: PHI SmartSoft-TOF .raw reader (pure Python, no vendor SDK)
 
@@ -18,4 +20,4 @@ PHI a single file. See :meth:`thyra.core.registry.MSIRegistry.detect_format`.
 """
 
 # Import readers to trigger registration
-from . import bruker, imzml, phi, waters  # noqa: F401
+from . import bruker, imzml, mzpeak, phi, waters  # noqa: F401

--- a/thyra/readers/mzpeak/__init__.py
+++ b/thyra/readers/mzpeak/__init__.py
@@ -1,0 +1,17 @@
+# thyra/readers/mzpeak/__init__.py
+"""Experimental mzPeak MSI reader.
+
+mzPeak (HUPO-PSI) is a Parquet-in-ZIP container intended as the successor to
+mzML/imzML at the raw/archival layer. Thyra treats it as an *input* only:
+archives convert to SpatialData through the normal pipeline, and Thyra never
+writes one.
+
+The format is a moving draft (v0.9 at the time of writing), so the reader
+codes defensively and announces itself as experimental in its log output.
+"""
+
+from .mzpeak_reader import MzPeakReader
+
+__all__ = [
+    "MzPeakReader",
+]

--- a/thyra/readers/mzpeak/mzpeak_reader.py
+++ b/thyra/readers/mzpeak/mzpeak_reader.py
@@ -1,0 +1,879 @@
+# thyra/readers/mzpeak/mzpeak_reader.py
+"""Experimental reader for mzPeak archives.
+
+mzPeak is a ZIP container of Parquet members plus a JSON index. Every member
+is stored uncompressed, so each Parquet file is a contiguous byte range that
+pyarrow can read through a plain file object.
+
+Container facts this module relies on, all measured against the reference
+implementation (HUPO-PSI/mzPeak @ 502c3a4) rather than inferred from the
+draft prose:
+
+* ``mzpeak_index.json`` is ``{"files": [...], "metadata": {...}}``. Each file
+  entry carries ``name``, ``entity_type``, ``data_kind`` and -- optionally --
+  ``column_mapping`` (alias ``metadata_mapping``) and ``parameters``. Members
+  are resolved through this index, never by hardcoded filename.
+* The reference parser lowercases and trims both vocabularies and accepts the
+  space spelling as an alias for the underscore one, falling through to an
+  ``Other`` variant rather than erroring. This reader matches that tolerance:
+  an unrecognised role is skipped, not fatal.
+* Signal data is one struct column
+  ``point: struct<spectrum_index: uint64, mz: double, intensity: float>``,
+  one point per row, sorted by ``spectrum_index``. A chunked layout exists
+  (top-level ``chunk`` instead of ``point``) and is out of scope.
+* There is no spectrum -> row-group map in the container. The KV key
+  ``spectrum_array_index`` sounds like one but describes which column holds
+  which CV array type. Spectra are located instead from
+  ``spectra_metadata.number_of_data_points`` (exact, O(n_spectra)) with
+  row-group statistics used to prune which groups to touch.
+* File-level metadata lives in the Parquet key-value footer of the metadata
+  member *and*, inconsistently, in the index's ``metadata`` object. The
+  footer was populated on every reference archive; the index object was empty
+  on the only imaging one. The footer wins, the index fills gaps.
+* Positions are ``opt_IMS_1000050_position_x`` / ``opt_IMS_1000051_position_y``
+  and exist only for imaging acquisitions. Thyra is MSI-only, so an archive
+  without them is refused.
+
+The format is a v0.9 draft. Everything here is written to fail loudly with a
+named file and a named cause rather than to guess.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import zipfile
+from pathlib import Path
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Generator,
+    List,
+    NamedTuple,
+    Optional,
+    Tuple,
+)
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ...core.base_reader import BaseMSIReader
+from ...core.registry import register_reader
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from ...core.base_extractor import MetadataExtractor
+
+logger = logging.getLogger(__name__)
+
+#: Name of the index member. Fixed by the specification; it is the one
+#: filename in the container that may be looked up directly, because it is
+#: what tells you the name of everything else.
+INDEX_MEMBER = "mzpeak_index.json"
+
+#: ZIP local-file-header magic. Used by format detection so a mislabelled
+#: ``.mzpeak`` fails detection instead of failing later inside pyarrow.
+ZIP_MAGIC = b"PK\x03\x04"
+
+# Imaging CV terms. Resolved by accession rather than by column or parameter
+# name: the reference archives spell IMS:1000046 "pixel size (x)" with
+# parentheses and IMS:1000047 "pixel size y" without, so name matching finds
+# one axis and misses the other.
+IMS_POSITION_X = "IMS:1000050"
+IMS_POSITION_Y = "IMS:1000051"
+
+#: Conventional column names for the position terms. Used only as a fallback
+#: when the index carries no column mapping, which the schema permits.
+DEFAULT_POSITION_X_COLUMN = "opt_IMS_1000050_position_x"
+DEFAULT_POSITION_Y_COLUMN = "opt_IMS_1000051_position_y"
+
+
+def _normalise_token(value: Any) -> str:
+    """Fold an index vocabulary token the way the reference parser does.
+
+    ``DataKind::from_str`` and ``EntityType::from_str`` both lowercase and
+    trim before matching, and both accept a space where the serialised form
+    uses an underscore (``"data arrays"`` for ``"data_arrays"``,
+    ``"mass spectrum"`` for ``"spectrum"``). Folding the same way here means
+    an archive written by any conforming writer resolves identically.
+
+    Args:
+        value: Raw token from the index, or anything else.
+
+    Returns:
+        The folded token, or ``""`` when the value is not a string.
+    """
+    if not isinstance(value, str):
+        return ""
+    return value.strip().lower().replace(" ", "_")
+
+
+def _lazy_pyarrow() -> Tuple[Any, Any]:
+    """Import pyarrow on first use.
+
+    pyarrow reaches every Thyra install already: it is a hard dependency of
+    spatialdata, which is a hard dependency of Thyra. It is imported lazily
+    anyway so that ``import thyra`` -- which imports every reader package to
+    trigger registration -- does not pay for a 50 MB extension module that
+    only mzPeak archives need.
+
+    Returns:
+        The ``pyarrow`` and ``pyarrow.parquet`` modules.
+
+    Raises:
+        ImportError: If pyarrow is missing or too old.
+    """
+    try:
+        import pyarrow  # noqa: WPS433 - deliberate lazy import
+        import pyarrow.parquet as pq  # noqa: WPS433
+    except ImportError as exc:  # pragma: no cover - install-shape dependent
+        raise ImportError(
+            "Reading mzPeak archives requires pyarrow, which is normally "
+            "installed as a dependency of spatialdata. Install it with "
+            "`pip install pyarrow>=20`."
+        ) from exc
+
+    major = int(str(pyarrow.__version__).split(".")[0])
+    if major < 20:
+        raise ImportError(
+            f"Reading mzPeak archives requires pyarrow >= 20, found "
+            f"{pyarrow.__version__}. Earlier versions mis-handle the "
+            "large_list and struct columns these archives use."
+        )
+    return pyarrow, pq
+
+
+class MzPeakSpatialIndex(NamedTuple):
+    """Everything about the archive that is one value per spectrum.
+
+    Small even for a very large archive -- one row per spectrum, not per
+    point -- so it is read once and kept, which is what lets the reader cut a
+    row group into spectra without consulting the file again.
+
+    Attributes:
+        spectrum_indices: ``spectrum_index`` of each positioned spectrum,
+            ascending.
+        coordinates: ``(n, 2)`` array of 0-based ``(x, y)`` pixel coordinates.
+        raw_positions: ``(n, 2)`` array of the positions as written, before
+            normalisation. Kept because coordinate bounds are reported in the
+            file's own frame.
+        point_counts: Number of data points in each spectrum.
+        offsets: The ``(x, y)`` minima subtracted to reach 0-based
+            coordinates.
+    """
+
+    spectrum_indices: NDArray[np.int64]
+    coordinates: NDArray[np.int64]
+    raw_positions: NDArray[np.int64]
+    point_counts: NDArray[np.int64]
+    offsets: Tuple[int, int]
+
+
+class MzPeakArchive:
+    """Resolved view over one ``.mzpeak`` container.
+
+    Owns the :class:`zipfile.ZipFile` handle and the parsed index, and hands
+    out Parquet members by role. Shared by the reader and the metadata
+    extractor so the archive is opened and validated exactly once.
+    """
+
+    def __init__(self, path: Path):
+        """Open an archive and resolve its members.
+
+        Args:
+            path: Path to the ``.mzpeak`` file.
+
+        Raises:
+            ValueError: If the file is not a ZIP, carries no index, or the
+                index is unreadable.
+        """
+        self.path = Path(path)
+        self._zip: Optional[zipfile.ZipFile] = None
+        self._parquet_cache: Dict[str, Any] = {}
+        self._file_metadata: Optional[Dict[str, Any]] = None
+        self._spatial_index: Optional[MzPeakSpatialIndex] = None
+        self._null_count: Optional[int] = None
+        self._null_count_cached = False
+
+        if not zipfile.is_zipfile(self.path):
+            raise ValueError(
+                f"Not an mzPeak archive (not a ZIP container): {self.path}"
+            )
+
+        self._zip = zipfile.ZipFile(self.path)
+        self._members = set(self._zip.namelist())
+        if INDEX_MEMBER not in self._members:
+            raise ValueError(
+                f"Not an mzPeak archive (no {INDEX_MEMBER} member): {self.path}"
+            )
+
+        try:
+            index = json.loads(self._zip.read(INDEX_MEMBER))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise ValueError(f"Malformed {INDEX_MEMBER} in {self.path}: {exc}") from exc
+        if not isinstance(index, dict):
+            raise ValueError(
+                f"Malformed {INDEX_MEMBER} in {self.path}: expected a JSON "
+                f"object, found {type(index).__name__}"
+            )
+
+        self.index: Dict[str, Any] = index
+        self._roles = self._resolve_roles(index)
+
+    def _resolve_roles(self, index: Dict[str, Any]) -> Dict[Tuple[str, str], dict]:
+        """Map ``(entity_type, data_kind)`` to the index entry for that member.
+
+        Entries whose member is missing from the ZIP are dropped with a
+        warning rather than raising: the index is allowed to describe more
+        than a given writer emitted, and only the members this reader
+        actually needs are worth failing over.
+
+        Args:
+            index: The parsed index document.
+
+        Returns:
+            Mapping from folded role pair to the raw index entry.
+        """
+        roles: Dict[Tuple[str, str], dict] = {}
+        entries = index.get("files")
+        if not isinstance(entries, list):
+            raise ValueError(
+                f"Malformed {INDEX_MEMBER} in {self.path}: 'files' must be a "
+                f"list, found {type(entries).__name__}"
+            )
+
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("name")
+            if not isinstance(name, str) or name not in self._members:
+                logger.warning(
+                    "mzPeak index of %s lists member %r which is not in the "
+                    "archive; ignoring it",
+                    self.path.name,
+                    name,
+                )
+                continue
+            key = (
+                _normalise_token(entry.get("entity_type")),
+                _normalise_token(entry.get("data_kind")),
+            )
+            roles.setdefault(key, entry)
+        return roles
+
+    def entry(self, entity_type: str, data_kind: str) -> Optional[dict]:
+        """Return the index entry for a role, or ``None`` when absent."""
+        return self._roles.get(
+            (_normalise_token(entity_type), _normalise_token(data_kind))
+        )
+
+    def require_entry(self, entity_type: str, data_kind: str) -> dict:
+        """Return the index entry for a role, raising when it is absent.
+
+        Raises:
+            ValueError: If no member fills the role.
+        """
+        found = self.entry(entity_type, data_kind)
+        if found is None:
+            available = sorted(f"{e}/{k}" for e, k in self._roles)
+            raise ValueError(
+                f"mzPeak archive {self.path} has no "
+                f"'{entity_type}/{data_kind}' member. Present roles: "
+                f"{', '.join(available) or 'none'}"
+            )
+        return found
+
+    def parquet(self, entity_type: str, data_kind: str) -> Any:
+        """Open the Parquet member filling a role.
+
+        The handle is cached: members are STORED, so pyarrow reads the
+        footer once and then seeks within the archive without re-inflating.
+        """
+        entry = self.require_entry(entity_type, data_kind)
+        name = entry["name"]
+        if name not in self._parquet_cache:
+            _, pq = _lazy_pyarrow()
+            assert self._zip is not None
+            self._parquet_cache[name] = pq.ParquetFile(self._zip.open(name))
+        return self._parquet_cache[name]
+
+    @staticmethod
+    def column_for_accession(entry: dict, accession: str) -> Optional[str]:
+        """Find the column bound to a CV accession in an index entry.
+
+        ``column_mapping`` carries the binding, but the reference struct
+        declares it ``serde(default)`` with the alias ``metadata_mapping``,
+        so both spellings occur and both may be absent entirely.
+
+        Args:
+            entry: An index file entry.
+            accession: The CV accession to look for, e.g. ``"IMS:1000050"``.
+
+        Returns:
+            The column path, or ``None`` when the entry binds no such term.
+        """
+        mapping = entry.get("column_mapping")
+        if not isinstance(mapping, list):
+            mapping = entry.get("metadata_mapping")
+        if not isinstance(mapping, list):
+            return None
+        for binding in mapping:
+            if not isinstance(binding, dict):
+                continue
+            if binding.get("accession") == accession:
+                path = binding.get("path")
+                if isinstance(path, str) and path:
+                    return path
+        return None
+
+    def layout(self) -> str:
+        """Return the physical layout of the signal member.
+
+        Returns:
+            ``"point"`` or ``"chunk"``.
+
+        Raises:
+            ValueError: If the member carries neither top-level column.
+        """
+        fields = list(self.parquet("spectrum", "data_arrays").schema_arrow.names)
+        if "point" in fields:
+            return "point"
+        if "chunk" in fields:
+            return "chunk"
+        raise ValueError(
+            f"{self.path} has an unrecognised mzPeak data layout: expected a "
+            f"top-level 'point' or 'chunk' column, found {fields}."
+        )
+
+    def position_columns(self) -> Optional[Tuple[str, str]]:
+        """Resolve the scan columns holding the imaging positions.
+
+        Preference is the CV binding in the index, because the column name is
+        a convention while the accession is the contract. Falls back to the
+        conventional names when the entry carries no mapping, which the
+        reference struct permits.
+
+        Returns:
+            ``(x_column, y_column)``, or ``None`` for a non-imaging archive.
+        """
+        entry = self.entry("spectrum", "scans")
+        if entry is None:
+            return None
+        names = set(self.parquet("spectrum", "scans").schema_arrow.names)
+        x_column = (
+            self.column_for_accession(entry, IMS_POSITION_X)
+            or DEFAULT_POSITION_X_COLUMN
+        )
+        y_column = (
+            self.column_for_accession(entry, IMS_POSITION_Y)
+            or DEFAULT_POSITION_Y_COLUMN
+        )
+        if x_column not in names or y_column not in names:
+            return None
+        return (x_column, y_column)
+
+    def spatial_index(self) -> MzPeakSpatialIndex:
+        """Read positions and per-spectrum point counts.
+
+        Scans join to spectra on ``source_index``, not on row order: the
+        reference schema numbers scans within a spectrum separately
+        (``scan_index``) and nothing promises the two members are ordered
+        alike.
+
+        Raises:
+            ValueError: If the archive is not an imaging acquisition, or
+                carries no positioned spectra.
+        """
+        if self._spatial_index is not None:
+            return self._spatial_index
+
+        columns = self.position_columns()
+        if columns is None:
+            raise ValueError(
+                f"{self.path} is not an imaging mzPeak archive: its scans "
+                f"member declares no {IMS_POSITION_X}/{IMS_POSITION_Y} "
+                f"position columns. Thyra converts imaging acquisitions only."
+            )
+        x_column, y_column = columns
+
+        scans = self.parquet("spectrum", "scans").read(
+            columns=["source_index", x_column, y_column]
+        )
+        source = np.asarray(scans.column("source_index").to_numpy(), dtype=np.int64)
+        xs = np.asarray(scans.column(x_column).to_numpy(), dtype=np.int64)
+        ys = np.asarray(scans.column(y_column).to_numpy(), dtype=np.int64)
+
+        # One spectrum may own several scans; imaging acquisitions write one.
+        # Keeping the first per spectrum means a multi-scan file resolves to a
+        # single pixel rather than silently overwriting itself.
+        _, first = np.unique(source, return_index=True)
+        source, xs, ys = source[first], xs[first], ys[first]
+
+        metadata = self.parquet("spectrum", "metadata").read(
+            columns=["index", "number_of_data_points"]
+        )
+        spectrum_index = np.asarray(metadata.column("index").to_numpy(), dtype=np.int64)
+        counts = np.asarray(
+            metadata.column("number_of_data_points").to_numpy(), dtype=np.int64
+        )
+        order = np.argsort(spectrum_index, kind="stable")
+        spectrum_index, counts = spectrum_index[order], counts[order]
+
+        # A spectrum with no scan row has no pixel, so it is dropped rather
+        # than placed at the origin.
+        lookup = {int(s): i for i, s in enumerate(source)}
+        keep = np.array([int(s) in lookup for s in spectrum_index], dtype=bool)
+        if not keep.all():
+            logger.warning(
+                "%d of %d spectra in %s have no scan row and therefore no "
+                "position; they are skipped",
+                int((~keep).sum()),
+                keep.size,
+                self.path.name,
+            )
+        spectrum_index, counts = spectrum_index[keep], counts[keep]
+        if spectrum_index.size == 0:
+            raise ValueError(f"{self.path} contains no positioned spectra.")
+
+        rows = np.array([lookup[int(s)] for s in spectrum_index], dtype=np.int64)
+        raw = np.stack([xs[rows], ys[rows]], axis=1)
+
+        # Positions are 1-based in the reference archives, but the format
+        # promises nothing, so normalise on the observed minimum rather than
+        # subtracting a constant.
+        offsets = (int(raw[:, 0].min()), int(raw[:, 1].min()))
+        coordinates = raw - np.array(offsets, dtype=np.int64)
+
+        self._spatial_index = MzPeakSpatialIndex(
+            spectrum_indices=spectrum_index,
+            coordinates=coordinates,
+            raw_positions=raw,
+            point_counts=counts,
+            offsets=offsets,
+        )
+        return self._spatial_index
+
+    def null_count(self) -> Optional[int]:
+        """How many rows carry a null m/z, or ``None`` when unknowable.
+
+        Read from Parquet column statistics, so it costs a footer lookup
+        rather than a pass over the data.
+
+        mzPeak compresses profile spectra by dropping interior runs of zero
+        intensity and marking each gap with a *null pair*: two adjacent rows
+        whose m/z **and** intensity are both null. On the reference imaging
+        archive that is 13,286 of 36,856 rows, in 512 pairs per spectrum.
+
+        The reference reader regenerates the missing m/z from the
+        per-spectrum ``mz_delta_model`` polynomial plus a locally estimated
+        median spacing. Those regenerated values are extrapolations rather
+        than the instrument's own numbers, and every one of them carries
+        zero intensity.
+
+        Thyra writes a sparse matrix, in which a zero-intensity point
+        occupies no storage and contributes nothing to any downstream
+        analysis. Reconstructing the pairs would therefore only add
+        approximate channels to the common mass axis that can never hold a
+        value, so the reader drops them and reports the count instead.
+        """
+        if self._null_count_cached:
+            return self._null_count
+        self._null_count_cached = True
+
+        metadata = self.parquet("spectrum", "data_arrays").metadata
+        total = 0
+        seen = False
+        for group in range(metadata.num_row_groups):
+            row_group = metadata.row_group(group)
+            for column in range(row_group.num_columns):
+                chunk = row_group.column(column)
+                if not chunk.path_in_schema.endswith(".mz"):
+                    continue
+                statistics = chunk.statistics
+                if statistics is None or statistics.null_count is None:
+                    self._null_count = None
+                    return None
+                seen = True
+                total += int(statistics.null_count)
+        self._null_count = total if seen else None
+        return self._null_count
+
+    def file_level_metadata(self) -> Dict[str, Any]:
+        """Merge the two places file-level metadata is written.
+
+        The Parquet key-value footer of the metadata member was populated on
+        every reference archive. The index's ``metadata`` object was
+        populated on two of three -- and empty on the only imaging one, which
+        is exactly the file whose pixel size matters. Reading either alone
+        loses information, so the footer is taken as authoritative and the
+        index fills keys the footer lacks (notably ``version``, which appears
+        only in the index).
+
+        Returns:
+            Mapping of metadata key to its decoded JSON value.
+        """
+        if self._file_metadata is not None:
+            return self._file_metadata
+
+        merged: Dict[str, Any] = {}
+
+        index_metadata = self.index.get("metadata")
+        if isinstance(index_metadata, dict):
+            merged.update(index_metadata)
+
+        footer = self.parquet("spectrum", "metadata").metadata.metadata or {}
+        for raw_key, raw_value in footer.items():
+            key = raw_key.decode("utf-8", "replace")
+            if key == "ARROW:schema":
+                continue
+            try:
+                merged[key] = json.loads(raw_value)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                # Scalars such as spectrum_count are written as bare text.
+                merged[key] = raw_value.decode("utf-8", "replace")
+
+        self._file_metadata = merged
+        return merged
+
+    def close(self) -> None:
+        """Release the ZIP handle and any cached Parquet readers."""
+        self._parquet_cache.clear()
+        if self._zip is not None:
+            self._zip.close()
+            self._zip = None
+
+
+@register_reader("mzpeak")
+class MzPeakReader(BaseMSIReader):
+    """Experimental reader for mzPeak (HUPO-PSI) imaging archives.
+
+    Experimental because the container is a v0.9 draft: column names, the
+    index vocabulary and the placement of file-level metadata have all moved
+    between prototype revisions, and are expected to move again before v1.0.
+    The reader is written against the reference implementation at 502c3a4 and
+    validates what it depends on, so a drifted archive produces a named error
+    rather than silently wrong pixels.
+
+    Data is processed-imzML-shaped: per-spectrum axes, no shared-axis
+    concept anywhere in the format. :attr:`has_shared_mass_axis` is therefore
+    always ``False`` and the resampling decision tree treats these files
+    exactly as it treats processed imzML.
+    """
+
+    def __init__(
+        self,
+        data_path: Path,
+        intensity_threshold: Optional[float] = None,
+        **kwargs: object,
+    ):
+        """Initialise the reader.
+
+        Args:
+            data_path: Path to the ``.mzpeak`` archive.
+            intensity_threshold: Minimum intensity to keep; see
+                :class:`~thyra.core.base_reader.BaseMSIReader`.
+            **kwargs: Accepted and ignored, for signature parity with the
+                other readers.
+        """
+        super().__init__(data_path, intensity_threshold=intensity_threshold, **kwargs)
+        self._archive: Optional[MzPeakArchive] = None
+        self._coordinates: Optional[NDArray[np.int64]] = None
+        self._point_counts: Optional[NDArray[np.int64]] = None
+        self._spectrum_indices: Optional[NDArray[np.int64]] = None
+        self._offsets: Optional[Tuple[int, int]] = None
+        self._common_axis: Optional[NDArray[np.float64]] = None
+        self._announced = False
+        self._dropped_points = 0
+
+    # ------------------------------------------------------------------
+    # Archive setup
+    # ------------------------------------------------------------------
+
+    @property
+    def archive(self) -> MzPeakArchive:
+        """The open archive, opened and validated on first access."""
+        if self._archive is None:
+            self._archive = MzPeakArchive(self.data_path)
+            self._validate_layout()
+            self._load_spatial_index()
+            if not self._announced:
+                version = self._archive.file_level_metadata().get("version", "unknown")
+                logger.warning(
+                    "mzPeak support is EXPERIMENTAL: %s declares container "
+                    "version %s, a draft format. Verify converted output "
+                    "before relying on it.",
+                    self.data_path.name,
+                    version,
+                )
+                self._announced = True
+        return self._archive
+
+    def _validate_layout(self) -> None:
+        """Refuse layouts this reader cannot honestly read.
+
+        Two cases are refused with a named cause rather than allowed to fail
+        somewhere deeper: the chunked encoding, which is a different physical
+        layout entirely, and any archive whose scans carry no positions,
+        which is a non-imaging acquisition that Thyra has nothing to do with.
+
+        Raises:
+            NotImplementedError: If the archive uses the chunked layout.
+            ValueError: If the archive carries no spatial positions.
+        """
+        assert self._archive is not None
+        if self._archive.layout() == "chunk":
+            raise NotImplementedError(
+                f"{self.data_path} uses the mzPeak chunked layout (top-level "
+                f"'chunk' column). Thyra reads only the point layout "
+                f"(top-level 'point' column). Re-export the archive without "
+                f"chunking to convert it."
+            )
+
+    def _load_spatial_index(self) -> None:
+        """Cache the archive's per-spectrum positions and point counts.
+
+        The archive owns the resolution so the metadata extractor sees the
+        same pixels the iteration does; this only keeps the arrays where the
+        hot loop can reach them without a dict lookup.
+        """
+        assert self._archive is not None
+        index = self._archive.spatial_index()
+        self._spectrum_indices = index.spectrum_indices
+        self._coordinates = index.coordinates
+        self._point_counts = index.point_counts
+        self._offsets = index.offsets
+
+    # ------------------------------------------------------------------
+    # BaseMSIReader contract
+    # ------------------------------------------------------------------
+
+    def _create_metadata_extractor(self) -> "MetadataExtractor":
+        """Create the mzPeak metadata extractor."""
+        from ...metadata.extractors.mzpeak_extractor import MzPeakMetadataExtractor
+
+        return MzPeakMetadataExtractor(self.archive, self.data_path)
+
+    @property
+    def has_shared_mass_axis(self) -> bool:
+        """Always ``False``.
+
+        mzPeak stores one m/z per point with no shared-axis or
+        calibration-model mechanism anywhere in the format, spec or reference
+        implementation. Claiming otherwise would make the converter read the
+        first spectrum's axis and apply it to every pixel.
+        """
+        return False
+
+    def get_common_mass_axis(self) -> NDArray[np.float64]:
+        """Build the union of every m/z value in the archive.
+
+        Accumulated row group by row group rather than over the whole column
+        at once: the m/z column is the bulk of the archive (~80% on real
+        vendor data, where per-frame calibration makes almost every value
+        unique), so materialising it entirely would cost more memory than the
+        conversion that follows.
+        """
+        if self._common_axis is not None:
+            return self._common_axis
+
+        data = self.archive.parquet("spectrum", "data_arrays")
+        axis = np.empty(0, dtype=np.float64)
+        for group in range(data.metadata.num_row_groups):
+            table = data.read_row_group(group, columns=["point"])
+            mzs = self._point_field(table, "mz")
+            # Null-pair padding carries no intensity; excluded so the
+            # axis holds only channels that can actually take a value.
+            mzs = mzs[~np.isnan(mzs)]
+            axis = np.union1d(axis, np.unique(mzs))
+
+        if axis.size == 0:
+            raise ValueError(
+                f"{self.data_path} yielded no m/z values; the archive has no "
+                f"usable signal data."
+            )
+        self._common_axis = axis.astype(np.float64, copy=False)
+        return self._common_axis
+
+    @staticmethod
+    def _point_field(table: Any, field: str) -> NDArray[Any]:
+        """Pull one child out of the ``point`` struct column as numpy."""
+        column = table.column("point").combine_chunks()
+        # ChunkedArray.combine_chunks() yields a ChunkedArray of one chunk on
+        # some pyarrow versions and a StructArray on others; normalise.
+        if hasattr(column, "num_chunks"):
+            column = column.chunk(0)
+        return column.field(field).to_numpy(zero_copy_only=False)
+
+    def iter_spectra(self, batch_size: Optional[int] = None) -> Generator[
+        Tuple[Tuple[int, int, int], NDArray[np.float64], NDArray[np.float64]],
+        None,
+        None,
+    ]:
+        """Yield every positioned spectrum in ``spectrum_index`` order.
+
+        Reads one row group at a time and cuts it into spectra in memory, so
+        the cost is one pass over the archive regardless of spectrum count.
+        Row groups split spectra at their boundaries, so a spectrum's points
+        are carried across iterations and emitted only once the next
+        ``spectrum_index`` appears -- which is why the emit happens on
+        transition rather than per row group.
+
+        Args:
+            batch_size: Accepted for interface parity and ignored. Row groups
+                already define the read granularity; a second batching layer
+                on top would only fragment them.
+
+        Yields:
+            ``((x, y, z), mzs, intensities)`` with 0-based coordinates,
+            ``z`` always 0, and both arrays float64.
+        """
+        if batch_size is not None:
+            logger.debug(
+                "mzPeak reads are row-group sized; ignoring batch_size=%s",
+                batch_size,
+            )
+
+        data = self.archive.parquet("spectrum", "data_arrays")
+        positioned = {
+            int(s): i for i, s in enumerate(self._require(self._spectrum_indices))
+        }
+
+        pending_index: Optional[int] = None
+        pending_mz: List[NDArray[Any]] = []
+        pending_intensity: List[NDArray[Any]] = []
+
+        for group in range(data.metadata.num_row_groups):
+            table = data.read_row_group(group, columns=["point"])
+            if table.num_rows == 0:
+                continue
+            indices = self._point_field(table, "spectrum_index").astype(
+                np.int64, copy=False
+            )
+            mzs = self._point_field(table, "mz")
+            intensities = self._point_field(table, "intensity")
+
+            # Cut at every change of spectrum_index. The column is sorted, so
+            # a change is a boundary and nothing needs grouping.
+            cuts = np.flatnonzero(np.diff(indices)) + 1
+            for start, stop in zip(
+                np.concatenate(([0], cuts)), np.concatenate((cuts, [indices.size]))
+            ):
+                index = int(indices[start])
+                if pending_index is not None and index != pending_index:
+                    emitted = self._emit(
+                        pending_index, pending_mz, pending_intensity, positioned
+                    )
+                    if emitted is not None:
+                        yield emitted
+                    pending_mz, pending_intensity = [], []
+                pending_index = index
+                pending_mz.append(mzs[start:stop])
+                pending_intensity.append(intensities[start:stop])
+
+        if pending_index is not None:
+            emitted = self._emit(
+                pending_index, pending_mz, pending_intensity, positioned
+            )
+            if emitted is not None:
+                yield emitted
+
+        if self._dropped_points:
+            logger.info(
+                "Dropped %d null-pair padding points from %s; they carry no "
+                "intensity and exist only to mark removed zero runs",
+                self._dropped_points,
+                self.data_path.name,
+            )
+
+    def _emit(
+        self,
+        spectrum_index: int,
+        mz_parts: List[NDArray[Any]],
+        intensity_parts: List[NDArray[Any]],
+        positioned: Dict[int, int],
+    ) -> Optional[
+        Tuple[Tuple[int, int, int], NDArray[np.float64], NDArray[np.float64]]
+    ]:
+        """Assemble one spectrum's carried parts into a yieldable tuple.
+
+        Returns ``None`` for a spectrum with no position, with no points left
+        after intensity filtering, or with an empty payload -- all three are
+        ordinary rather than exceptional, and the converter's sparse grid
+        handles the resulting gaps.
+        """
+        row = positioned.get(spectrum_index)
+        if row is None:
+            return None
+
+        mzs = np.concatenate(mz_parts).astype(np.float64, copy=False)
+        intensities = np.concatenate(intensity_parts).astype(np.float64, copy=False)
+
+        # Drop null-pair padding before anything else sees it. Both columns
+        # are null on those rows, so a surviving NaN would propagate into the
+        # mass axis and into every intensity statistic downstream. See
+        # MzPeakArchive.null_count() for why filling them is the wrong repair.
+        valid = ~np.isnan(mzs)
+        if not valid.all():
+            self._dropped_points += int((~valid).sum())
+            mzs = mzs[valid]
+            intensities = intensities[valid]
+
+        mzs, intensities = self._apply_intensity_filter(mzs, intensities)
+        if mzs.size == 0:
+            return None
+
+        coordinates = self._require(self._coordinates)
+        return (
+            (int(coordinates[row, 0]), int(coordinates[row, 1]), 0),
+            mzs,
+            intensities,
+        )
+
+    @staticmethod
+    def _require(value: Optional[NDArray[Any]]) -> NDArray[Any]:
+        """Assert that the spatial index has been loaded."""
+        if value is None:
+            raise RuntimeError("mzPeak spatial index not loaded; access .archive first")
+        return value
+
+    @property
+    def n_spectra(self) -> int:
+        """Number of positioned spectra in the archive."""
+        _ = self.archive
+        return int(self._require(self._spectrum_indices).size)
+
+    @property
+    def mass_range(self) -> Tuple[float, float]:
+        """Observed m/z range, from the per-spectrum metadata columns."""
+        return self.get_essential_metadata().mass_range
+
+    def get_total_peak_count(self) -> int:
+        """Points carrying a value across all positioned spectra.
+
+        Excludes null-pair padding; see :meth:`MzPeakArchive.null_count`.
+        """
+        return self.get_essential_metadata().total_peaks
+
+    def get_peak_counts_per_pixel(self) -> Optional[NDArray[np.int32]]:
+        """Per-pixel point counts, for single-pass streaming conversion.
+
+        Delegated to the extractor, which is the one place that knows whether
+        the archive's recorded counts include null-pair padding. Computing
+        them here as well would give the converter a second, higher answer.
+        """
+        return self.get_essential_metadata().peak_counts_per_pixel
+
+    def get_region_map(self) -> Optional[dict]:
+        """Always ``None``.
+
+        mzPeak has no region or ROI concept: there is no column, no CV
+        binding and no index field carrying acquisition-region identity. It
+        is one of the gaps the working group has been asked to close.
+        """
+        return None
+
+    def close(self) -> None:
+        """Close the archive."""
+        if self._archive is not None:
+            self._archive.close()
+            self._archive = None


### PR DESCRIPTION
# Pull Request

## Description

Adds an experimental reader for **mzPeak**, the HUPO-PSI Parquet-in-ZIP
container intended as the successor to mzML/imzML at the raw/archival layer.
`.mzpeak` archives now convert to SpatialData through the normal `convert_msi`
pipeline.

Thyra's position is that mzPeak is an **input, never an output** — there is no
writer here and none is planned. Support is labelled experimental in the
docstring, the docs and the reader's log output because the container is a v0.9
draft: column names, the index vocabulary and the placement of file-level
metadata have all moved between prototype revisions.

Written and verified against the reference implementation at
[HUPO-PSI/mzPeak@502c3a4](https://github.com/HUPO-PSI/mzPeak).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test coverage improvement

## Changes Made

- `thyra/readers/mzpeak/` — `MzPeakReader` (`@register_reader("mzpeak")`) plus
  an `MzPeakArchive` layer that owns the ZIP handle, the parsed index and the
  per-spectrum spatial index.
- `thyra/metadata/extractors/mzpeak_extractor.py` — essential and
  comprehensive metadata.
- `thyra/core/registry.py` — detection for `.mzpeak`: extension, ZIP
  signature, then the `mzpeak_index.json` member. Deliberately container-level;
  a non-imaging or chunked archive still *detects* as mzPeak and is refused by
  the reader, which can say which of the two it was.
- Docs: formats table, capability matrix, and a section on what is refused.

### Design notes worth a reviewer's attention

**Members are resolved through the index, never by filename**, and the index
vocabulary is folded exactly as the reference parser folds it — lowercased,
trimmed, `data arrays` accepted as an alias for `data_arrays`, unknown roles
skipped rather than fatal. `column_mapping` also accepts its `metadata_mapping`
alias and may be absent entirely.

**File-level metadata is merged from two places.** It lives in the metadata
member's Parquet key-value footer *and* in the index's `metadata` object,
inconsistently: the reference imaging archive leaves the index object empty and
fills the footer, while other archives populate both. Reading either alone
loses data.

**Null-pair padding is dropped, not reconstructed.** This is the one decision
most worth challenging, so the reasoning in full: mzPeak compresses profile
spectra by removing interior runs of zero intensity and marking each gap with
two rows whose m/z *and* intensity are both null — 36% of rows on the reference
imaging archive. The reference reader regenerates the missing m/z from a
per-spectrum polynomial (`mz_delta_model`). Those regenerated values are
extrapolations rather than the instrument's own numbers, and every one carries
zero intensity. Since Thyra writes a sparse matrix where a zero occupies no
storage, filling them would only add approximate mass-axis channels that can
never hold a value. Consequences are handled rather than ignored: recorded
point counts include the padding, so totals are corrected using Parquet
`null_count` statistics (free, no data pass), and `get_peak_counts_per_pixel()`
returns `None` on a padded archive rather than handing the converter inflated
numbers that would mis-size the CSR `indptr`.

**CV terms are matched on accession, never on name.** The vocabulary spells
`IMS:1000046` with parentheses around the axis and `IMS:1000047` without, so
name matching finds one axis and misses the other.

**Out of scope, refused by name:** the chunked layout (`NotImplementedError`),
and non-imaging archives, which carry no positions and have no pixels to place.

## Dependencies

**No new dependency and no new extra.** The reader needs `pyarrow >= 20`, which
already reaches every install as a hard dependency of `spatialdata` — the
lockfile resolves 25.0.1 through that edge. It is nonetheless imported
**lazily**, with an actionable `ImportError`, because `import thyra` imports
every reader package to trigger registration and should not pay for a large
extension module that only mzPeak archives need. Declaring an optional extra
was considered and rejected as theatre: it would gate a package that is
unconditionally present.

## Testing

- [x] All existing tests pass
- [x] New tests have been added to cover the changes
- [x] Manual testing has been performed
- [x] Integration tests pass

47 unit tests and 8 integration tests. Archives are built by a pure-Python
helper (`zipfile` + `pyarrow`) that spells the container out literally and
imports nothing from `thyra.readers.mzpeak` — the same "break the loop"
principle as the hand-authored imzML corpus, since a builder that asked the
reader how to spell things would pass while real archives failed.

**The acceptance gate is imzML parity:** the same spectra written once as imzML
and once as mzPeak must convert to the same store. Asserted on the native union
axis at `rtol=0, atol=0`, and again through resampling.

Also covered: spectra straddling row-group boundaries, sparse acquisitions that
must not densify, 0-based and offset position frames, index spelling and alias
tolerance, both metadata locations, unit conversion, and the refusal paths.

An **opt-in interoperability test** converts an archive written by the
reference implementation, enabled by pointing
`THYRA_MZPEAK_REFERENCE_ARCHIVE` at one. The reference samples are not
vendored: that repository publishes no licence, so redistributing its data from
a package that ships to PyPI is not ours to do.

That test earned its place immediately — it caught a bug no constructed fixture
saw. The declared grid extent was recorded in `uns` keyed by CV accession, and
zarr writes a dict key as a directory name, so the colon in `IMS:1000042` made
the entire store unwritable on Windows (`[Errno 22]`). Now keyed by plain name,
with an integration test that saves a store rather than stopping at the
metadata object.

## Performance Impact

- [x] No performance impact

Reader-only; no converter, batching or existing-reader code paths are touched.
Within the reader, `iter_spectra` reads one row group at a time and slices
spectra in memory, so a conversion is one pass over the archive regardless of
spectrum count.

## Additional Notes

**This is a `feat:` commit, so merging will minor-bump and release.** That is
intended, but flagging it explicitly since it publishes.

One limitation worth recording: bit-identical parity with a source imzML is
impossible for a *padded* archive, because the format has discarded zero runs
the imzML still carries. Parity holds exactly for unpadded archives, which is
what the tests pin.

Possible follow-ups, deliberately not in this PR: chunked-layout support, and
feeding findings back to the working group — the schema in
`schema/mzpeak_index.json` contradicts its own implementation on the
`data_arrays` spelling and omits `column_mapping` entirely, and there is still
no spectrum → row-group map in the container.
