### PR TITLE
feat(readers): native solariX .d reader via peaks.sqlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Full documentation: **[M4i-Imaging-Mass-Spectrometry.github.io/thyra](https://M4
 | Input | Extension | Status |
 |-------|-----------|--------|
 | ImzML | `.imzML` | Full support |
-| Bruker | `.d` | Full support (timsTOF + Rapiflex) |
+| Bruker | `.d` | Full support (timsTOF + solariX + Rapiflex) |
 | Waters | `.raw` directory | Full support |
 | PHI SmartSoft-TOF | `.raw` file | Full support (nanoTOF, ToF-SIMS) |
 | mzPeak | `.mzpeak` | Experimental (HUPO-PSI v0.9 draft, read-only) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ The output is a single SpatialData/Zarr directory containing intensity matrices,
 
 | | Feature | Description |
 |---|---------|-------------|
-| **Formats** | Multiple inputs | ImzML, Bruker (.d timsTOF + Rapiflex), Waters (.raw directory), PHI SmartSoft-TOF (.raw file) |
+| **Formats** | Multiple inputs | ImzML, Bruker (.d timsTOF + solariX, Rapiflex), Waters (.raw directory), PHI SmartSoft-TOF (.raw file) |
 | **Output** | SpatialData/Zarr | Cloud-ready, chunked, standardised |
 | **Scale** | Memory efficient | Streaming mode for 100+ GB datasets |
 | **Optics** | Optical alignment | Automatic MSI-to-microscopy registration (Bruker) |
@@ -94,7 +94,7 @@ tic = np.asarray(sdata.images["msi_dataset_z0_tic"])[0]
 | Format | Path | Instruments |
 |--------|------|-------------|
 | ImzML  | `.imzML` file | Any vendor exporting to the open standard |
-| Bruker | `.d` directory | timsTOF fleX, Rapiflex MALDI-TOF |
+| Bruker | `.d` directory | timsTOF fleX, solariX/MRMS FT-ICR, Rapiflex MALDI-TOF |
 | Waters | `.raw` directory | MassLynx imaging (DESI, MALDI) |
 | PHI    | `.raw` file | SmartSoft-TOF nanoTOF (ToF-SIMS) |
 

--- a/docs/resampling.md
+++ b/docs/resampling.md
@@ -104,6 +104,7 @@ catch-all default. This table is the actual observed behaviour of that chain:
 | Rapiflex, profile | Rapiflex MALDI-TOF | `tic_preserving` | `constant` |
 | Bruker MALDI-TOF | Rapiflex MALDI-TOF | `tic_preserving` | `constant` |
 | imzML declaring an FT-ICR analyzer or model | FT-ICR | `nearest_neighbor` | `fticr` |
+| solariX `.d` (native, peaks.sqlite) | FT-ICR | `nearest_neighbor` | `fticr` |
 | imzML declaring an Orbitrap analyzer or model | Orbitrap | `nearest_neighbor` | `orbitrap` |
 | PHI SmartSoft-TOF `.raw` | PHI SmartSoft-TOF (ToF-SIMS) | `nearest_neighbor` | `linear_tof` |
 | Waters MassLynx `.raw`, any representation | Waters MassLynx | `nearest_neighbor` | `reflector_tof` |
@@ -148,6 +149,11 @@ catch-all default. This table is the actual observed behaviour of that chain:
     family-identifying product name in free-form model text. A file that
     declares none of the three stays untyped and falls through to the
     generic rows below -- an unstated analyzer stays unstated.
+
+    The native solariX `.d` route needs none of this: its extractor stamps
+    `instrument_type = "FT-ICR"` directly from the instrument identity in
+    `peaks.sqlite`, so the same FT-ICR row is reached without an export
+    step (see [Supported Formats](supported-formats.md#bruker-solarix)).
 
     One known gap: SCiLS Lab-lineage imzML exports of timsTOF data stamp the
     generic `MS:1001534 Bruker Daltonics flex series` term rather than a

--- a/docs/solarix-notes.md
+++ b/docs/solarix-notes.md
@@ -139,6 +139,36 @@ the same pair a vendor imzML export of the same data reaches, minus the
 export step. See [Resampling](resampling.md) for why TIC-preserving is
 refused for centroid data.
 
+## Cross-validation against a vendor imzML export
+
+The reader was validated against a SCiLS-lineage centroid imzML export of
+the *same acquisition* (a 7,362-pixel run; the export is a 949-pixel tissue
+ROI crop with re-based coordinates). Registering the ROI onto the reader's
+raster by normalized cross-correlation of TIC images -- testing all four
+axis orientations -- found the identity orientation with a pure translation,
+and every ROI pixel landed on a measured pixel. On that overlap:
+
+- **The peak lists are the same peaks.** Every one of the 949 overlapping
+  pixels has an identical peak count on both sides -- the exporter consumed
+  the same picked peaks this reader decodes, it did not re-pick.
+- **Intensities differ only by the exporter's normalization.** Within each
+  pixel the imzML/native intensity ratio is constant to the last float32
+  digit, and the per-pixel factor times the RMS of the pixel's native peak
+  intensities is one dataset-wide constant: the export applied RMS
+  normalization (the `_rms` in its filename) plus a global scale. Dividing
+  the factor out reproduces the native TICs with a maximum relative error
+  of 2e-7, and the TIC correlation goes to r = 1.000000.
+- **m/z values agree to 0.00 ppm on average.** The signed difference is
+  zero-mean in every 200 Da band -- no calibration difference. Individual
+  peaks deviate by up to ~4 mDa, growing quadratically with m/z (0.06 mDa
+  median at m/z 200, 2.0 mDa at m/z 1200), which is the FT-ICR grid-spacing
+  law: the exporter snapped centroids to its own profile-grid axis. The
+  native reader keeps the full-precision centroids as stored.
+
+So the native route and the vendor-export route see the same data; the
+export adds RMS normalization and axis snapping, and drops the pixels
+outside the drawn ROI.
+
 ## What the native route adds over an imzML export
 
 Everything an export carries, plus metadata no exporter writes: per-pixel

--- a/docs/solarix-notes.md
+++ b/docs/solarix-notes.md
@@ -1,0 +1,148 @@
+# solariX Notes
+
+Thyra reads Bruker solariX / MRMS (FT-ICR) imaging `.d` directories natively
+by consuming `peaks.sqlite`, the processed peak store ftmsControl writes into
+every imaging acquisition. There is no public specification for this file;
+the layout below was established by inspecting real acquisitions spanning
+2018-2024 (ftmsControl 2.2, flexImaging 5.0.80-5.0.89) and decode-verifying
+the binary blobs against their own metadata. The same file is read by at
+least one independent open-source tool for the solariX XR, so the store is
+not a single-instrument quirk.
+
+What this route deliberately is **not**: a transient processor. The `.d`
+also holds the raw time-domain transients (`ser`, tens of GB per region) and
+Bruker's proprietary `.mcf` containers. Thyra never opens either -- no FT,
+no apodization, no peak picking. The peaks were picked by the acquisition
+software at acquisition time, and that processing is frozen in the data.
+Anyone needing different peak picking must export via the vendor software.
+
+---
+
+## Directory layout
+
+```
+sample.d/
+  peaks.sqlite            centroided per-pixel peak lists  <- what Thyra reads
+  ImagingInfo.xml         per-scan index (spot name, TIC, base peak)
+  ser                     raw transients, fixed-length per scan (ignored)
+  <guid>_N.mcf/.mcf_idx   Bruker container stores (ignored)
+  parameterChanges.sqlite per-scan parameter history (ignored)
+  Storage.mcf_idx         container index (ignored)
+  *.m/                    acquisition method directory (ignored)
+sample.mis                flexImaging sequence NEXT TO the .d, same stem
+sample.dat                flexImaging cache (ignored)
+```
+
+Detection requires `peaks.sqlite` **and** `ImagingInfo.xml` inside a `.d`
+directory. Two traps are handled explicitly:
+
+- **Pre-scan directories.** flexImaging writes sibling `.d` directories such
+  as `sample_0_C17_000001.d` holding `fid` + `analysis.baf` + `calib.bin` --
+  single-spectrum pre-scans, not imaging runs. They contain none of the
+  detection files and are rejected as unrecognised Bruker data.
+- **Peaks-less acquisitions.** A `.d` with `ser` and `ImagingInfo.xml` but no
+  `peaks.sqlite` is still recognisably solariX-family; the error names the
+  imzML export fallback (DataAnalysis, SCiLS Lab, or flexImaging) instead of
+  claiming the directory is not Bruker data.
+
+## peaks.sqlite
+
+Three tables matter. `Properties` is a key/value table carrying the schema
+identity (`SchemaType = Imaging`, `SchemaVersionMajor = 1`,
+`SchemaVersionMinor = 2` in every file inspected), the acquisition software
+name/version, the instrument vendor, family, source type and serial number,
+the operator, the acquisition timestamp and the acquired m/z range
+(`MzAcqRangeLower`/`MzAcqRangeUpper`).
+
+The reader checks `SchemaType` and `SchemaVersionMajor` at open and refuses
+anything it has not been verified against, quoting the values it found. A
+newer ftmsControl that bumps the major version fails loudly rather than
+decoding blobs on an unknown layout.
+
+`AcquisitionKeys` holds one row per acquisition mode with `Polarity`,
+`ScanMode`, `AcquisitionMode` and `MsLevel`. Only the polarity enum has been
+verified (against a paired positive/negative acquisition of the same
+sample): **0 = positive, 1 = negative**. The other enums are undocumented,
+so Thyra stores the raw integers without inventing labels. Observed values:
+`ScanMode 0 / MsLevel 1` on full scans, `ScanMode 2 / MsLevel 2` on a CASI
+(quadrupole isolation) run.
+
+`Spectra` holds one row per pixel: stage-raster coordinates
+(`XIndexPos`/`YIndexPos`), `NumPeaks`, per-scan acquisition values
+(`NumSummations`, `LaserPower`, `LaserRepRate`), `RegionNumber`, and the
+peak blobs.
+
+### Blob encoding
+
+| Column | Encoding | Length |
+|---|---|---|
+| `PeakMzValues` | little-endian float64, ascending | `NumPeaks * 8` |
+| `PeakIntensityValues` | little-endian float32 | `NumPeaks * 4` |
+| `PeakFwhmValues` | little-endian float32 | `NumPeaks * 4` |
+| `PeakSnrValues` | little-endian float32 | `NumPeaks * 4` |
+
+The m/z values are already calibrated -- the frequency-to-m/z law (ML1/ML2/
+ML3 in the acquisition method) has been applied by the time the peaks are
+stored, so the reader does no calibration math. Every blob length is checked
+against `NumPeaks * itemsize` before decoding; a mismatch is refused as
+corruption rather than silently truncated. `PeakFlags`, `BH` and `BC` are
+undecoded (flags were all-zero in every file inspected) and nothing is
+derived from them.
+
+The database is opened strictly read-only through a URI (`mode=ro`), so
+sqlite never creates journal or WAL side files next to it. That matters
+because solariX data commonly lives on read-only network shares.
+
+## Coordinates and sparsity
+
+`XIndexPos`/`YIndexPos` are **absolute** stage-raster indices -- a real
+region started at X 1239, not 0. The reader subtracts the per-dataset
+minimum to produce 0-based coordinates and reports the subtracted origin in
+`coordinate_offsets` and the absolute extents in the format metadata.
+
+Rasters are sparse: flexImaging acquires the polygon drawn on the optical
+image, so the bounding box contains cells that were never measured (81.5 %
+fill on the reference region). Unmeasured cells are simply absent from the
+output, exactly like sparse pixels in any other format. A measured scan can
+also record zero peaks (seen at the tissue-free edges of one acquisition);
+such pixels are skipped like unmeasured ones.
+
+One fidelity check worth recording: on the reference region the sum of a
+pixel's stored peak intensities reproduces the per-scan `tic` value in
+`ImagingInfo.xml` -- an independent record written at acquisition time --
+to a ratio of 0.9999. TIC images computed from the peak store are therefore
+faithful to what the instrument reported.
+
+## Pixel size
+
+The `.d` itself does not record the raster pitch anywhere -- the acquisition
+method file was swept for raster/pixel tokens and carries none. The only
+source is the `<Raster>x,y</Raster>` element (micrometres) of the
+flexImaging `.mis` file sitting next to the `.d` with the same stem.
+
+Resolution order: a stem-matching `.mis` in the parent directory; failing
+that, a *lone* `.mis` in the parent is accepted as unambiguous. Multiple
+non-matching candidates are refused -- on a multi-region slide each region
+has its own `.mis`, and guessing one would silently assign a wrong pixel
+size. When no source resolves, the pixel size is reported as unknown and
+conversion asks for `--pixel-size` instead of defaulting.
+
+## Resampling
+
+The stored spectra are centroided per-pixel peak lists, so every spectrum
+has its own m/z values. The metadata extractor stamps
+`instrument_type = "FT-ICR"` from the instrument identity in `Properties`
+(`InstrumentFamily 513` additionally maps to the model name `solariX`;
+unknown family numbers are surfaced raw). The resampling decision tree
+therefore lands on `nearest_neighbor` onto the `fticr` axis with no flags --
+the same pair a vendor imzML export of the same data reaches, minus the
+export step. See [Resampling](resampling.md) for why TIC-preserving is
+refused for centroid data.
+
+## What the native route adds over an imzML export
+
+Everything an export carries, plus metadata no exporter writes: per-pixel
+laser power, repetition rate and summation counts, the acquisition software
+identity and version, the raw acquisition-mode enums, per-scan region
+numbers, the absolute stage-raster extents, and the acquisition m/z range
+as acquired. And no manual vendor-software step per dataset.

--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -1,6 +1,6 @@
 # Supported Formats
 
-Thyra reads six MSI formats and writes all of them into the same
+Thyra reads seven MSI formats and writes all of them into the same
 SpatialData/Zarr layout. The input format is detected from the path -- there is
 no format flag on the CLI, and `format_type` in the Python API selects the
 *output* format, not the input.
@@ -9,6 +9,7 @@ no format flag on the CLI, and `format_type` in the Python API selects the
 |---|---|---|---|
 | **imzML** | `.imzML` file + `.ibd` | extension, `.ibd` must exist | none |
 | **Bruker timsTOF** | `.d` directory | `analysis.tsf` or `analysis.tdf` | bundled DLL |
+| **Bruker solariX** | `.d` directory | `peaks.sqlite` + `ImagingInfo.xml` | none |
 | **Bruker Rapiflex** | directory | `*.dat` + `*_poslog.txt` | none |
 | **Waters MassLynx** | `.raw` **directory** | `_FUNC*.DAT` files inside | bundled DLL |
 | **PHI SmartSoft-TOF** | `.raw` **file** | `SOFH` magic in first 4 bytes | none |
@@ -16,12 +17,16 @@ no format flag on the CLI, and `format_type` in the Python API selects the
 
 ```bash
 thyra sample.imzML       out.zarr   # imzML
-thyra sample.d           out.zarr   # Bruker timsTOF
+thyra sample.d           out.zarr   # Bruker timsTOF or solariX (see below)
 thyra rapiflex_folder/   out.zarr   # Bruker Rapiflex
 thyra waters_run.raw/    out.zarr   # Waters (a directory)
 thyra tofsims_run.raw    out.zarr   # PHI (a file)
 thyra sample.mzpeak      out.zarr   # mzPeak (experimental)
 ```
+
+Two Bruker instrument families share the `.d` extension and are told apart by
+what the directory contains: timsTOF writes `analysis.tsf`/`analysis.tdf`,
+solariX (FT-ICR / MRMS) writes `peaks.sqlite` alongside `ImagingInfo.xml`.
 
 ---
 
@@ -49,14 +54,14 @@ _FUNC*.DAT files, or a PHI SmartSoft-TOF file beginning with the SOFH magic.
 Not every source carries every kind of metadata. This is what Thyra can
 actually populate from each.
 
-| | imzML | timsTOF | Rapiflex | Waters | PHI | mzPeak |
-|---|---|---|---|---|---|---|
-| Pixel size from metadata | yes | yes | yes | yes | yes | sometimes |
-| Optical image | -- | yes | yes | -- | -- | -- |
-| Optical alignment | -- | yes (`.mis`) | -- | -- | -- | -- |
-| Multi-region | -- | yes | -- | -- | mosaic tiles | -- |
-| 3D / multi-slice | yes | yes | -- | -- | -- | -- |
-| Native non-m/z axis kept | -- | -- | -- | -- | flight time | -- |
+| | imzML | timsTOF | solariX | Rapiflex | Waters | PHI | mzPeak |
+|---|---|---|---|---|---|---|---|
+| Pixel size from metadata | yes | yes | yes (`.mis`) | yes | yes | yes | sometimes |
+| Optical image | -- | yes | -- | yes | -- | -- | -- |
+| Optical alignment | -- | yes (`.mis`) | -- | -- | -- | -- | -- |
+| Multi-region | -- | yes | recorded | -- | -- | mosaic tiles | -- |
+| 3D / multi-slice | yes | yes | -- | -- | -- | -- | -- |
+| Native non-m/z axis kept | -- | -- | -- | -- | -- | flight time | -- |
 
 Anything a format does not supply is simply absent from the output rather than
 guessed at. Pixel size is the one exception worth knowing about: when a source
@@ -88,6 +93,26 @@ mobility). Reading goes through Bruker's `timsdata` library, which is bundled
 for Windows and Linux. This is the richest source Thyra handles: it carries
 optical microscopy images, FlexImaging `.mis` teaching points for MSI-to-optical
 registration, and per-pixel region annotations for multi-region slides.
+
+## Bruker solariX
+
+`.d` directories from solariX / MRMS (FT-ICR) instruments running ftmsControl,
+detected by `peaks.sqlite` together with `ImagingInfo.xml`. Thyra reads the
+processed peak store the acquisition software writes into every imaging `.d`:
+centroided, calibrated per-pixel peak lists with stage-raster coordinates and
+the instrument identity. **No vendor SDK** and no FT processing are involved --
+the raw transient block (`ser`) and the `.mcf` containers are never touched.
+See [solariX Notes](solarix-notes.md) for the verified layout, what the reader
+refuses, and the pixel-size story.
+
+Two things to know up front:
+
+- The pixel size lives **only** in the flexImaging `.mis` file next to the
+  `.d` (same stem). Without it, pass `--pixel-size` explicitly -- Thyra never
+  guesses.
+- A solariX-family `.d` that carries raw transients but no `peaks.sqlite`
+  cannot be read natively; the error says so and names the imzML export
+  fallback (DataAnalysis, SCiLS Lab, or flexImaging).
 
 ## Bruker Rapiflex
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
   - Coordinate Systems: coordinate-systems.md
   - imzML Parser Notes: imzml-parser-notes.md
   - PHI ToF-SIMS Notes: phi-tofsims-notes.md
+  - solariX Notes: solarix-notes.md
   - API Reference: api.md
   - Contributing: contributing.md
   - Code of Conduct: code-of-conduct.md

--- a/tests/unit/readers/test_solarix_reader.py
+++ b/tests/unit/readers/test_solarix_reader.py
@@ -1,0 +1,569 @@
+"""Tests for the Bruker solariX peaks.sqlite reader.
+
+Builds synthetic .d directories matching the verified solariX layout --
+a peaks.sqlite with hand-packed blobs plus ImagingInfo.xml and a sibling
+.mis -- so the reader can be exercised without committing any vendor data.
+"""
+
+import logging
+import sqlite3
+
+import numpy as np
+import pytest
+
+from thyra.core.registry import detect_format, get_reader_class
+from thyra.preview import preview_msi
+from thyra.readers.bruker import BrukerFolderStructure, BrukerFormat, SolarixReader
+from thyra.resampling.types import AxisType, ResamplingMethod
+
+# Properties as found in a real acquisition (ftmsControl 2.2, schema
+# Imaging 1.2); tests override individual keys to probe the refusals.
+DEFAULT_PROPERTIES = {
+    "SchemaType": "Imaging",
+    "SchemaVersionMajor": "1",
+    "SchemaVersionMinor": "2",
+    "AcquisitionSoftware": "ftmsControl",
+    "AcquisitionSoftwareVendor": "Bruker",
+    "AcquisitionSoftwareVersion": "2.2",
+    "InstrumentVendor": "Bruker",
+    "InstrumentFamily": "513",
+    "InstrumentSourceType": "7",
+    "InstrumentSerialNumber": "1272500.00145",
+    "AcquisitionDateTime": "2019-09-20T14:10:43.435+02:00",
+    "OperatorName": "Admin",
+    "MzAcqRangeLower": "100.53",
+    "MzAcqRangeUpper": "1000.0",
+}
+
+# (Id, Polarity, ScanMode, AcquisitionMode, MsLevel) -- a positive full scan.
+DEFAULT_ACQUISITION_KEYS = [(0, 0, 0, 33, 1)]
+
+# Absolute stage-raster coordinates, deliberately far from 0 (a real region
+# started at X 1239) so the offset-to-0-based behaviour is actually exercised.
+# The four pixels cover a 2x2 bounding box minus one corner: sparse raster.
+DEFAULT_SPECTRA = [
+    {
+        "id": 1,
+        "x": 1239,
+        "y": 166,
+        "mzs": [100.967, 250.5, 999.731],
+        "intensities": [1000.0, 2500.5, 300.25],
+    },
+    {"id": 2, "x": 1240, "y": 166, "mzs": [150.25, 250.5], "intensities": [10.5, 20.0]},
+    {"id": 3, "x": 1240, "y": 167, "mzs": [500.125], "intensities": [42.0]},
+]
+
+
+def make_peaks_sqlite(
+    d_dir,
+    spectra=None,
+    properties=None,
+    acquisition_keys=None,
+    blob_overrides=None,
+):
+    """Write a synthetic peaks.sqlite with hand-packed peak blobs."""
+    spectra = DEFAULT_SPECTRA if spectra is None else spectra
+    props = dict(DEFAULT_PROPERTIES)
+    props.update(properties or {})
+    keys = DEFAULT_ACQUISITION_KEYS if acquisition_keys is None else acquisition_keys
+    blob_overrides = blob_overrides or {}
+
+    conn = sqlite3.connect(d_dir / "peaks.sqlite")
+    conn.execute("CREATE TABLE Properties (Key TEXT, Value TEXT)")
+    conn.executemany("INSERT INTO Properties VALUES (?, ?)", props.items())
+    conn.execute(
+        "CREATE TABLE AcquisitionKeys (Id INTEGER, Polarity INTEGER, "
+        "ScanMode INTEGER, AcquisitionMode INTEGER, MsLevel INTEGER)"
+    )
+    conn.executemany("INSERT INTO AcquisitionKeys VALUES (?, ?, ?, ?, ?)", keys)
+    conn.execute(
+        "CREATE TABLE Spectra (Id INTEGER, Chip INTEGER, SpotName TEXT, "
+        "RegionNumber INTEGER, XIndexPos INTEGER, YIndexPos INTEGER, "
+        "AcquisitionKey INTEGER, ParentMass REAL, DateTime TEXT, "
+        "CalibrationDateTime TEXT, MotorPositionX REAL, MotorPositionY REAL, "
+        "NumSummations INTEGER, LaserPower REAL, LaserRepRate REAL, "
+        "NumPeaks INTEGER, PeakMzValues BLOB, PeakIntensityValues BLOB, "
+        "PeakFwhmValues BLOB, PeakSnrValues BLOB, PeakFlags BLOB, "
+        "BH BLOB, BC BLOB)"
+    )
+    for spec in spectra:
+        mzs = np.asarray(spec["mzs"], dtype="<f8")
+        intensities = np.asarray(spec["intensities"], dtype="<f4")
+        n = spec.get("num_peaks", mzs.size)
+        mz_blob = blob_overrides.get(("mz", spec["id"]), mzs.tobytes())
+        int_blob = blob_overrides.get(("intensity", spec["id"]), intensities.tobytes())
+        conn.execute(
+            "INSERT INTO Spectra (Id, SpotName, RegionNumber, XIndexPos, "
+            "YIndexPos, AcquisitionKey, NumSummations, LaserPower, "
+            "LaserRepRate, NumPeaks, PeakMzValues, PeakIntensityValues, "
+            "PeakFwhmValues, PeakSnrValues) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                spec["id"],
+                f"R00X{spec['x']}Y{spec['y']}",
+                spec.get("region", 0),
+                spec["x"],
+                spec["y"],
+                spec.get("acquisition_key", 0),
+                spec.get("num_summations", 300),
+                spec.get("laser_power", 14.0),
+                spec.get("laser_rep_rate", 2000.0),
+                n,
+                mz_blob,
+                int_blob,
+                np.full(mzs.size, 2e-4, dtype="<f4").tobytes(),
+                np.full(mzs.size, 10.0, dtype="<f4").tobytes(),
+            ),
+        )
+    conn.commit()
+    conn.close()
+
+
+def make_imaging_info(d_dir, n_scans):
+    """Write a minimal ImagingInfo.xml with one <scan> entry per spectrum."""
+    scans = "".join(
+        f"<scan><count>{i + 1}</count><spotName>R00X0Y0</spotName>"
+        f"<minutes>0.1</minutes><tic>4.4E9</tic><maxpeak>9.8E8</maxpeak></scan>"
+        for i in range(n_scans)
+    )
+    (d_dir / "ImagingInfo.xml").write_text(
+        f"<ImagingInfo>{scans}</ImagingInfo>", encoding="utf-8"
+    )
+
+
+def make_solarix_d(
+    parent,
+    name="sample",
+    spectra=None,
+    properties=None,
+    acquisition_keys=None,
+    blob_overrides=None,
+    with_mis=True,
+    raster=(50, 50),
+    n_info_scans=None,
+):
+    """Build a synthetic solariX imaging .d with its sibling .mis."""
+    spectra = DEFAULT_SPECTRA if spectra is None else spectra
+    d_dir = parent / f"{name}.d"
+    d_dir.mkdir()
+    make_peaks_sqlite(
+        d_dir,
+        spectra=spectra,
+        properties=properties,
+        acquisition_keys=acquisition_keys,
+        blob_overrides=blob_overrides,
+    )
+    make_imaging_info(d_dir, len(spectra) if n_info_scans is None else n_info_scans)
+    (d_dir / "ser").write_bytes(b"\x00" * 64)
+    if with_mis:
+        (parent / f"{name}.mis").write_text(
+            "<ImagingSequence>"
+            f"<Raster>{raster[0]},{raster[1]}</Raster>"
+            "</ImagingSequence>",
+            encoding="utf-8",
+        )
+    return d_dir
+
+
+@pytest.fixture
+def solarix_d(tmp_path):
+    """A default synthetic solariX .d with a matching .mis."""
+    return make_solarix_d(tmp_path)
+
+
+class TestSolarixDetection:
+    """Format detection for the solariX layout and its traps."""
+
+    def test_detect_format_solarix(self, solarix_d):
+        assert detect_format(solarix_d) == "solarix"
+
+    def test_folder_structure_detects_solarix(self, solarix_d):
+        assert BrukerFolderStructure.detect_format(solarix_d) is BrukerFormat.SOLARIX
+
+    def test_parent_folder_containing_solarix_d(self, tmp_path, solarix_d):
+        assert detect_format(tmp_path) == "solarix"
+
+    def test_metadata_files_found(self, solarix_d):
+        info = BrukerFolderStructure(solarix_d).analyze()
+
+        assert info.format is BrukerFormat.SOLARIX
+        assert info.metadata_files["peaks"] == solarix_d / "peaks.sqlite"
+        assert info.metadata_files["imaging_info"] == solarix_d / "ImagingInfo.xml"
+        assert info.metadata_files["ser"] == solarix_d / "ser"
+
+    def test_prescan_d_still_falls_through(self, tmp_path):
+        """flexImaging pre-scan dirs (fid + analysis.baf) are not imaging runs."""
+        prescan = tmp_path / "sample_0_C17_000001.d"
+        prescan.mkdir()
+        (prescan / "fid").write_bytes(b"\x00" * 16)
+        (prescan / "analysis.baf").write_bytes(b"\x00" * 16)
+        (prescan / "calib.bin").write_bytes(b"\x00" * 16)
+
+        with pytest.raises(ValueError, match="missing analysis files"):
+            detect_format(prescan)
+
+    def test_solarix_family_without_peaks_names_the_fallback(self, tmp_path):
+        """ser + ImagingInfo.xml but no peaks.sqlite: still solariX, but the
+        error must point at the imzML export route, not claim non-detection."""
+        d_dir = tmp_path / "old_acquisition.d"
+        d_dir.mkdir()
+        (d_dir / "ser").write_bytes(b"\x00" * 16)
+        (d_dir / "ImagingInfo.xml").write_text("<ImagingInfo/>", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="without peaks.sqlite") as excinfo:
+            detect_format(d_dir)
+        assert "imzML" in str(excinfo.value)
+
+    def test_timstof_detection_unaffected(self, tmp_path):
+        d_dir = tmp_path / "tims.d"
+        d_dir.mkdir()
+        (d_dir / "analysis.tdf").touch()
+
+        assert detect_format(d_dir) == "bruker"
+
+    def test_registry_round_trip(self):
+        assert get_reader_class("solarix") is SolarixReader
+
+
+class TestSolarixReader:
+    """Spectrum iteration and blob decoding."""
+
+    def test_iter_spectra_round_trip(self, solarix_d):
+        with SolarixReader(solarix_d) as reader:
+            spectra = list(reader.iter_spectra())
+
+        assert len(spectra) == 3
+        coords, mzs, intensities = spectra[0]
+        assert coords == (0, 0, 0)
+        np.testing.assert_array_equal(mzs, np.array([100.967, 250.5, 999.731]))
+        np.testing.assert_array_equal(
+            intensities, np.float32([1000.0, 2500.5, 300.25]).astype(np.float64)
+        )
+        assert mzs.dtype == np.float64
+        assert intensities.dtype == np.float64
+
+    def test_absolute_indices_offset_to_zero_based(self, solarix_d):
+        """XIndexPos starts at 1239, not 0 -- forget the offset and every
+        image becomes a sliver in a huge canvas."""
+        with SolarixReader(solarix_d) as reader:
+            coords = [c for c, _, _ in reader.iter_spectra()]
+
+            assert coords == [(0, 0, 0), (1, 0, 0), (1, 1, 0)]
+            assert reader.coordinate_offsets == (1239, 166, 0)
+            assert reader.dimensions == (2, 2, 1)
+
+    def test_sparse_raster_pixel_absent(self, solarix_d):
+        """The (1239, 167) cell was never acquired: no yield, zero count."""
+        with SolarixReader(solarix_d) as reader:
+            coords = {c[:2] for c, _, _ in reader.iter_spectra()}
+            counts = reader.get_peak_counts_per_pixel()
+
+        assert (0, 1) not in coords
+        # pixel_idx = y * n_x + x with n_x = 2
+        np.testing.assert_array_equal(counts, np.array([3, 2, 0, 1]))
+
+    def test_truncated_mz_blob_is_refused(self, tmp_path):
+        """A blob shorter than NumPeaks * itemsize must not decode silently."""
+        d_dir = make_solarix_d(
+            tmp_path,
+            blob_overrides={("mz", 2): np.asarray([150.25], dtype="<f8").tobytes()},
+        )
+
+        with SolarixReader(d_dir) as reader:
+            with pytest.raises(ValueError, match="Corrupt PeakMzValues.*Id=2"):
+                list(reader.iter_spectra())
+
+    def test_truncated_intensity_blob_is_refused(self, tmp_path):
+        d_dir = make_solarix_d(
+            tmp_path,
+            blob_overrides={("intensity", 3): b"\x00"},
+        )
+
+        with SolarixReader(d_dir) as reader:
+            with pytest.raises(ValueError, match="Corrupt PeakIntensityValues"):
+                list(reader.iter_spectra())
+
+    def test_empty_spectrum_is_skipped(self, tmp_path):
+        spectra = DEFAULT_SPECTRA + [
+            {"id": 4, "x": 1241, "y": 166, "mzs": [], "intensities": []}
+        ]
+        d_dir = make_solarix_d(tmp_path, spectra=spectra)
+
+        with SolarixReader(d_dir) as reader:
+            assert len(list(reader.iter_spectra())) == 3
+
+    def test_unsorted_mz_values_are_sorted(self, tmp_path):
+        spectra = [
+            {
+                "id": 1,
+                "x": 10,
+                "y": 20,
+                "mzs": [500.0, 100.0, 300.0],
+                "intensities": [5.0, 1.0, 3.0],
+            }
+        ]
+        d_dir = make_solarix_d(tmp_path, spectra=spectra)
+
+        with SolarixReader(d_dir) as reader:
+            _, mzs, intensities = next(reader.iter_spectra())
+
+        np.testing.assert_array_equal(mzs, [100.0, 300.0, 500.0])
+        np.testing.assert_array_equal(intensities, [1.0, 3.0, 5.0])
+
+    def test_intensity_threshold_filters(self, solarix_d):
+        with SolarixReader(solarix_d, intensity_threshold=100.0) as reader:
+            spectra = {c[:2]: (m, i) for c, m, i in reader.iter_spectra()}
+
+        # Pixel (1, 0) had intensities 10.5 and 20.0 -- both filtered out.
+        assert (1, 0) not in spectra
+        mzs, intensities = spectra[(0, 0)]
+        np.testing.assert_array_equal(mzs, [100.967, 250.5, 999.731])
+
+    def test_common_mass_axis_is_sorted_union(self, solarix_d):
+        with SolarixReader(solarix_d) as reader:
+            axis = reader.get_common_mass_axis()
+
+        np.testing.assert_array_equal(
+            axis,
+            np.unique(np.float64([100.967, 250.5, 999.731, 150.25, 250.5, 500.125])),
+        )
+
+    def test_has_shared_mass_axis_is_false(self, solarix_d):
+        with SolarixReader(solarix_d) as reader:
+            assert reader.has_shared_mass_axis is False
+
+    def test_region_map_and_info(self, tmp_path):
+        spectra = [
+            {
+                "id": 1,
+                "x": 5,
+                "y": 5,
+                "mzs": [100.0],
+                "intensities": [1.0],
+                "region": 0,
+            },
+            {
+                "id": 2,
+                "x": 6,
+                "y": 5,
+                "mzs": [100.0],
+                "intensities": [1.0],
+                "region": 1,
+            },
+        ]
+        d_dir = make_solarix_d(tmp_path, spectra=spectra)
+
+        with SolarixReader(d_dir) as reader:
+            assert reader.get_region_map() == {(0, 0): 0, (1, 0): 1}
+            assert reader.get_region_info() == [
+                {"region_number": 0, "n_spectra": 1},
+                {"region_number": 1, "n_spectra": 1},
+            ]
+
+    def test_closed_reader_refuses_iteration(self, solarix_d):
+        reader = SolarixReader(solarix_d)
+        reader.close()
+
+        with pytest.raises(RuntimeError, match="closed"):
+            list(reader.iter_spectra())
+
+    def test_scan_count_mismatch_warns(self, tmp_path, caplog):
+        d_dir = make_solarix_d(tmp_path, n_info_scans=99)
+
+        with caplog.at_level(logging.WARNING):
+            SolarixReader(d_dir).close()
+
+        assert any("truncated or partially copied" in m for m in caplog.messages)
+
+
+class TestSolarixSchemaRefusal:
+    """Unverified schemas must fail loudly with the found values."""
+
+    def test_wrong_schema_type(self, tmp_path):
+        d_dir = make_solarix_d(tmp_path, properties={"SchemaType": "LC-MS"})
+
+        with pytest.raises(ValueError, match="SchemaType='LC-MS'"):
+            SolarixReader(d_dir)
+
+    def test_wrong_major_version(self, tmp_path):
+        d_dir = make_solarix_d(tmp_path, properties={"SchemaVersionMajor": "2"})
+
+        with pytest.raises(ValueError, match="SchemaVersionMajor='2'"):
+            SolarixReader(d_dir)
+
+    def test_no_peaks_sqlite_names_the_fallback(self, tmp_path):
+        d_dir = tmp_path / "no_peaks.d"
+        d_dir.mkdir()
+        (d_dir / "ser").write_bytes(b"\x00" * 16)
+        (d_dir / "ImagingInfo.xml").write_text("<ImagingInfo/>", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="imzML"):
+            SolarixReader(d_dir)
+
+    def test_missing_properties_table(self, tmp_path):
+        d_dir = tmp_path / "empty.d"
+        d_dir.mkdir()
+        sqlite3.connect(d_dir / "peaks.sqlite").close()
+        (d_dir / "ImagingInfo.xml").write_text("<ImagingInfo/>", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="Properties"):
+            SolarixReader(d_dir)
+
+
+class TestSolarixPixelSize:
+    """The .mis sibling is the only pixel-size source; never guess."""
+
+    def test_raster_from_matching_mis(self, solarix_d):
+        with SolarixReader(solarix_d) as reader:
+            assert reader.pixel_size_um == (50.0, 50.0)
+            assert ".mis" in reader.pixel_size_source
+
+    def test_missing_mis_reports_unknown(self, tmp_path):
+        d_dir = make_solarix_d(tmp_path, with_mis=False)
+
+        with SolarixReader(d_dir) as reader:
+            assert reader.pixel_size_um is None
+            assert "unknown" in reader.pixel_size_source
+            assert reader.get_essential_metadata().pixel_size is None
+
+    def test_single_non_matching_mis_is_used(self, tmp_path):
+        d_dir = make_solarix_d(tmp_path, with_mis=False)
+        (tmp_path / "renamed.mis").write_text(
+            "<ImagingSequence><Raster>25,25</Raster></ImagingSequence>",
+            encoding="utf-8",
+        )
+
+        with SolarixReader(d_dir) as reader:
+            assert reader.pixel_size_um == (25.0, 25.0)
+
+    def test_multiple_non_matching_mis_refused(self, tmp_path):
+        """Several other regions' .mis files: guessing one would silently
+        assign a wrong raster, so the pixel size stays unknown."""
+        d_dir = make_solarix_d(tmp_path, with_mis=False)
+        for name in ("region_2.mis", "region_3.mis"):
+            (tmp_path / name).write_text(
+                "<ImagingSequence><Raster>75,75</Raster></ImagingSequence>",
+                encoding="utf-8",
+            )
+
+        with SolarixReader(d_dir) as reader:
+            assert reader.pixel_size_um is None
+
+    def test_user_override_wins(self, solarix_d):
+        with SolarixReader(solarix_d, pixel_size_um=30.0) as reader:
+            assert reader.pixel_size_um == (30.0, 30.0)
+            assert reader.pixel_size_source == "user override"
+
+
+class TestSolarixMetadata:
+    """Essential and comprehensive metadata content."""
+
+    def test_essential_metadata(self, solarix_d):
+        with SolarixReader(solarix_d) as reader:
+            essential = reader.get_essential_metadata()
+
+        assert essential.dimensions == (2, 2, 1)
+        assert essential.coordinate_bounds == (0.0, 1.0, 0.0, 1.0)
+        assert essential.mass_range == (100.53, 1000.0)
+        assert essential.pixel_size == (50.0, 50.0)
+        assert essential.n_spectra == 3
+        assert essential.total_peaks == 6
+        assert essential.coordinate_offsets == (1239, 166, 0)
+        assert essential.spectrum_type == "centroid spectrum"
+
+    def test_metadata_only_matches_full_mode(self, solarix_d):
+        with SolarixReader(solarix_d) as full:
+            full_essential = full.get_essential_metadata()
+        with SolarixReader(solarix_d, metadata_only=True) as cheap:
+            cheap_essential = cheap.get_essential_metadata()
+
+        assert cheap_essential == full_essential
+
+    def test_instrument_info_exact_strings(self, solarix_d):
+        """FTICRDetector string-matches "FT-ICR"; these are load-bearing."""
+        with SolarixReader(solarix_d) as reader:
+            info = reader.get_comprehensive_metadata().instrument_info
+
+        assert info["instrument_type"] == "FT-ICR"
+        assert info["manufacturer"] == "Bruker"
+        assert info["instrument_model"] == "solariX"
+        assert info["instrument_name"] == "solariX"
+        assert info["instrument_family"] == 513
+        assert info["serial_number"] == "1272500.00145"
+
+    def test_unknown_instrument_family_keeps_raw_number_only(self, tmp_path):
+        d_dir = make_solarix_d(tmp_path, properties={"InstrumentFamily": "999"})
+
+        with SolarixReader(d_dir) as reader:
+            info = reader.get_comprehensive_metadata().instrument_info
+
+        assert info["instrument_type"] == "FT-ICR"
+        assert info["instrument_family"] == 999
+        assert "instrument_model" not in info
+
+    def test_polarity_mapping(self, tmp_path):
+        positive = make_solarix_d(tmp_path, name="pos")
+        negative = make_solarix_d(
+            tmp_path, name="neg", acquisition_keys=[(0, 1, 0, 33, 1)]
+        )
+
+        with SolarixReader(positive) as reader:
+            params = reader.get_comprehensive_metadata().acquisition_params
+            assert params["polarity"] == "positive"
+            assert params["acquisition_key_0_polarity_raw"] == 0
+        with SolarixReader(negative) as reader:
+            params = reader.get_comprehensive_metadata().acquisition_params
+            assert params["polarity"] == "negative"
+
+    def test_mixed_polarity_keys_stay_unnamed(self, tmp_path):
+        d_dir = make_solarix_d(
+            tmp_path, acquisition_keys=[(0, 0, 0, 33, 1), (1, 1, 0, 33, 1)]
+        )
+
+        with SolarixReader(d_dir) as reader:
+            params = reader.get_comprehensive_metadata().acquisition_params
+
+        assert params["polarity"] is None
+        assert params["acquisition_key_0_polarity_raw"] == 0
+        assert params["acquisition_key_1_polarity_raw"] == 1
+
+    def test_acquisition_params_carry_laser_and_raw_enums(self, solarix_d):
+        with SolarixReader(solarix_d) as reader:
+            params = reader.get_comprehensive_metadata().acquisition_params
+
+        assert params["laser_power"] == 14.0
+        assert params["laser_rep_rate"] == 2000.0
+        assert params["num_summations"] == 300
+        assert params["acquisition_key_0_scan_mode_raw"] == 0
+        assert params["acquisition_key_0_acquisition_mode_raw"] == 33
+        assert params["acquisition_key_0_ms_level_raw"] == 1
+
+    def test_format_specific_block(self, solarix_d):
+        with SolarixReader(solarix_d) as reader:
+            fmt = reader.get_comprehensive_metadata().format_specific
+
+        assert fmt["format"] == "Bruker solariX peaks.sqlite"
+        assert fmt["schema_version"] == "1.2"
+        assert fmt["acquisition_software"] == "ftmsControl"
+        assert fmt["raster_x_range"] == [1239, 1240]
+        assert fmt["raster_y_range"] == [166, 167]
+        assert fmt["regions"] == [{"region_number": 0, "n_spectra": 3}]
+
+
+class TestSolarixDecisionTree:
+    """A native solariX .d must land on nearest_neighbor + fticr, no flags.
+
+    Same surface the Ousia wizard reads, mirroring the solarix_fticr imzML
+    fixture test -- the native route and the export route must agree.
+    """
+
+    def test_preview_reports_fticr_and_nearest_neighbor(self, solarix_d):
+        preview = preview_msi(solarix_d)
+
+        assert preview.readable, preview.error
+        assert preview.instrument_type is AxisType.FTICR
+        assert preview.resampling_method is ResamplingMethod.NEAREST_NEIGHBOR
+        assert preview.n_pixels == 3
+        assert preview.grid_dims == (2, 2)
+        assert preview.pixel_size_um == 50.0
+        assert preview.mz_range == (100.53, 1000.0)

--- a/thyra/__main__.py
+++ b/thyra/__main__.py
@@ -12,6 +12,7 @@ import click  # noqa: E402
 
 from thyra import __version__  # noqa: E402
 from thyra.convert import convert_msi  # noqa: E402
+from thyra.core.registry import detect_format  # noqa: E402
 from thyra.utils.logging_config import setup_logging  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -143,14 +144,15 @@ def _validate_input_path(input: Path) -> None:
                 f"found: {ibd_path}"
             )
     elif input.is_dir() and input.suffix.lower() == ".d":
