### PR TITLE
fix(solarix): open peaks.sqlite on UNC paths

### DIFF
--- a/docs/solarix-notes.md
+++ b/docs/solarix-notes.md
@@ -91,7 +91,13 @@ derived from them.
 
 The database is opened strictly read-only through a URI (`mode=ro`), so
 sqlite never creates journal or WAL side files next to it. That matters
-because solariX data commonly lives on read-only network shares.
+because solariX data commonly lives on read-only network shares. One
+consequence of that: a mapped network drive resolves to a UNC path
+(`\\server\share\...`) before the reader sees it, and in a `file:` URI the
+server name would read as an authority, which sqlite rejects. The reader
+therefore writes such paths as `file:////server/share/...` -- empty
+authority, path intact -- which opens where `file://server/share/...`
+does not.
 
 ## Coordinates and sparsity
 

--- a/tests/unit/readers/test_solarix_reader.py
+++ b/tests/unit/readers/test_solarix_reader.py
@@ -7,6 +7,7 @@ a peaks.sqlite with hand-packed blobs plus ImagingInfo.xml and a sibling
 
 import logging
 import sqlite3
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -14,6 +15,7 @@ import pytest
 from thyra.core.registry import detect_format, get_reader_class
 from thyra.preview import preview_msi
 from thyra.readers.bruker import BrukerFolderStructure, BrukerFormat, SolarixReader
+from thyra.readers.bruker.solarix.solarix_reader import _read_only_uri
 from thyra.resampling.types import AxisType, ResamplingMethod
 
 # Properties as found in a real acquisition (ftmsControl 2.2, schema
@@ -567,3 +569,33 @@ class TestSolarixDecisionTree:
         assert preview.grid_dims == (2, 2)
         assert preview.pixel_size_um == 50.0
         assert preview.mz_range == (100.53, 1000.0)
+
+
+class TestSolarixReadOnlyUri:
+    """The URI builder behind ``_open_peaks_db``."""
+
+    def test_unc_path_keeps_the_authority_empty(self):
+        # What a mapped network drive resolves to on Windows. With a single
+        # pair of slashes sqlite reads "server" as a URI authority and
+        # refuses the open.
+        uri = _read_only_uri(Path("//server/share/run.d/peaks.sqlite"))
+        assert uri == "file:////server/share/run.d/peaks.sqlite?mode=ro"
+
+    def test_drive_and_posix_paths_are_untouched(self):
+        assert (
+            _read_only_uri(Path("C:/data/run.d/peaks.sqlite"))
+            == "file:C%3A/data/run.d/peaks.sqlite?mode=ro"
+        )
+        assert (
+            _read_only_uri(Path("/data/run.d/peaks.sqlite"))
+            == "file:/data/run.d/peaks.sqlite?mode=ro"
+        )
+
+    def test_built_uri_opens_the_store_read_only(self, solarix_d):
+        conn = sqlite3.connect(_read_only_uri(solarix_d / "peaks.sqlite"), uri=True)
+        try:
+            assert conn.execute("SELECT COUNT(*) FROM Spectra").fetchone()[0] == 3
+            with pytest.raises(sqlite3.OperationalError, match="readonly"):
+                conn.execute("DELETE FROM Spectra")
+        finally:
+            conn.close()

--- a/thyra/readers/bruker/solarix/solarix_reader.py
+++ b/thyra/readers/bruker/solarix/solarix_reader.py
@@ -46,6 +46,23 @@ from ..mis_parser import parse_mis_file
 logger = logging.getLogger(__name__)
 
 
+def _read_only_uri(path: Path) -> str:
+    """The sqlite URI that opens ``path`` strictly read-only.
+
+    A UNC path -- which is what a mapped network drive resolves to on
+    Windows -- starts with ``//server/share``; inside a ``file:`` URI that
+    reads as an authority, which sqlite rejects ("invalid uri authority").
+    Doubling the leading slashes leaves the authority empty and the path
+    intact, so ``file:////server/share/...`` opens where
+    ``file://server/share/...`` does not. Drive-letter and POSIX paths
+    are unaffected.
+    """
+    posix = path.as_posix()
+    if posix.startswith("//"):
+        posix = "//" + posix
+    return f"file:{quote(posix)}?mode=ro"
+
+
 @register_reader("solarix")
 class SolarixReader(BrukerBaseMSIReader):
     """Reader for Bruker solariX imaging ``.d`` directories.
@@ -159,7 +176,7 @@ class SolarixReader(BrukerBaseMSIReader):
         journal/WAL side files next to the database, which matters when the
         data sits on a read-only network share.
         """
-        uri = f"file:{quote(self._peaks_path.as_posix())}?mode=ro"
+        uri = _read_only_uri(self._peaks_path)
         try:
             return sqlite3.connect(uri, uri=True)
         except sqlite3.Error as exc:


### PR DESCRIPTION
# Pull Request

## Description
Conversions of solariX `.d` acquisitions from a mapped network drive failed at open time with `invalid uri authority`. The CLI resolves the input path, which turns a mapped drive into its UNC form (`\server\share\...`); the reader then quoted `//server/share/...` straight into the `file:` URI it uses for `mode=ro`, and sqlite parsed the server name as a URI authority (only empty or `localhost` is accepted). This doubles the leading slashes for UNC paths (`file:////server/share/...`), which leaves the authority empty and the path intact. Drive-letter and POSIX paths are unchanged.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvement
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues
None filed; found while converting a 50-acquisition study that lives on a mapped share. The reader notes already state that solariX data commonly sits on network shares, which is exactly the case that failed.

## Changes Made
- `thyra/readers/bruker/solarix/solarix_reader.py`: the URI construction moves out of `_open_peaks_db` into a module helper `_read_only_uri(path)`, which prefixes an extra `//` when the POSIX form of the path starts with `//`.
- `tests/unit/readers/test_solarix_reader.py`: three tests on the helper -- the UNC form, drive-letter and POSIX paths untouched, and the synthetic fixture store opening through the helper with a write refused.
- `docs/solarix-notes.md`: one paragraph in the `peaks.sqlite` section explaining why UNC paths are written this way.

## Testing
- [x] All existing tests pass (`tests/unit/readers/test_solarix_reader.py`: 42 passed; pre-commit hooks including mypy, flake8, bandit and pydocstyle passed at commit)
- [x] New tests have been added to cover the changes
- [x] Manual testing has been performed (a real acquisition opened through the resolved UNC path: 7,362 spectra readable, `DELETE` refused with "attempt to write a readonly database"; two whole-sample conversions from the share completed)
- [ ] Integration tests pass (if applicable) -- not run; no integration fixture exercises a network path

## Code Quality
- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Code is well-commented, particularly in hard-to-understand areas
- [x] No new warnings or errors introduced

## Documentation
- [x] Documentation has been updated (if applicable)
- [x] Docstrings have been added/updated for new functions
- [ ] CHANGELOG.md has been updated (if applicable) -- not touched in this PR

## Performance Impact
- [x] No performance impact
- [ ] Performance improvement (describe below)
- [ ] Potential performance regression (describe below)

## Additional Notes
Passing the drive-letter path to sqlite instead would also open, but only as long as nothing upstream resolves the path; the four-slash form works whichever spelling reaches the reader. The failure was invisible to the existing tests because their fixtures live in temporary directories and the reader's own validation ran on local disks.
