### PR TITLE
fix(converters): store the mean, not the sum, as the 3D average spectrum

### DIFF
--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -144,6 +144,11 @@ plt.title("Average Mass Spectrum")
 plt.show()
 ```
 
+It is the **mean over the acquired spectra** -- the intensity summed down the
+m/z axis and divided by the number of pixels that carry a spectrum, not by the
+number of grid positions. Every write path stores it on that scale, including
+the 3D volume path, which previously stored the undivided sum here.
+
 ### Per-Region Average Spectrum
 
 For multi-region datasets, Thyra also stores a mean spectrum per acquisition

--- a/tests/unit/converters/test_uns_provenance_parity.py
+++ b/tests/unit/converters/test_uns_provenance_parity.py
@@ -507,6 +507,50 @@ def test_tic_image_totals_the_matrix(stores, path_name):
 
 
 @pytest.mark.parametrize("path_name", list(WRITE_PATHS))
+def test_average_spectrum_is_a_mean_on_every_path(stores, path_name):
+    """``uns["average_spectrum"]`` is the per-pixel mean, not the sum.
+
+    The volume path stored ``total_intensity`` unscaled -- the sum over
+    pixels, under a key named "average". The comment on it said "use
+    total_intensity to match original behavior", carried through the
+    refactor that split the converters and never revisited; the slice
+    paths divide by ``pixel_count`` two lines from the same place.
+
+    So a volume came out with a spectrum ``_N_SPECTRA`` times the one
+    the other three paths wrote from identical data -- and, on a
+    multi-region volume, a factor apart from the
+    ``average_spectrum_per_region`` block beside it in the same ``uns``,
+    which divides by the region's pixel count and always did. Nothing
+    pinned it: no test read this key off the 3D path, and the scale
+    factor is invisible in a plot with an unlabelled y-axis, so it reads
+    as correct until a consumer compares two stores or trusts the axis.
+
+    Derived from ``X`` rather than from ``total_intensity`` so the
+    expectation comes from the stored matrix a consumer can see, not
+    from the accumulator the writer used.
+    """
+    table_path = _table_path(stores, path_name)
+    x = _read_x(table_path)
+    total = np.asarray(x.sum(axis=0)).ravel()
+    stored = np.asarray(_read_uns(table_path)["average_spectrum"], dtype=np.float64)
+
+    np.testing.assert_allclose(
+        stored,
+        total / _N_SPECTRA,
+        rtol=1e-9,
+        err_msg=(
+            f"{path_name} stored an average_spectrum that is not the mean "
+            f"over the {_N_SPECTRA} acquired spectra"
+        ),
+    )
+
+    # Guard the guard: with more than one spectrum the mean and the total
+    # are different arrays, so the assertion above can tell them apart.
+    assert _N_SPECTRA > 1
+    assert not np.allclose(stored, total), f"{path_name} stored the total, not the mean"
+
+
+@pytest.mark.parametrize("path_name", list(WRITE_PATHS))
 def test_read_lazy_sees_the_block(stores, path_name):
     """The access mode a consumer actually uses.
 

--- a/thyra/converters/spatialdata/spatialdata_3d_converter.py
+++ b/thyra/converters/spatialdata/spatialdata_3d_converter.py
@@ -214,9 +214,12 @@ class SpatialData3DConverter(BaseSpatialDataConverter):
             # Drop bbox positions that have no spectrum (#88)
             adata = self._drop_empty_pixels(adata)
 
-            # Add average spectrum to .uns (use total_intensity to match
-            # original behavior)
-            adata.uns["average_spectrum"] = data_structures["total_intensity"]
+            # Add average spectrum to .uns. Divided by the pixel count,
+            # as the slice paths do: this key is the per-pixel mean
+            # everywhere else, including the per-region block below.
+            adata.uns["average_spectrum"] = data_structures["total_intensity"] / max(
+                data_structures["pixel_count"], 1
+            )
 
             # Add per-region mean spectra for multi-region datasets
             if "region_total_intensity" in data_structures:


### PR DESCRIPTION
## The defect

`SpatialData3DConverter` stored the raw `total_intensity` accumulator in
`uns["average_spectrum"]` — the **sum** over pixels, under a key named
"average":

```python
# Add average spectrum to .uns (use total_intensity to match
# original behavior)
adata.uns["average_spectrum"] = data_structures["total_intensity"]
```

The slice paths divide the same accumulator by `pixel_count`
(`spatialdata_2d_converter.py:259-264`, `streaming_converter.py:407`), and so
does the `average_spectrum_per_region` block *twelve lines below the line
above* in the 3D converter itself. So on a multi-region volume the two spectra
sat in the same `uns`, describing the same pixels, a factor of n-pixels apart.

The comment traces to `dc298c0` ("refactor: split spatialdata converter into
modular architecture") — it was carried forward to preserve pre-refactor
behaviour and never revisited. Nothing pinned it: no test read this key off the
3D path, and a scale factor is invisible in a plot with an unlabelled y-axis, so
it reads as correct until a consumer compares two stores or trusts the axis.

## Why it matters downstream

Ousia already assumes the mean. `backend/readers/spectrum.py` uses the stored
value verbatim when the key is present (`source: "precomputed"`), and when it is
absent computes its own from `X` by dividing by the **non-empty row count** —
the same denominator the slice paths use. A volume therefore handed it a
spectrum n-pixels too large, and which of the two scales a consumer got depended
on whether the key had been written at all.

The documented contract was already the mean: `docs/output-format.md` calls the
section "Average Spectrum" and labels the plot axis "Average Intensity". This
aligns the code to the docs rather than changing the contract.

## Blast radius

Only true multi-slice volumes. `SpatialDataConverter` routes to
`SpatialData3DConverter` only when `dimensions[2] > 1` **and** `handle_3d=True`
(`converter.py:56-90`); a single-z dataset gets the 2D converter even with
`--handle-3d`. Every 2D conversion already stored the mean and is untouched.

**Existing 3D stores are stale** — the value is baked in at conversion time, so
a volume converted before this change keeps the summed spectrum and needs
re-converting to pick up the fix.

## The change

- `spatialdata_3d_converter.py`: divide by `pixel_count`, as the slice paths do.
- `test_uns_provenance_parity.py`: a regression test in the write-path parity
  module, whose thesis is that what a store records about itself must agree on
  every path — it already converts one mock dataset down all four and compares.
  The expectation is derived from the stored `X`, not from the accumulator the
  writer used, so it checks the value a consumer can actually see.
- `docs/output-format.md`: state the denominator explicitly, since leaving it
  unstated is how this drifted.

## Verification

- The new test fails on `volume_3d` alone without the fix (max relative
  difference 26 on a 27-spectrum fixture), passes on all four paths with it.
- Full suite: **1939 passed, 13 skipped** locally.
- End-to-end through the public factory on a 5×5×3 mock — 60 acquired spectra
  of 75 grid positions — the stored spectrum now equals `X.sum(axis=0) / 60`,
  where it was previously exactly 60× that.
- `pre-commit` clean on all three files.

Related to #39 (proper 3D MSI implementation), though it does not close it.