-        if (
-            not (input / "analysis.tsf").exists()
-            and not (input / "analysis.tdf").exists()
-        ):
-            raise click.BadParameter(
-                "Bruker .d directory requires analysis.tsf or "
-                f"analysis.tdf file: {input}"
-            )
+        # Several Bruker formats share the .d extension (timsTOF via
+        # analysis.tsf/.tdf, solariX via peaks.sqlite), so delegate to the
+        # registry's detection rather than duplicating the marker files
+        # here -- its errors also carry the format-specific guidance
+        # (e.g. the imzML-export fallback for a peaks-less solariX .d).
+        try:
+            detect_format(input)
+        except ValueError as e:
+            raise click.BadParameter(str(e)) from e
 
 
 def _validate_output_path(output: Path) -> None:

--- a/thyra/core/registry.py
+++ b/thyra/core/registry.py
@@ -71,25 +71,29 @@ class MSIRegistry:
         """Detect Bruker data format using BrukerFolderStructure.
 
         Uses the unified BrukerFolderStructure to detect whether the path
-        contains timsTOF or Rapiflex data.
+        contains timsTOF, Rapiflex, or solariX data.
 
         Args:
             path: Path to check
 
         Returns:
             Format name ('bruker' for timsTOF, 'rapiflex' for Rapiflex,
-            or empty string if not a Bruker format)
+            'solarix' for solariX, or empty string if not a Bruker format)
         """
         BrukerFolderStructure, BrukerFormat = _get_bruker_folder_structure()
 
         try:
             detected_format = BrukerFolderStructure.detect_format(path)
