### PR TITLE
fix(metadata): read stores through an extended-length path on Windows

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -231,10 +231,21 @@ extended-length (`\\?\`) path, which is exempt from the 260-character limit, so
 long output paths convert normally. A log line records when this happens.
 
 !!! note "Reading a store at a long path"
-    The store is written correctly, but *other* tools still face the same limit
-    when reading it. Either enable long path support system-wide
+    The store is written correctly, but reading it is subject to the same
+    limit, and a read past it does not fail: Windows reports the deep files as
+    missing and Zarr returns its fill value for a missing chunk by design.
+    `spatialdata.read_zarr` then reports a structurally invalid store, and a
+    bare `zarr.open_group` hands back empty metadata (every ontology term as
+    `{"accession": "", "name": ""}`) without any error.
+
+    `thyra validate`, `thyra export-metaspace` and
+    `thyra.metadata.schema.read_msi_metadata_blocks` detect this and read
+    through an extended-length path on their own. For *other* tools either
+    enable long path support system-wide
     (`HKLM\SYSTEM\CurrentControlSet\Control\FileSystem`, `LongPathsEnabled` = 1;
-    needs administrator rights and a reboot), pass the `\\?\` prefix yourself:
+    needs administrator rights and a reboot), pass the store through
+    `thyra.utils.windows_paths.prepare_zarr_read_path` or add the `\\?\`
+    prefix yourself:
     ```python
     import spatialdata as sd
     sdata = sd.read_zarr(r"\\?\C:\very\long\path\output.zarr")

--- a/docs/metadata-schema.md
+++ b/docs/metadata-schema.md
@@ -286,6 +286,12 @@ the [var column contract](#var-column-conventions) and that every table
 carries a metadata block. Exit status is `0` when every document
 conforms (warnings allowed) and `1` otherwise, so it can gate CI.
 
+On Windows, a store whose files sit past the 260-character path limit is
+read through an extended-length path automatically; without that, Zarr
+would return empty terms for the keys it cannot open and the document
+would fail validation for the wrong reason (see
+[long output paths](getting-started.md#windows-long-output-paths)).
+
 Errors mean the document does not conform: structural violations, unknown
 PSI-MS/IMS/UO accessions, version incompatibility. Warnings mean it
 conforms but says something suspicious: a term label that does not match

--- a/tests/unit/metadata/schema/test_store_long_path.py
+++ b/tests/unit/metadata/schema/test_store_long_path.py
@@ -1,0 +1,141 @@
+"""A store under a deep path must read back exactly, not as fill values.
+
+Windows caps a normal path at 260 characters and the limit applies to every
+key inside the store. Past it, Windows reports a key as missing and Zarr
+returns the array's fill value instead of raising, so a metadata block read
+from a plain path came back with every ontology term as
+``{"accession": "", "name": ""}`` and ``thyra validate`` blamed the document.
+Reproduced on 2026-09-05 with a TDF conversion into a 178-character scratch
+directory. The mobility fixture writes Thyra's deepest key
+(``..._mobility/uns/msi_metadata/ms_analysis/ion_mobility/...``), which is
+the one that broke.
+
+The deep path is built by hand rather than under ``tmp_path`` because the
+store has to be removed through an extended-length path afterwards, and
+pytest's own cleanup would trip the same limit. Off Windows the path is
+simply deep and the test is a plain round trip.
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+spatialdata = pytest.importorskip("spatialdata")
+
+from thyra.convert import convert_msi  # noqa: E402
+from thyra.metadata.schema import (  # noqa: E402
+    check_store_var_conventions,
+    read_msi_metadata_blocks,
+)
+from thyra.metadata.schema.cli import validate_command  # noqa: E402
+from thyra.utils.windows_paths import (  # noqa: E402
+    WINDOWS_MAX_PATH,
+    to_extended_length_path,
+)
+
+FIXTURE = (
+    Path(__file__).resolve().parents[3]
+    / "data"
+    / "fixtures"
+    / "mobility_continuous.imzML"
+)
+
+#: Long enough for the deepest metadata key, about 100 characters below the
+#: store root, to land well past the limit.
+DEEP_ROOT_LENGTH = 180
+
+
+def _walkable(path: Path) -> Path:
+    """The spelling under which every key of a deep store is reachable."""
+    return to_extended_length_path(path) if sys.platform == "win32" else path
+
+
+def _longest_key(store: Path) -> int:
+    """Longest key in the store as a plain path would spell it."""
+    root = _walkable(store)
+    prefix = len(str(root)) - len(str(store))
+    return max(
+        len(parent) + 1 + len(name) - prefix
+        for parent, _dirs, files in os.walk(root)
+        for name in files
+    )
+
+
+@pytest.fixture(scope="module")
+def stores():
+    """The same store twice: converted at a deep path, then copied short."""
+    base = Path(tempfile.mkdtemp(prefix="thyra_deep_"))
+    try:
+        deep_dir = base
+        while len(str(deep_dir)) < DEEP_ROOT_LENGTH:
+            deep_dir = deep_dir / "nested_directory_segment"
+            deep_dir.mkdir()
+        deep = deep_dir / "x.zarr"
+        assert convert_msi(
+            str(FIXTURE), str(deep), dataset_id="mob", pixel_size_um=10.0
+        ), "conversion reported failure"
+        assert _longest_key(deep) > WINDOWS_MAX_PATH, "path is not deep enough"
+
+        short = base / "short.zarr"
+        shutil.copytree(_walkable(deep), short)
+        yield deep, short
+    finally:
+        shutil.rmtree(_walkable(base), ignore_errors=True)
+
+
+class TestDeepStoreReadsBack:
+    def test_metadata_block_is_identical_to_the_short_copy(self, stores):
+        deep, short = stores
+
+        deep_blocks = read_msi_metadata_blocks(deep)
+
+        assert set(deep_blocks) == {"mob_z0", "mob_z0_mobility"}
+        assert deep_blocks == read_msi_metadata_blocks(short)
+
+    def test_the_deepest_terms_are_not_fill_values(self, stores):
+        """The exact symptom: the ion mobility terms read back empty."""
+        deep, _ = stores
+
+        block = read_msi_metadata_blocks(deep)["mob_z0_mobility"]
+        mobility = block["ms_analysis"]["ion_mobility"]
+
+        assert mobility["unit_term"]["accession"].startswith("MS:")
+        assert mobility["separation_term"]["accession"].startswith("MS:")
+
+    def test_processing_history_survives(self, stores):
+        """The processing JSON must come back parsed, not left as a string."""
+        deep, _ = stores
+
+        for block in read_msi_metadata_blocks(deep).values():
+            assert isinstance(block["processing"], list)
+            assert block["processing"][0]["name"] == "conversion"
+
+    def test_var_conventions_agree_with_the_short_copy(self, stores):
+        deep, short = stores
+
+        issues = check_store_var_conventions(deep)
+
+        assert issues == check_store_var_conventions(short)
+        assert all(not table_issues for table_issues in issues.values())
+
+    def test_validate_command_passes(self, stores):
+        deep, _ = stores
+
+        result = CliRunner().invoke(validate_command, [str(deep)])
+
+        assert result.exit_code == 0, result.output
+        assert "FAILED" not in result.output
+
+    def test_validate_command_accepts_a_relative_path(self, stores, monkeypatch):
+        """The length that matters is the absolute one, whatever was typed."""
+        deep, _ = stores
+        monkeypatch.chdir(deep.parent)
+
+        result = CliRunner().invoke(validate_command, [deep.name])
+
+        assert result.exit_code == 0, result.output

--- a/tests/unit/utils/test_windows_paths.py
+++ b/tests/unit/utils/test_windows_paths.py
@@ -42,18 +42,25 @@ class TestPrepareZarrReadPath:
         monkeypatch.setattr(windows_paths, "_long_paths_enabled", lambda: False)
 
     @staticmethod
-    def _store_with_key_length(monkeypatch, total: int) -> Path:
+    def _store_with_key_length(monkeypatch, total: int, walked=None) -> Path:
         """A store whose longest key is ``total`` characters.
 
         The walk is faked rather than written to disk: creating a key past
         the limit is exactly the thing that needs the prefix, so a real file
-        cannot be used to test the code that decides to apply it.
+        cannot be used to test the code that decides to apply it. The fake
+        is handed the extended path and sizes its one key so that the plain
+        spelling measures ``total``; ``walked`` collects the paths it saw.
         """
         store = Path("C:\\stores\\store.zarr")
-        name = "k" * max(1, total - len(str(store)) - 1)
-        monkeypatch.setattr(
-            windows_paths.os, "walk", lambda p: [(str(store), [], [name])]
-        )
+
+        def walk(path):
+            root = str(path)
+            if walked is not None:
+                walked.append(root)
+            plain_root_length = len(root) - len(EXTENDED_PREFIX)
+            return [(root, [], ["k" * max(1, total - plain_root_length - 1)])]
+
+        monkeypatch.setattr(windows_paths.os, "walk", walk)
         return store
 
     def test_shallow_store_is_untouched(self, on_windows, monkeypatch):
@@ -68,6 +75,49 @@ class TestPrepareZarrReadPath:
 
         assert str(result).startswith(EXTENDED_PREFIX)
         assert str(result).endswith(str(store))
+
+    def test_key_at_the_limit_is_untouched(self, on_windows, monkeypatch):
+        store = self._store_with_key_length(monkeypatch, WINDOWS_MAX_PATH)
+
+        assert prepare_zarr_read_path(store) == store
+
+    def test_key_one_past_the_limit_is_extended(self, on_windows, monkeypatch):
+        """The prefix on the walked path must not be counted as key length."""
+        store = self._store_with_key_length(monkeypatch, WINDOWS_MAX_PATH + 1)
+
+        assert str(prepare_zarr_read_path(store)).startswith(EXTENDED_PREFIX)
+
+    def test_the_walk_goes_through_the_extended_path(self, on_windows, monkeypatch):
+        """A plain walk cannot list a directory past the limit and skips it
+        silently, so it would miss exactly the keys being measured."""
+        walked: list[str] = []
+        store = self._store_with_key_length(monkeypatch, 120, walked)
+
+        prepare_zarr_read_path(store)
+
+        assert walked and all(p.startswith(EXTENDED_PREFIX) for p in walked)
+
+    def test_relative_path_is_resolved_before_extending(self, on_windows, monkeypatch):
+        """The length that matters is the absolute one, and the prefix is
+        only valid on an absolute path."""
+        self._store_with_key_length(monkeypatch, WINDOWS_MAX_PATH + 20)
+
+        result = prepare_zarr_read_path(Path("store.zarr"))
+
+        text = str(result)
+        assert text.startswith(EXTENDED_PREFIX)
+        assert Path(text[len(EXTENDED_PREFIX) :]).is_absolute()
+
+    def test_already_extended_path_is_returned_without_walking(
+        self, on_windows, monkeypatch
+    ):
+        def refuse(path):
+            raise AssertionError(f"walked {path}")
+
+        monkeypatch.setattr(windows_paths.os, "walk", refuse)
+        store = Path(EXTENDED_PREFIX + "C:\\stores\\store.zarr")
+
+        assert prepare_zarr_read_path(store) == store
 
     def test_no_op_off_windows(self, monkeypatch):
         store = self._store_with_key_length(monkeypatch, WINDOWS_MAX_PATH + 20)

--- a/thyra/metadata/schema/store_io.py
+++ b/thyra/metadata/schema/store_io.py
@@ -11,6 +11,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, Union
 
+from ...utils.windows_paths import prepare_zarr_read_path
 from .models import MSI_METADATA_UNS_KEY
 
 logger = logging.getLogger(__name__)
@@ -34,7 +35,10 @@ def read_msi_metadata_blocks(store_path: Union[str, Path]) -> Dict[str, Dict[str
     import anndata as ad
     import zarr
 
-    root = zarr.open_group(str(store_path), mode="r")
+    # A store under a long Windows path reads back wrong rather than
+    # failing: zarr hands out fill values for the keys it cannot open, so
+    # every ontology term would come back as {"accession": "", "name": ""}.
+    root = zarr.open_group(str(prepare_zarr_read_path(Path(store_path))), mode="r")
     if "tables" not in root:
         raise ValueError(
             f"{store_path} does not look like a SpatialData store: "
@@ -59,7 +63,21 @@ def read_msi_metadata_blocks(store_path: Union[str, Path]) -> Dict[str, Dict[str
             try:
                 block["processing"] = json.loads(block["processing"])
             except json.JSONDecodeError:
-                logger.warning("Table %s has an unparseable processing section", name)
+                if block["processing"] == "":
+                    # Converters write at least "[]". An empty string is the
+                    # fill value of a string array: the chunk exists but
+                    # could not be read, which on Windows means a key past
+                    # the path limit (see thyra.utils.windows_paths).
+                    logger.warning(
+                        "Table %s has an empty processing section, which no "
+                        "converter writes; the store's deep keys may be "
+                        "unreadable at this path",
+                        name,
+                    )
+                else:
+                    logger.warning(
+                        "Table %s has an unparseable processing section", name
+                    )
         blocks[name] = block
 
     return blocks

--- a/thyra/metadata/schema/validate.py
+++ b/thyra/metadata/schema/validate.py
@@ -23,6 +23,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from pydantic import ValidationError
 
+from ...utils.windows_paths import prepare_zarr_read_path
 from ..ontology.cache import ONTOLOGY
 from .models import (
     MSI_METADATA_SCHEMA_VERSION,
@@ -252,7 +253,9 @@ def check_store_var_conventions(
     import numpy as np
     import zarr
 
-    root = zarr.open_group(str(store_path), mode="r")
+    # Same routing as read_msi_metadata_blocks: past the Windows path limit
+    # zarr returns fill values instead of failing.
+    root = zarr.open_group(str(prepare_zarr_read_path(Path(store_path))), mode="r")
     if "tables" not in root:
         raise ValueError(
             f"{store_path} does not look like a SpatialData store: "

--- a/thyra/utils/windows_paths.py
+++ b/thyra/utils/windows_paths.py
@@ -27,9 +27,14 @@ otherwise, so ordinary paths are handled exactly as before. It is not
 applied to the *source data* path: readers reach vendor SDKs that may not
 accept extended-length syntax.
 
-Reading a converted store back is subject to the same limit, and a store
-whose keys sit past it looks structurally invalid rather than merely
-unreachable -- see :func:`prepare_zarr_read_path`.
+Reading a converted store back is subject to the same limit, and a read
+past it does not fail. Windows reports an over-long key as missing, and
+Zarr treats a missing key as one that was never written: a whole-store
+``spatialdata.read_zarr`` finds the deep groups absent and calls the store
+structurally invalid, while ``zarr.open_group`` on the metadata alone
+quietly returns fill values, so every ontology term reads back as
+``{"accession": "", "name": ""}``. See :func:`prepare_zarr_read_path`,
+which Thyra's own read paths go through.
 """
 
 import logging
@@ -54,6 +59,18 @@ WINDOWS_MAX_PATH = 259
 #: ``raw_metadata\\max count of pixels x``). Metadata key names come from
 #: the source file and can be longer, so this carries headroom above the
 #: observed worst case.
+#:
+#: The hazard on the read side is that a key past the limit is not an
+#: error. Windows reports it as missing, and Zarr treats a missing chunk as
+#: the array's fill value by design (``""`` for strings, ``0`` for
+#: numbers), so a metadata block read from a plain path comes back with
+#: empty ontology terms and a blank processing history instead of an
+#: exception, and validation then blames the document. Zarr has no strict
+#: mode that could tell "never written" from "cannot open", and its own
+#: key listing cannot enter an over-long directory either, so nothing
+#: inside Zarr can detect it. The only detection is an independent,
+#: extended-length walk of the store, which :func:`prepare_zarr_read_path`
+#: performs; every read entry point must go through it.
 DEEPEST_KEY_RESERVE = 160
 
 _EXTENDED_PREFIX = "\\\\?\\"
@@ -112,17 +129,28 @@ def prepare_zarr_read_path(store_path: Path) -> Path:
     r"""Return a path that can actually open a store written to a long path.
 
     The write side is protected by :func:`prepare_zarr_output_path`, but the
-    limit applies just as much to reading it back. A store whose keys sit past
-    260 characters is written correctly and then cannot be opened by
-    ``spatialdata.read_zarr(path)``: the deep keys are invisible, so the store
-    looks structurally invalid rather than merely unreachable. Plain
-    ``os.path.exists`` on those keys returns ``False`` too, which makes the
-    store look corrupt when it is intact.
+    limit applies just as much to reading it back, and a read past it does
+    not fail. Windows reports an over-long key as missing and Zarr treats a
+    missing key as never written: ``spatialdata.read_zarr(path)`` finds the
+    deep groups absent and calls the store structurally invalid, while
+    ``zarr.open_group(path)`` on an intact metadata block returns the fill
+    value for every chunk it cannot open, so ontology terms read back as
+    ``{"accession": "", "name": ""}`` and validation blames the document
+    rather than the path. Plain ``os.path.exists`` on those keys returns
+    ``False`` too, which makes the store look corrupt when it is intact.
 
     Unlike the output helper this cannot project the deepest key, because the
     keys already exist and their length depends on what was written. It walks
     the store to find the longest key instead, which is cheap next to the
-    read that follows.
+    read that follows, and stops at the first key past the limit. The walk
+    itself goes through an extended-length path: a plain ``os.walk`` cannot
+    list a directory past the limit and skips it silently, so it would miss
+    exactly the keys this is looking for and could pass a store whose deepest
+    keys do not fit.
+
+    A relative path is resolved first, since the length that matters is the
+    absolute one and the prefix needs an absolute path anyway. A path that
+    already carries the prefix is returned as it is.
 
     Args:
         store_path: Path to an existing Zarr store.
@@ -133,14 +161,20 @@ def prepare_zarr_read_path(store_path: Path) -> Path:
     if sys.platform != "win32":
         return store_path
 
-    longest = len(str(store_path))
-    try:
-        for root, _dirs, files in os.walk(store_path):
-            for name in files:
-                longest = max(longest, len(root) + 1 + len(name))
-    except OSError:
-        # Walking already failed, which is itself a sign the prefix is needed.
-        return to_extended_length_path(store_path)
+    if str(store_path).startswith(_EXTENDED_PREFIX):
+        return store_path
+
+    absolute = store_path if store_path.is_absolute() else store_path.resolve()
+    extended = to_extended_length_path(absolute)
+    # Keys are measured as the plain path would spell them.
+    prefix_length = len(str(extended)) - len(str(absolute))
+
+    longest = len(str(absolute))
+    for root, _dirs, files in os.walk(extended):
+        for name in files:
+            longest = max(longest, len(root) + 1 + len(name) - prefix_length)
+        if longest > WINDOWS_MAX_PATH:
+            break
 
     if longest <= WINDOWS_MAX_PATH:
         return store_path
@@ -149,12 +183,12 @@ def prepare_zarr_read_path(store_path: Path) -> Path:
         return store_path
 
     logger.info(
-        "Store contains keys up to %d characters, past the %d character "
+        "Store contains a key %d characters long, past the %d character "
         "Windows limit. Reading through an extended-length path.",
         longest,
         WINDOWS_MAX_PATH,
     )
-    return to_extended_length_path(store_path)
+    return extended
 
 
 def prepare_zarr_output_path(output_path: Path, dataset_id: str) -> Path:


### PR DESCRIPTION
## Problem

`read_msi_metadata_blocks` and `check_store_var_conventions` opened the store at the raw path. When the store sits under a path deep enough for its deepest keys to pass the 259 character Windows limit, zarr cannot open those chunk files and returns the array fill value instead of failing. Every `OntologyTerm` inside `uns["msi_metadata"]` then reads back as `{"accession": "", "name": ""}`, and `thyra validate` reports pattern and min-length errors on `ms_analysis.ion_mobility.unit_term`, `ionisation_source_term` and friends, blaming the document rather than the path.

Reproduced on 2026-09-05 with `thyra <tdf.d> <178-char scratch dir>/x.zarr`: the converter warned and wrote through an extended-length path, but nothing on the read side used one. Reading the same store through `prepare_zarr_read_path` returned the correct terms and validated OK.

## Fix

- Both readers (and therefore `thyra validate` and `thyra export-metaspace`) now go through `thyra.utils.windows_paths.prepare_zarr_read_path`.
- `prepare_zarr_read_path` is hardened in three ways:
  - A relative input is resolved before measuring, since the CLI hands the path over as typed and the `\?\` prefix is only valid on an absolute path.
  - The store is walked through the extended path. A plain `os.walk` cannot list a directory past the limit and skips it silently, so it could miss the very keys it is measuring: on the repro store only 197 of 415 files were visible to a plain walk.
  - The walk stops at the first key past the limit, and an input that already carries the prefix is returned without walking.
- An empty `processing` string, which no converter writes (they emit at least `[]`), is now logged as the fill-value symptom rather than a generic parse failure.
- The hazard is documented next to `DEEPEST_KEY_RESERVE` and in the two docs pages: zarr has no strict mode that can tell "never written" from "cannot open", and its own key listing cannot enter an over-long directory either, so an independent extended-length walk is the only detection available.

## Tests

- New `tests/unit/metadata/schema/test_store_long_path.py` converts the `mobility_continuous` imzML fixture into a 180+ character path (the mobility table carries Thyra's deepest key), copies the store to a short path, and asserts the metadata blocks, the var checks and `thyra validate` (absolute and relative path) agree. With the routing reverted, four of its six cases fail on the reported symptom; with it, all pass.
- `tests/unit/utils/test_windows_paths.py` gains cases for the limit boundary, the extended-path walk, relative input, and already-extended input.
- Locally on Windows 11 with `LongPathsEnabled=0`: the new file plus the windows_paths, store round-trip, var-conventions, CLI and mobility-table suites pass (81 tests). All pre-commit hooks pass on the changed files.