-            if detected_format == BrukerFormat.TIMSTOF:
-                return "bruker"
-            elif detected_format == BrukerFormat.RAPIFLEX:
-                return "rapiflex"
         except Exception:  # nosec B110 - intentionally ignore detection errors
-            pass  # Format detection failure means this is not a Bruker format
+            # Format detection failure means this is not a Bruker format
+            return ""
+
+        if detected_format == BrukerFormat.TIMSTOF:
+            return "bruker"
+        elif detected_format == BrukerFormat.RAPIFLEX:
+            return "rapiflex"
+        elif detected_format == BrukerFormat.SOLARIX:
+            return "solarix"
 
         return ""
 
@@ -139,6 +143,7 @@ class MSIRegistry:
         Supports:
         - .imzml files (ImzML format)
         - .d directories (Bruker timsTOF)
+        - .d directories (Bruker solariX / MRMS, via peaks.sqlite)
         - Folders with .dat + _poslog.txt (Bruker Rapiflex)
         - .raw directories (Waters MassLynx)
         - .raw files (PHI SmartSoft-TOF ToF-SIMS)
@@ -176,6 +181,15 @@ class MSIRegistry:
         bruker_format = self._detect_bruker_format(input_path)
         if bruker_format:
             return bruker_format
+        BrukerFolderStructure, _ = _get_bruker_folder_structure()
+        if BrukerFolderStructure.is_solarix_without_peaks(input_path):
+            raise ValueError(
+                f"solariX .d directory without peaks.sqlite: {input_path}. "
+                "The acquisition holds raw transients (ser) but no processed "
+                "peak store, which is what Thyra reads. Export the dataset "
+                "as imzML from the Bruker software (DataAnalysis, SCiLS Lab, "
+                "or flexImaging) and convert the imzML file instead."
+            )
         raise ValueError("Bruker .d directory missing analysis " f"files: {input_path}")
 
     def _detect_mzpeak_format(self, input_path: Path) -> str:
@@ -276,6 +290,7 @@ class MSIRegistry:
             ".imzml",
             ".mzpeak (HUPO-PSI, experimental)",
             ".d (timsTOF)",
+            ".d (solariX/MRMS)",
             "folder (Rapiflex)",
             ".raw directory (Waters)",
             ".raw file (PHI SmartSoft-TOF)",
@@ -364,7 +379,8 @@ def detect_format(input_path: Path) -> str:
         input_path: Path to MSI data file or directory
 
     Returns:
-        Format name ('imzml', 'bruker', 'rapiflex', 'waters', or 'phi')
+        Format name ('imzml', 'bruker', 'rapiflex', 'solarix', 'waters',
+        or 'phi')
     """
     return _registry.detect_format(input_path)
 

--- a/thyra/metadata/extractors/__init__.py
+++ b/thyra/metadata/extractors/__init__.py
@@ -32,6 +32,7 @@ from .bruker_extractor import BrukerMetadataExtractor
 from .imzml_extractor import ImzMLMetadataExtractor
 from .mzpeak_extractor import MzPeakMetadataExtractor
 from .phi_extractor import PhiMetadataExtractor
+from .solarix_extractor import SolarixMetadataExtractor
 from .waters_extractor import WatersMetadataExtractor
 
 # Public API
@@ -40,6 +41,7 @@ __all__ = [
     "ImzMLMetadataExtractor",
     "MzPeakMetadataExtractor",
     "PhiMetadataExtractor",
+    "SolarixMetadataExtractor",
     "WatersMetadataExtractor",
 ]
 
@@ -49,6 +51,7 @@ FORMAT_EXTRACTORS = {
     "bruker": BrukerMetadataExtractor,
     "tsf": BrukerMetadataExtractor,
     "tdf": BrukerMetadataExtractor,
+    "solarix": SolarixMetadataExtractor,
     "waters": WatersMetadataExtractor,
     "phi": PhiMetadataExtractor,
     "mzpeak": MzPeakMetadataExtractor,

--- a/thyra/metadata/extractors/solarix_extractor.py
+++ b/thyra/metadata/extractors/solarix_extractor.py
@@ -1,0 +1,178 @@
+# thyra/metadata/extractors/solarix_extractor.py
+"""Metadata extractor for Bruker solariX (FT-ICR / MRMS) peaks.sqlite data.
+
+Reads from the reader's already-loaded Properties/AcquisitionKeys tables and
+SQL aggregates, so no blobs are decoded for metadata extraction.
+"""
+
+import logging
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
+
+from ...core.base_extractor import MetadataExtractor
+from ..types import ComprehensiveMetadata, EssentialMetadata
+
+if TYPE_CHECKING:
+    from ...readers.bruker.solarix.solarix_reader import SolarixReader
+
+logger = logging.getLogger(__name__)
+
+# Properties.InstrumentFamily observed on a solariX (serial 1272500.00145);
+# the mapping is verified against that one instrument only, so the raw
+# family number is always surfaced alongside the derived model name.
+_SOLARIX_INSTRUMENT_FAMILY = 513
+
+# Polarity enum in AcquisitionKeys, verified against a paired
+# positive/negative acquisition of the same sample.
+_POLARITY_NAMES = {0: "positive", 1: "negative"}
+
+
+def _collapse(pair: Tuple[Any, Any]) -> Any:
+    """Collapse a (min, max) aggregate to a scalar when constant."""
+    low, high = pair
+    if low == high:
+        return low
+    return [low, high]
+
+
+class SolarixMetadataExtractor(MetadataExtractor):
+    """solariX-specific metadata extractor.
+
+    Args:
+        reader: The :class:`SolarixReader` to describe.
+    """
+
+    def __init__(self, reader: "SolarixReader"):
+        """Initialise the extractor.
+
+        Args:
+            reader: The :class:`SolarixReader` to describe.
+        """
+        super().__init__(reader)
+        self._reader = reader
+
+    def _extract_essential_impl(self) -> EssentialMetadata:
+        """Extract metadata needed to drive conversion."""
+        reader = self._reader
+        summary = reader.summary
+        n_x, n_y, _ = reader.dimensions
+
+        total_peaks = summary["total_peaks"]
+        return EssentialMetadata(
+            dimensions=reader.dimensions,
+            coordinate_bounds=(0.0, float(n_x - 1), 0.0, float(n_y - 1)),
+            mass_range=reader.mass_range,
+            pixel_size=reader.pixel_size_um,
+            n_spectra=summary["n_spectra"],
+            total_peaks=total_peaks,
+            estimated_memory_gb=(total_peaks * 2 * 8) / (1024**3),
+            source_path=str(reader.data_path),
+            # The absolute stage-raster origin subtracted by iter_spectra;
+            # XIndexPos starts wherever the stage was, not at 0.
+            coordinate_offsets=reader.coordinate_offsets,
+            spectrum_type="centroid spectrum",
+        )
+
+    def _extract_comprehensive_impl(self) -> ComprehensiveMetadata:
+        """Extract full metadata including vendor-specific detail."""
+        return ComprehensiveMetadata(
+            essential=self.get_essential(),
+            format_specific=self._extract_format_specific(),
+            acquisition_params=self._extract_acquisition_params(),
+            instrument_info=self._extract_instrument_info(),
+            raw_metadata=self._extract_raw_metadata(),
+        )
+
+    def _polarity(self) -> Optional[str]:
+        """Polarity name via the verified enum, or None when mixed/unknown.
+
+        Verified against a paired positive/negative acquisition:
+        0 = positive, 1 = negative. Anything else stays unnamed and is
+        available raw in ``acquisition_keys``.
+        """
+        raw_values = {
+            key["polarity_raw"] for key in self._reader.acquisition_keys.values()
+        }
+        if len(raw_values) != 1:
+            return None
+        return _POLARITY_NAMES.get(next(iter(raw_values)))
+
+    def _extract_format_specific(self) -> Dict[str, Any]:
+        reader = self._reader
+        props = reader.properties
+        summary = reader.summary
+        return {
+            "format": "Bruker solariX peaks.sqlite",
+            "schema_type": props.get("SchemaType"),
+            "schema_version": (
+                f"{props.get('SchemaVersionMajor')}."
+                f"{props.get('SchemaVersionMinor')}"
+            ),
+            "acquisition_software": props.get("AcquisitionSoftware"),
+            "acquisition_software_vendor": props.get("AcquisitionSoftwareVendor"),
+            "acquisition_software_version": props.get("AcquisitionSoftwareVersion"),
+            # Absolute stage-raster extents before the 0-based offset.
+            "raster_x_range": [summary["x_min"], summary["x_max"]],
+            "raster_y_range": [summary["y_min"], summary["y_max"]],
+            "pixel_size_source": reader.pixel_size_source,
+            "mis_file": str(reader.mis_path) if reader.mis_path else "",
+            "regions": reader.get_region_info() or [],
+        }
+
+    def _extract_acquisition_params(self) -> Dict[str, Any]:
+        reader = self._reader
+        props = reader.properties
+        stats = reader.get_acquisition_stats()
+        params: Dict[str, Any] = {
+            "polarity": self._polarity(),
+            "mz_acq_range": list(reader.mass_range),
+            "acquisition_datetime": props.get("AcquisitionDateTime"),
+            "operator_name": props.get("OperatorName"),
+            "laser_power": _collapse(stats["laser_power"]),
+            "laser_rep_rate": _collapse(stats["laser_rep_rate"]),
+            "num_summations": _collapse(stats["num_summations"]),
+        }
+        # Raw enum values per acquisition key; the full ScanMode /
+        # AcquisitionMode / MsLevel enums are undocumented, so the numbers
+        # are stored as found rather than labelled.
+        for key_id, key in sorted(reader.acquisition_keys.items()):
+            prefix = f"acquisition_key_{key_id}"
+            params[f"{prefix}_polarity_raw"] = key["polarity_raw"]
+            params[f"{prefix}_scan_mode_raw"] = key["scan_mode_raw"]
+            params[f"{prefix}_acquisition_mode_raw"] = key["acquisition_mode_raw"]
+            params[f"{prefix}_ms_level_raw"] = key["ms_level_raw"]
+        return params
+
+    def _extract_instrument_info(self) -> Dict[str, Any]:
+        props = self._reader.properties
+        family = props.get("InstrumentFamily")
+        try:
+            family_number: Optional[int] = int(family)
+        except (TypeError, ValueError):
+            family_number = None
+
+        info: Dict[str, Any] = {
+            # The exact string FTICRDetector matches on -- routes the data
+            # to nearest-neighbor resampling on the FTICR axis.
+            "instrument_type": "FT-ICR",
+            "manufacturer": props.get("InstrumentVendor") or "Bruker",
+            "serial_number": props.get("InstrumentSerialNumber"),
+            "instrument_family": family_number,
+            "instrument_source_type": props.get("InstrumentSourceType"),
+        }
+        # Family 513 -> solariX is verified against one instrument
+        # (serial 1272500.00145); other families keep the raw number only.
+        if family_number == _SOLARIX_INSTRUMENT_FAMILY:
+            info["instrument_model"] = "solariX"
+            info["instrument_name"] = "solariX"
+        return info
+
+    def _extract_raw_metadata(self) -> Dict[str, Any]:
+        reader = self._reader
+        return {
+            "properties": dict(reader.properties),
+            "acquisition_keys": {
+                str(key_id): dict(key)
+                for key_id, key in reader.acquisition_keys.items()
+            },
+            "mis_metadata": dict(reader.mis_metadata),
+        }

--- a/thyra/readers/__init__.py
+++ b/thyra/readers/__init__.py
@@ -4,12 +4,12 @@
 This package provides reader implementations for different MSI data formats:
 - ImzML: Open format for MSI data
 - mzPeak: HUPO-PSI Parquet-in-ZIP archive (experimental, read-only)
-- Bruker: timsTOF and Rapiflex data
+- Bruker: timsTOF, Rapiflex and solariX data
 - Waters: MassLynx .raw imaging data
 - PHI: SmartSoft-TOF .raw ToF-SIMS data
 
 Reader organization:
-- bruker/: All Bruker formats (timsTOF, Rapiflex)
+- bruker/: All Bruker formats (timsTOF, Rapiflex, solariX)
 - imzml/: ImzML format reader
 - mzpeak/: mzPeak archive reader (pyarrow, lazily imported)
 - waters/: Waters .raw format reader (native DLL via ctypes)

--- a/thyra/readers/bruker/__init__.py
+++ b/thyra/readers/bruker/__init__.py
@@ -3,10 +3,12 @@
 This package provides readers for Bruker MSI data formats:
 - timsTOF: TSF/TDF data via SDK (BrukerReader)
 - Rapiflex: MALDI-TOF data via pure Python (RapiflexReader)
+- solariX: FT-ICR/MRMS peaks.sqlite data via pure Python (SolarixReader)
 
 Organization:
 - timstof/: timsTOF reader and SDK integration
 - rapiflex/: Rapiflex reader (pure Python)
+- solarix/: solariX reader (pure Python)
 
 Common functionality is provided by BrukerBaseMSIReader and
 BrukerFolderStructure for folder analysis.
@@ -23,6 +25,7 @@ from .folder_structure import BrukerFolderInfo, BrukerFolderStructure, BrukerFor
 
 # Import readers from submodules to trigger registration
 from .rapiflex import RapiflexReader
+from .solarix import SolarixReader
 from .timstof.timstof_reader import BrukerReader
 
 __all__ = [
@@ -34,6 +37,7 @@ __all__ = [
     # Readers
     "BrukerReader",
     "RapiflexReader",
+    "SolarixReader",
     # Exceptions
     "BrukerReaderError",
     "DataError",

--- a/thyra/readers/bruker/folder_structure.py
+++ b/thyra/readers/bruker/folder_structure.py
@@ -8,6 +8,7 @@ without requiring any SDK dependencies.
 Supported formats:
 - timsTOF: .d folders containing analysis.tdf or analysis.tsf
 - Rapiflex: Folders with .dat, _poslog.txt, and _info.txt files
+- solariX: .d folders containing peaks.sqlite and ImagingInfo.xml
 """
 
 import logging
@@ -24,6 +25,7 @@ class BrukerFormat(Enum):
 
     TIMSTOF = "timstof"
     RAPIFLEX = "rapiflex"
+    SOLARIX = "solarix"
     UNKNOWN = "unknown"
 
 
@@ -82,6 +84,15 @@ class BrukerFolderStructure:
         "tsf_bin": "analysis.tsf_bin",
     }
 
+    # File patterns for solariX (FT-ICR / MRMS) format. Detection keys on
+    # the processed peak store plus the per-scan index; ``ser`` (the raw
+    # transient block) marks the solariX family but is never read.
+    SOLARIX_PATTERNS = {
+        "peaks": "peaks.sqlite",
+        "imaging_info": "ImagingInfo.xml",
+        "ser": "ser",
+    }
+
     # Common optical image patterns
     OPTICAL_IMAGE_PATTERNS = ["*.tif", "*.tiff", "*.TIF", "*.TIFF"]
 
@@ -137,10 +148,12 @@ class BrukerFolderStructure:
 
     def _detect_format(self) -> Tuple["BrukerFormat", Path]:
         """Detect the Bruker format and return (format, data_path)."""
-        # Check if this is a .d folder (timsTOF)
+        # Check if this is a .d folder (timsTOF or solariX)
         if self.path.suffix.lower() == ".d":
             if self._is_timstof_folder(self.path):
                 return BrukerFormat.TIMSTOF, self.path
+            if self._is_solarix_folder(self.path):
+                return BrukerFormat.SOLARIX, self.path
 
         # Check if this folder contains Rapiflex data
         if self._is_rapiflex_folder(self.path):
@@ -151,6 +164,8 @@ class BrukerFolderStructure:
         for d_folder in d_folders:
             if self._is_timstof_folder(d_folder):
                 return BrukerFormat.TIMSTOF, d_folder
+            if self._is_solarix_folder(d_folder):
+                return BrukerFormat.SOLARIX, d_folder
 
         # Check subfolders for Rapiflex
         for subdir in self.path.iterdir():
@@ -168,6 +183,40 @@ class BrukerFolderStructure:
         has_tsf = (path / self.TIMSTOF_PATTERNS["tsf"]).exists()
 
         return has_tdf or has_tsf
+
+    def _is_solarix_folder(self, path: Path) -> bool:
+        """Check if path is a solariX imaging .d folder.
+
+        Requires BOTH the processed peak store and the per-scan index.
+        FlexImaging pre-scan directories (``fid`` + ``analysis.baf``) carry
+        neither and must fall through to UNKNOWN.
+        """
+        if not path.is_dir():
+            return False
+
+        has_peaks = (path / self.SOLARIX_PATTERNS["peaks"]).exists()
+        has_imaging_info = (path / self.SOLARIX_PATTERNS["imaging_info"]).exists()
+
+        return has_peaks and has_imaging_info
+
+    @classmethod
+    def is_solarix_without_peaks(cls, path: Path) -> bool:
+        """Check if path is a solariX-family .d that lacks processed peaks.
+
+        A ``.d`` holding raw transients (``ser``) and ``ImagingInfo.xml``
+        but no ``peaks.sqlite`` is a solariX acquisition Thyra cannot read
+        natively; callers use this to name the imzML-export fallback instead
+        of reporting a generic detection failure.
+        """
+        path = Path(path)
+        if not path.is_dir():
+            return False
+
+        has_ser = (path / cls.SOLARIX_PATTERNS["ser"]).exists()
+        has_imaging_info = (path / cls.SOLARIX_PATTERNS["imaging_info"]).exists()
+        has_peaks = (path / cls.SOLARIX_PATTERNS["peaks"]).exists()
+
+        return has_ser and has_imaging_info and not has_peaks
 
     def _is_rapiflex_folder(self, path: Path) -> bool:
         """Check if path is a Rapiflex data folder."""
@@ -279,6 +328,17 @@ class BrukerFolderStructure:
                 file_path = data_path / pattern
                 if file_path.exists():
                     metadata[name] = file_path
+
+        elif fmt == BrukerFormat.SOLARIX:
+            # solariX metadata files inside the .d
+            for name, pattern in self.SOLARIX_PATTERNS.items():
+                file_path = data_path / pattern
+                if file_path.exists():
+                    metadata[name] = file_path
+            # Acquisition method (XML) inside the *.m method directory
+            method_files = sorted(data_path.glob("*.m/apexAcquisition.method"))
+            if method_files:
+                metadata["method"] = method_files[0]
 
         return metadata
 

--- a/thyra/readers/bruker/solarix/__init__.py
+++ b/thyra/readers/bruker/solarix/__init__.py
@@ -1,0 +1,9 @@
+"""Bruker solariX (FT-ICR / MRMS) reader package.
+
+Reads the processed ``peaks.sqlite`` store inside a solariX imaging ``.d``
+directory. Pure Python -- no vendor SDK involved.
+"""
+
+from .solarix_reader import SolarixReader
+
+__all__ = ["SolarixReader"]

--- a/thyra/readers/bruker/solarix/solarix_reader.py
+++ b/thyra/readers/bruker/solarix/solarix_reader.py
@@ -1,0 +1,620 @@
+# thyra/readers/bruker/solarix/solarix_reader.py
+"""Bruker solariX (FT-ICR / MRMS) ``.d`` reader via ``peaks.sqlite``.
+
+ftmsControl writes a processed peak store inside every imaging ``.d``:
+``peaks.sqlite`` holds centroided, calibrated per-pixel peak lists together
+with stage-raster coordinates and the instrument identity. This reader
+consumes that store and nothing else -- the raw transient block (``ser``)
+and the proprietary ``.mcf`` containers are never touched, so no vendor
+SDK and no FT processing are involved.
+
+Layout expected::
+
+    sample.d/
+        peaks.sqlite            <- centroided per-pixel peak lists (read)
+        ImagingInfo.xml         <- per-scan index (consistency check only)
+        ser                     <- raw transients (ignored)
+        *.mcf, *.mcf_idx        <- Bruker containers (ignored)
+        *.m/                    <- acquisition method (ignored)
+    sample.mis                  <- flexImaging sequence NEXT TO the .d;
+                                   the only source of the pixel size
+
+The blob encoding was decode-verified on real acquisitions (2018-2024,
+ftmsControl 2.2): ``PeakMzValues`` is little-endian float64 x NumPeaks,
+ascending; ``PeakIntensityValues``/``PeakFwhmValues``/``PeakSnrValues`` are
+little-endian float32 x NumPeaks. ``XIndexPos``/``YIndexPos`` are absolute
+stage-raster indices, so the reader offsets them to 0-based coordinates and
+keeps the originals in the metadata.
+"""
+
+import logging
+import sqlite3
+import xml.etree.ElementTree as ET  # nosec B405 - trusted local instrument files
+from pathlib import Path
+from typing import Any, Dict, Generator, List, Optional, Tuple
+from urllib.parse import quote
+
+import numpy as np
+from numpy.typing import NDArray
+from tqdm import tqdm
+
+from ....core.base_extractor import MetadataExtractor
+from ....core.registry import register_reader
+from ..base_bruker_reader import BrukerBaseMSIReader
+from ..mis_parser import parse_mis_file
+
+logger = logging.getLogger(__name__)
+
+
+@register_reader("solarix")
+class SolarixReader(BrukerBaseMSIReader):
+    """Reader for Bruker solariX imaging ``.d`` directories.
+
+    Pure Python: stdlib ``sqlite3`` plus numpy. The database is opened
+    read-only through a URI so no journal or WAL files are ever created
+    next to it -- solariX data frequently lives on network shares.
+    """
+
+    def __init__(
+        self,
+        data_path: Path,
+        pixel_size_um: Optional[float] = None,
+        metadata_only: bool = False,
+        intensity_threshold: Optional[float] = None,
+        **kwargs: object,
+    ) -> None:
+        """Initialize the solariX reader.
+
+        Args:
+            data_path: Path to the solariX imaging ``.d`` directory.
+            pixel_size_um: Override the pixel size in micrometres. When
+                omitted it is read from the ``<Raster>`` element of the
+                sibling ``.mis`` file; without that file the pixel size is
+                reported as unknown rather than defaulted.
+            metadata_only: If True, skip the eager per-spectrum index load
+                and the ImagingInfo.xml consistency check; essential and
+                comprehensive metadata then come from the ``Properties``
+                table and SQL aggregates alone. Used by ``thyra.preview_msi``
+                to keep the per-sample preview cheap. Spectrum iteration
+                still works in this mode -- the index loads on demand.
+            intensity_threshold: Minimum intensity to retain.
+            **kwargs: Passed to :class:`BrukerBaseMSIReader`.
+        """
+        super().__init__(data_path, intensity_threshold=intensity_threshold, **kwargs)
+
+        self._pixel_size_override = pixel_size_um
+        self._metadata_only = bool(metadata_only)
+        self._closed = False
+
+        self._validate_layout()
+        self._conn = self._open_peaks_db()
+
+        self._properties: Dict[str, Any] = self._load_properties()
+        self._check_schema()
+        self._acquisition_keys: Dict[int, Dict[str, Any]] = (
+            self._load_acquisition_keys()
+        )
+
+        # Per-spectrum index (Id, X, Y, NumPeaks, RegionNumber). Loaded
+        # eagerly for a full open, on demand in metadata-only mode.
+        self._spectra_index: Optional[Dict[str, NDArray]] = None
+        self._summary: Dict[str, int] = {}
+        self._acquisition_stats: Optional[Dict[str, Any]] = None
+        self._common_mass_axis: Optional[NDArray[np.float64]] = None
+
+        # Pixel size from the sibling .mis (flexImaging sequence).
+        self._mis_path: Optional[Path] = self._resolve_mis_path()
+        self._mis_metadata: Dict[str, Any] = (
+            parse_mis_file(self._mis_path) if self._mis_path else {}
+        )
+
+        if self._metadata_only:
+            self._summary = self._load_summary_aggregates()
+        else:
+            self._load_spectra_index()
+            self._check_imaging_info()
+
+        logger.info(
+            "Initialized SolarixReader: %s, %d spectra, raster X %d-%d, " "Y %d-%d%s",
+            self.data_path.name,
+            self._summary["n_spectra"],
+            self._summary["x_min"],
+            self._summary["x_max"],
+            self._summary["y_min"],
+            self._summary["y_max"],
+            " (metadata only)" if self._metadata_only else "",
+        )
+
+    # ------------------------------------------------------------------ setup
+
+    def _validate_layout(self) -> None:
+        """Refuse anything that is not a solariX imaging .d directory."""
+        if not self.data_path.is_dir():
+            raise ValueError(
+                f"solariX format requires a .d directory, got: {self.data_path}"
+            )
+        peaks = self.data_path / "peaks.sqlite"
+        if not peaks.exists():
+            if (self.data_path / "ser").exists() and (
+                self.data_path / "ImagingInfo.xml"
+            ).exists():
+                raise ValueError(
+                    f"solariX .d directory without peaks.sqlite: "
+                    f"{self.data_path}. The acquisition holds raw transients "
+                    "(ser) but no processed peak store, which is what Thyra "
+                    "reads. Export the dataset as imzML from the Bruker "
+                    "software (DataAnalysis, SCiLS Lab, or flexImaging) and "
+                    "convert the imzML file instead."
+                )
+            raise ValueError(
+                f"Not a solariX imaging .d directory (no peaks.sqlite): "
+                f"{self.data_path}"
+            )
+        self._peaks_path = peaks
+
+    def _open_peaks_db(self) -> sqlite3.Connection:
+        """Open peaks.sqlite strictly read-only.
+
+        The URI form with ``mode=ro`` guarantees sqlite never creates
+        journal/WAL side files next to the database, which matters when the
+        data sits on a read-only network share.
+        """
+        uri = f"file:{quote(self._peaks_path.as_posix())}?mode=ro"
+        try:
+            return sqlite3.connect(uri, uri=True)
+        except sqlite3.Error as exc:
+            raise ValueError(
+                f"Cannot open {self._peaks_path} read-only: {exc}"
+            ) from exc
+
+    def _load_properties(self) -> Dict[str, Any]:
+        """Load the Properties key/value table verbatim."""
+        try:
+            rows = self._conn.execute("SELECT Key, Value FROM Properties").fetchall()
+        except sqlite3.Error as exc:
+            raise ValueError(
+                f"peaks.sqlite has no readable Properties table in "
+                f"{self.data_path}: {exc}"
+            ) from exc
+        return {str(key): value for key, value in rows}
+
+    def _check_schema(self) -> None:
+        """Verify the schema this reader was written against.
+
+        All probed acquisitions (2018-2024, ftmsControl 2.2) declare
+        ``SchemaType = Imaging`` with ``SchemaVersionMajor = 1``. Anything
+        else is unverified territory, so fail loudly with the found values
+        rather than decoding blobs on an unknown layout.
+        """
+        schema_type = self._properties.get("SchemaType")
+        major = self._properties.get("SchemaVersionMajor")
+        if str(schema_type) != "Imaging" or str(major) != "1":
+            raise ValueError(
+                f"Unsupported peaks.sqlite schema in {self.data_path}: "
+                f"SchemaType={schema_type!r}, SchemaVersionMajor={major!r} "
+                "(this reader supports SchemaType='Imaging', "
+                "SchemaVersionMajor=1). If this is a newer ftmsControl "
+                "schema, export the dataset as imzML instead and report the "
+                "version so support can be added."
+            )
+
+    def _load_acquisition_keys(self) -> Dict[int, Dict[str, Any]]:
+        """Load AcquisitionKeys rows, keyed by Id.
+
+        ``ScanMode``/``AcquisitionMode``/``MsLevel`` are stored as the raw
+        integers found in the file -- the full enums are not publicly
+        documented, so no labels are invented for them. Only ``Polarity``
+        has a verified mapping (0=positive, 1=negative).
+        """
+        try:
+            rows = self._conn.execute(
+                "SELECT Id, Polarity, ScanMode, AcquisitionMode, MsLevel "
+                "FROM AcquisitionKeys"
+            ).fetchall()
+        except sqlite3.Error as exc:
+            raise ValueError(
+                f"peaks.sqlite has no readable AcquisitionKeys table in "
+                f"{self.data_path}: {exc}"
+            ) from exc
+        return {
+            int(row[0]): {
+                "polarity_raw": row[1],
+                "scan_mode_raw": row[2],
+                "acquisition_mode_raw": row[3],
+                "ms_level_raw": row[4],
+            }
+            for row in rows
+        }
+
+    def _load_summary_aggregates(self) -> Dict[str, int]:
+        """Cheap dataset summary straight from SQL aggregates."""
+        row = self._conn.execute(
+            "SELECT COUNT(*), MIN(XIndexPos), MAX(XIndexPos), "
+            "MIN(YIndexPos), MAX(YIndexPos), SUM(NumPeaks) FROM Spectra"
+        ).fetchone()
+        n_spectra = int(row[0] or 0)
+        if n_spectra == 0:
+            raise ValueError(f"peaks.sqlite holds no spectra in {self.data_path}")
+        return {
+            "n_spectra": n_spectra,
+            "x_min": int(row[1]),
+            "x_max": int(row[2]),
+            "y_min": int(row[3]),
+            "y_max": int(row[4]),
+            "total_peaks": int(row[5] or 0),
+        }
+
+    def _load_spectra_index(self) -> Dict[str, NDArray]:
+        """Load the per-spectrum index (no blobs). Idempotent."""
+        if self._spectra_index is not None:
+            return self._spectra_index
+
+        rows = self._conn.execute(
+            "SELECT Id, XIndexPos, YIndexPos, NumPeaks, "
+            "COALESCE(RegionNumber, 0) FROM Spectra ORDER BY Id"
+        ).fetchall()
+        if not rows:
+            raise ValueError(f"peaks.sqlite holds no spectra in {self.data_path}")
+
+        arr = np.asarray(rows, dtype=np.int64)
+        self._spectra_index = {
+            "id": arr[:, 0],
+            "x": arr[:, 1],
+            "y": arr[:, 2],
+            "num_peaks": arr[:, 3],
+            "region": arr[:, 4],
+        }
+        self._summary = {
+            "n_spectra": int(arr.shape[0]),
+            "x_min": int(arr[:, 1].min()),
+            "x_max": int(arr[:, 1].max()),
+            "y_min": int(arr[:, 2].min()),
+            "y_max": int(arr[:, 2].max()),
+            "total_peaks": int(arr[:, 3].sum()),
+        }
+        return self._spectra_index
+
+    def _check_imaging_info(self) -> None:
+        """Cross-check the scan count against ImagingInfo.xml.
+
+        The per-scan index is an independent record of the acquisition, so
+        a mismatch means the .d was truncated or partially copied. This is
+        a warning rather than an error: the peak store itself is still
+        internally consistent.
+        """
+        info_path = self.data_path / "ImagingInfo.xml"
+        try:
+            root = ET.parse(info_path).getroot()  # nosec B314
+            n_scans = sum(1 for _ in root.iter("scan"))
+        except (ET.ParseError, OSError) as exc:
+            logger.warning("Could not parse %s: %s", info_path, exc)
+            return
+        if n_scans != self._summary["n_spectra"]:
+            logger.warning(
+                "ImagingInfo.xml lists %d scans but peaks.sqlite holds %d "
+                "spectra in %s -- the .d may be truncated or partially copied",
+                n_scans,
+                self._summary["n_spectra"],
+                self.data_path,
+            )
+
+    def _resolve_mis_path(self) -> Optional[Path]:
+        """Locate the flexImaging .mis that belongs to this .d.
+
+        The sequence file sits NEXT TO the .d with the same stem. When the
+        stems do not match, a lone .mis in the parent directory is accepted
+        as unambiguous; multiple non-matching candidates are refused so a
+        wrong region's raster cannot be picked up silently.
+        """
+        parent = self.data_path.parent
+        if not parent.exists():
+            return None
+
+        matching = parent / f"{self.data_path.stem}.mis"
+        if matching.exists():
+            return matching
+
+        candidates = sorted(parent.glob("*.mis"))
+        if len(candidates) == 1:
+            logger.info(
+                "No .mis matching stem '%s'; using the only candidate %s",
+                self.data_path.stem,
+                candidates[0].name,
+            )
+            return candidates[0]
+        if candidates:
+            logger.warning(
+                "No .mis matching stem '%s' and %d non-matching candidates "
+                "in %s -- refusing to guess, pixel size will be unknown",
+                self.data_path.stem,
+                len(candidates),
+                parent,
+            )
+        return None
+
+    # ------------------------------------------------------------- properties
+
+    @property
+    def properties(self) -> Dict[str, Any]:
+        """The peaks.sqlite Properties table, verbatim."""
+        return self._properties
+
+    @property
+    def acquisition_keys(self) -> Dict[int, Dict[str, Any]]:
+        """The AcquisitionKeys rows keyed by Id, raw enum values preserved."""
+        return self._acquisition_keys
+
+    @property
+    def summary(self) -> Dict[str, int]:
+        """Dataset summary: n_spectra, raster extents, total peaks."""
+        return self._summary
+
+    @property
+    def dimensions(self) -> Tuple[int, int, int]:
+        """Grid dimensions ``(x, y, z)`` of the raster bounding box."""
+        s = self._summary
+        return (s["x_max"] - s["x_min"] + 1, s["y_max"] - s["y_min"] + 1, 1)
+
+    @property
+    def coordinate_offsets(self) -> Tuple[int, int, int]:
+        """The absolute stage-raster origin subtracted from coordinates."""
+        return (self._summary["x_min"], self._summary["y_min"], 0)
+
+    @property
+    def mis_path(self) -> Optional[Path]:
+        """Path to the flexImaging .mis used for the pixel size, if any."""
+        return self._mis_path
+
+    @property
+    def mis_metadata(self) -> Dict[str, Any]:
+        """Parsed .mis metadata (raster, areas, teaching points)."""
+        return self._mis_metadata
+
+    @property
+    def pixel_size_um(self) -> Optional[Tuple[float, float]]:
+        """Pixel pitch ``(x_um, y_um)``, or ``None`` when unknown.
+
+        The .d itself does not record the raster pitch anywhere -- the
+        acquisition method was swept for raster/pixel tokens and carries
+        none -- so the only sources are the sibling .mis or the caller.
+        """
+        if self._pixel_size_override is not None:
+            return (float(self._pixel_size_override), float(self._pixel_size_override))
+        raster = self._mis_metadata.get("raster")
+        if raster and len(raster) == 2:
+            return (float(raster[0]), float(raster[1]))
+        return None
+
+    @property
+    def pixel_size_source(self) -> str:
+        """Where :attr:`pixel_size_um` came from, for provenance."""
+        if self._pixel_size_override is not None:
+            return "user override"
+        if self._mis_metadata.get("raster"):
+            return f"flexImaging .mis Raster element ({self._mis_path})"
+        return "unknown (no .mis with a Raster element found next to the .d)"
+
+    @property
+    def mass_range(self) -> Tuple[float, float]:
+        """Acquisition m/z range from the Properties table."""
+        try:
+            return (
+                float(self._properties["MzAcqRangeLower"]),
+                float(self._properties["MzAcqRangeUpper"]),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(
+                f"peaks.sqlite Properties carry no usable MzAcqRangeLower/"
+                f"MzAcqRangeUpper in {self.data_path}: {exc}"
+            ) from exc
+
+    def get_acquisition_stats(self) -> Dict[str, Any]:
+        """Per-spectrum acquisition parameter ranges (one SQL aggregate).
+
+        LaserPower, LaserRepRate and NumSummations are recorded per scan;
+        they are constant within a normal acquisition, so min == max is the
+        expected case and the pair collapses to a scalar downstream.
+        """
+        if self._acquisition_stats is None:
+            row = self._conn.execute(
+                "SELECT MIN(LaserPower), MAX(LaserPower), "
+                "MIN(LaserRepRate), MAX(LaserRepRate), "
+                "MIN(NumSummations), MAX(NumSummations), "
+                "MIN(NumPeaks), MAX(NumPeaks) FROM Spectra"
+            ).fetchone()
+            self._acquisition_stats = {
+                "laser_power": (row[0], row[1]),
+                "laser_rep_rate": (row[2], row[3]),
+                "num_summations": (row[4], row[5]),
+                "num_peaks": (row[6], row[7]),
+            }
+        return self._acquisition_stats
+
+    # --------------------------------------------------------- reader interface
+
+    def _create_metadata_extractor(self) -> MetadataExtractor:
+        """Create the solariX metadata extractor."""
+        from ....metadata.extractors.solarix_extractor import SolarixMetadataExtractor
+
+        return SolarixMetadataExtractor(self)
+
+    @property
+    def has_shared_mass_axis(self) -> bool:
+        """Centroided per-pixel peak lists: every spectrum differs."""
+        return False
+
+    def get_common_mass_axis(self) -> NDArray[np.float64]:
+        """Union of every spectrum's m/z values, sorted and deduplicated.
+
+        Only the no-resampling path consumes this; with resampling enabled
+        the FT-ICR axis generator builds the axis from the mass range
+        instead.
+        """
+        if self._common_mass_axis is None:
+            chunks: List[NDArray[np.float64]] = []
+            cursor = self._conn.execute(
+                "SELECT Id, NumPeaks, PeakMzValues FROM Spectra ORDER BY Id"
+            )
+            for spectrum_id, num_peaks, mz_blob in cursor:
+                mzs = self._decode_blob(
+                    spectrum_id, "PeakMzValues", mz_blob, int(num_peaks), np.float64
+                )
+                if mzs.size:
+                    chunks.append(mzs)
+            if not chunks:
+                raise ValueError(
+                    f"Cannot build a mass axis: no peaks in {self.data_path}"
+                )
+            self._common_mass_axis = np.unique(np.concatenate(chunks))
+        return self._common_mass_axis
+
+    def _decode_blob(
+        self,
+        spectrum_id: int,
+        column: str,
+        blob: Optional[bytes],
+        num_peaks: int,
+        dtype: type,
+    ) -> NDArray:
+        """Decode one little-endian peak blob, refusing silent truncation.
+
+        The blob length must equal ``NumPeaks * itemsize`` exactly; a
+        mismatch means the database is corrupt or the layout drifted, and
+        decoding a truncated read would fabricate a spectrum.
+        """
+        if num_peaks == 0:
+            return np.array([], dtype=dtype)
+        itemsize = np.dtype(dtype).itemsize
+        expected = num_peaks * itemsize
+        actual = len(blob) if blob is not None else 0
+        if actual != expected:
+            raise ValueError(
+                f"Corrupt {column} blob in Spectra row Id={spectrum_id} of "
+                f"{self._peaks_path}: NumPeaks={num_peaks} implies "
+                f"{expected} bytes, found {actual}"
+            )
+        return np.frombuffer(blob, dtype=np.dtype(dtype).newbyteorder("<")).astype(
+            dtype, copy=True
+        )
+
+    def iter_spectra(self, batch_size: Optional[int] = None) -> Generator[
+        Tuple[Tuple[int, int, int], NDArray[np.float64], NDArray[np.float64]],
+        None,
+        None,
+    ]:
+        """Iterate spectra in acquisition order.
+
+        Args:
+            batch_size: Ignored; present for interface compatibility.
+
+        Yields:
+            ``((x, y, z), mzs, intensities)`` with 0-based coordinates
+            (the absolute stage-raster origin is subtracted), float64 m/z
+            and float64 intensities.
+        """
+        if self._closed:
+            raise RuntimeError("Reader has been closed")
+
+        x_min, y_min, _ = self.coordinate_offsets
+        cursor = self._conn.execute(
+            "SELECT Id, XIndexPos, YIndexPos, NumPeaks, PeakMzValues, "
+            "PeakIntensityValues FROM Spectra ORDER BY Id"
+        )
+
+        pbar = tqdm(
+            cursor,
+            desc="Reading solariX spectra",
+            unit=" spectra",
+            total=self._summary["n_spectra"],
+            dynamic_ncols=True,
+        )
+        try:
+            for spectrum_id, x, y, num_peaks, mz_blob, intensity_blob in pbar:
+                num_peaks = int(num_peaks)
+                if num_peaks == 0:
+                    continue
+                mzs = self._decode_blob(
+                    spectrum_id, "PeakMzValues", mz_blob, num_peaks, np.float64
+                )
+                intensities = self._decode_blob(
+                    spectrum_id,
+                    "PeakIntensityValues",
+                    intensity_blob,
+                    num_peaks,
+                    np.float32,
+                ).astype(np.float64)
+
+                # Stored ascending in every probed file; downstream mapping
+                # assumes sorted m/z, so restore the invariant if a file
+                # ever violates it rather than mapping garbage.
+                if mzs.size > 1 and np.any(np.diff(mzs) < 0):
+                    logger.warning(
+                        "Unsorted PeakMzValues in Spectra row Id=%d; sorting",
+                        spectrum_id,
+                    )
+                    order = np.argsort(mzs, kind="stable")
+                    mzs = mzs[order]
+                    intensities = intensities[order]
+
+                mzs, intensities = self._apply_intensity_filter(mzs, intensities)
+                if mzs.size == 0:
+                    continue
+
+                yield (int(x - x_min), int(y - y_min), 0), mzs, intensities
+        finally:
+            pbar.close()
+
+    def get_peak_counts_per_pixel(self) -> Optional[NDArray[np.int32]]:
+        """Per-pixel peak counts from the NumPeaks column, no blob decode."""
+        index = self._load_spectra_index()
+        n_x, n_y, _ = self.dimensions
+        x_min, y_min, _ = self.coordinate_offsets
+
+        counts = np.zeros(n_x * n_y, dtype=np.int32)
+        pixel_idx = (index["y"] - y_min) * n_x + (index["x"] - x_min)
+        counts[pixel_idx] = index["num_peaks"]
+        return counts
+
+    def get_region_map(self) -> Optional[dict]:
+        """Map 0-based ``(x, y)`` to the RegionNumber recorded per scan."""
+        index = self._load_spectra_index()
+        x_min, y_min, _ = self.coordinate_offsets
+        return {
+            (int(x - x_min), int(y - y_min)): int(region)
+            for x, y, region in zip(index["x"], index["y"], index["region"])
+        }
+
+    def get_region_info(self) -> Optional[list]:
+        """Summary of acquisition regions found in the Spectra table.
+
+        A plain SQL aggregate rather than the spectra index, so the
+        metadata-only preview path stays cheap.
+        """
+        rows = self._conn.execute(
+            "SELECT COALESCE(RegionNumber, 0) AS region, COUNT(*) "
+            "FROM Spectra GROUP BY region ORDER BY region"
+        ).fetchall()
+        return [
+            {"region_number": int(region), "n_spectra": int(count)}
+            for region, count in rows
+        ]
+
+    def close(self) -> None:
+        """Close the database connection and drop caches."""
+        if self._closed:
+            return
+        try:
+            self._conn.close()
+        except sqlite3.Error:  # pragma: no cover - best effort
+            pass
+        self._spectra_index = None
+        self._common_mass_axis = None
+        self._closed = True
+        logger.debug("SolarixReader closed")
+
+    def __repr__(self) -> str:
+        """Return a string representation of the reader."""
+        return (
+            f"SolarixReader(path={self.data_path}, "
+            f"n_spectra={self._summary.get('n_spectra', '?')})"
+        )


### PR DESCRIPTION
Closes the gap where a Bruker solariX / MRMS (FT-ICR) imaging `.d` directory was rejected with `Bruker .d directory missing analysis files`, forcing a manual vendor-software imzML export per dataset.

## What this does

ftmsControl writes a processed peak store into every imaging `.d`: `peaks.sqlite`, holding centroided, calibrated per-pixel peak lists plus stage-raster coordinates and the instrument identity. This PR adds a reader that consumes that store directly -- stdlib `sqlite3` + numpy, no vendor SDK, no FT processing. The raw transient block (`ser`) and the `.mcf` containers are never touched.

- **Detection**: `BrukerFormat.SOLARIX` on `peaks.sqlite` + `ImagingInfo.xml`. FlexImaging pre-scan `.d` dirs (`fid` + `analysis.baf`) still fall through to the existing error; a solariX-family `.d` without `peaks.sqlite` now gets an explicit error naming the imzML-export fallback.
- **Reader**: database opened strictly read-only via URI (no journal/WAL side files on network shares); schema check (`Imaging`, major 1) refuses unknown layouts quoting the found values; every blob length is verified against `NumPeaks` before decoding; absolute stage-raster indices are offset to 0-based with the origin kept in metadata; sparse rasters and zero-peak scans handled; `metadata_only` fast path keeps previews on SQL aggregates alone.
- **Extractor**: stamps `instrument_type = FT-ICR`, so the resampling decision tree resolves `nearest_neighbor` + `fticr` with no flags -- the same pair a vendor imzML export of the same data reaches. Polarity via the verified `0=positive / 1=negative` enum; the undocumented `ScanMode`/`AcquisitionMode`/`MsLevel` enums are stored raw. `InstrumentFamily 513` maps to the model name `solariX`. Laser power, rep rate, summations, software identity, serial and schema version are carried into the store.
- **Pixel size**: from the sibling flexImaging `.mis` `<Raster>` element (stem match, lone-candidate fallback, ambiguity refused). Without it the conversion asks for `--pixel-size` instead of guessing.
- **CLI**: the `.d` pre-validation now delegates to registry detection instead of hard-coding the timsTOF marker files (it used to reject solariX before `convert_msi` ever ran).
- **Tests**: 39 new tests building synthetic `.d` fixtures in-test (no binary data committed). Docs: new `docs/solarix-notes.md` format page plus supported-formats, resampling and README rows.

## Verification

Read-only against real acquisitions spanning three vintages (2019, 2022, 2024; ftmsControl 2.2): pixel counts, raster extents, blob decode, pixel size from `.mis`, and per-pixel peak-intensity sums matching the per-scan TIC values in `ImagingInfo.xml` at ratio 0.9999. A real pre-scan `.d` is still rejected with the existing message. CLI end-to-end resolves FT-ICR -> `nearest_neighbor` + `fticr` with no flags.

**Cross-validation against a vendor imzML export of the same acquisition** (SCiLS-lineage centroid ROI crop, 949 of 7,362 pixels; registered onto the raster by TIC cross-correlation over all four axis orientations):

- Identity orientation, pure translation -- no axis flips; every ROI pixel lands on a measured pixel.
- Identical per-pixel peak counts on all 949 overlapping pixels: the export carries the same picked peaks this reader decodes.
- Intensities equal up to the export's RMS normalization (per-pixel ratio constant to the last float32 digit; factor x RMS = one dataset-wide constant). Dividing it out reproduces the native TICs to a max relative error of 2e-7; TIC correlation r = 1.000000.
- m/z zero-mean to 0.00 ppm in every 200 Da band; individual deviations grow quadratically with m/z up to ~4 mDa -- the exporter snapping centroids to its own profile-grid axis, documented in `docs/solarix-notes.md`.