### PR TITLE
feat(mobility): bin a TDF point cloud onto a common mobility grid

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -133,6 +133,14 @@ thyra tims_data.d output.zarr --mobility-grid
 thyra tims_data.d output.zarr --mobility-grid --mobility-bins 512     --mobility-min 1.05 --mobility-max 1.25
 ```
 
+!!! warning "The grid table is built in memory, and a whole acquisition may not fit"
+    Unlike the summed table, which the streaming route scatters to disk, the
+    mobility grid table is accumulated in RAM. 400 frames of a measured timsTOF
+    acquisition peaked at 2.0 GB; its full 26,000 pixels project to about 109 GB.
+    The conversion projects that figure as it reads, warns past a quarter of the
+    machine's free memory and refuses past half of it. Convert one `--region` at
+    a time if a whole image will not fit.
+
 !!! note "A mobility-resolved table wants a coarser mass axis than the default"
     The table's features are `(m/z bin, mobility channel)` pairs, so the mass
     axis' width is multiplied by 256. A default resampled timsTOF axis is

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -49,6 +49,7 @@ thyra input.imzML output.zarr && python analyse.py output.zarr
 | `--include-optical / --no-optical` | enabled | Include optical images in output |
 | `--mobility-table / --no-mobility-table` | enabled | Also write the mobility-resolved sibling table when the source shares one set of (m/z, ion mobility) features across pixels (see [Output Format](output-format.md#ion-mobility)) |
 | `--mobility-heatmap / --no-mobility-heatmap` | enabled | When the source has an ion mobility dimension, store the mean mass-mobility frame on the summed table as `uns["mobility_heatmap"]`; one extra pass over the source (see [Output Format](output-format.md#ion-mobility)) |
+| `--mobility-grid / --no-mobility-grid` | **disabled** | When the source carries ion mobility per pixel rather than as a shared feature list (Bruker TDF), bin the point cloud onto a common mobility grid and write the same mobility-resolved sibling table; one extra pass over the source, a much larger table, and it forces `--tdf-spectrum scan_sum` (see [Output Format](output-format.md#the-same-table-from-a-common-mobility-grid)) |
 | `--msms-table / --no-msms-table` | **disabled** | When the source isolates several precursors per pixel in disjoint mobility slices (Bruker PASEF), also write them split apart as a demultiplexed sibling table; one extra pass over the source (see [Output Format](output-format.md#demultiplexed-msms-table)) |
 
 ### Examples
@@ -108,6 +109,50 @@ thyra input.imzML output.zarr --log-file conversion.log
     When something looks wrong in the output, re-run with `-v DEBUG --log-file
     debug.log`. The log will contain pixel size detection details, resampling
     parameters, region info, and timing for each step.
+
+---
+
+## Ion Mobility Grid (Advanced)
+
+These size the grid `--mobility-grid` bins onto. They do nothing without it.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--mobility-bins INTEGER` | `256` | Mobility channels the grid divides the range into |
+| `--mobility-min FLOAT` | axis minimum | Lower edge of the grid, in the axis unit (1/K0 for TIMS) |
+| `--mobility-max FLOAT` | axis maximum | Upper edge of the grid |
+
+### Examples
+
+```bash
+# The mobility-resolved table for a TIMS acquisition, at the default
+# 256 channels over the range the acquisition actually used
+thyra tims_data.d output.zarr --mobility-grid
+
+# A narrower range at finer resolution, giving up the heatmap alignment
+thyra tims_data.d output.zarr --mobility-grid --mobility-bins 512     --mobility-min 1.05 --mobility-max 1.25
+```
+
+!!! note "A mobility-resolved table wants a coarser mass axis than the default"
+    The table's features are `(m/z bin, mobility channel)` pairs, so the mass
+    axis' width is multiplied by 256. A default resampled timsTOF axis is
+    around 140,000 bins; 200 frames of one measured acquisition filled 3.9
+    million of the resulting pairs, and a whole 26,000-pixel acquisition
+    would pass the 20,000,000 ceiling the table is refused at. Reach for
+    `--resample-bins` when the whole image is wanted resolved.
+
+!!! warning "The defaults are an alignment, and the grid changes the TIC"
+    256 channels over the mobility axis' own value range is exactly what
+    `uns["mobility_heatmap"]` bins over, so a box drawn on the heatmap
+    selects grid channels by integer index. `--mobility-bins`,
+    `--mobility-min` and `--mobility-max` each give that up.
+
+    Asking for a grid also switches a TDF conversion to `--tdf-spectrum
+    scan_sum` unless that option was given explicitly, and says so at
+    `WARNING`: the grid is built from raw scans, and its marginal over
+    channels reproduces the summed table only when that table was built the
+    same way. The switch moves the stored TIC by 13 to 21 percent against a
+    default conversion of the same file.
 
 ---
 
@@ -262,7 +307,7 @@ These options only apply when converting Bruker `.d` directories.
 | `--use-recalibrated / --no-recalibrated` | enabled | Use recalibrated m/z state |
 | `--interactive-calibration` | off | Display available calibration states |
 | `--intensity-threshold FLOAT` | none | Minimum intensity filter |
-| `--tdf-spectrum {vendor_centroid,scan_sum}` | `vendor_centroid` | How a TDF (TIMS) frame's mobility scans collapse into one spectrum per pixel |
+| `--tdf-spectrum {vendor_centroid,scan_sum}` | `vendor_centroid`; `scan_sum` when `--mobility-grid` is given | How a TDF (TIMS) frame's mobility scans collapse into one spectrum per pixel |
 
 ### Examples
 

--- a/docs/metadata-schema.md
+++ b/docs/metadata-schema.md
@@ -107,7 +107,11 @@ the ramp; how it was summed is the `tdf_spectrum` parameter of the
 `resolved_table` names the mobility-resolved sibling table when one was
 written beside the summed table, and `grid` (`{law, lower, upper,
 n_channels}`) describes the common mobility grid such a table was binned onto
-when it was built from per-pixel mobility values; both are unset otherwise.
+when it was built from per-pixel mobility values (`--mobility-grid`); both
+are unset otherwise. `grid` is the only thing in the store that says which of
+the two mechanisms filled that table -- reading it off a shared feature axis
+bins nothing -- and it is a description, not a structural difference: the
+table is the same shape either way.
 The arrays that describe the axis itself and the mass-mobility heatmap live
 outside this block, in `uns["mobility_axis"]` and `uns["mobility_heatmap"]`
 (see [Output Format](output-format.md#ion-mobility)): this block is versioned
@@ -233,7 +237,7 @@ consumer can rely on one spelling:
 | `mobility` | the converter, on mobility-resolved tables only | The feature's ion mobility (1/K0 or drift time; see `uns["mobility_axis"]`). Its presence is what marks the table as mobility-resolved. |
 | `precursor_mz` | the converter, on demultiplexed MS/MS tables only | The isolated m/z the feature's fragments came from (see `uns["msms_schedule"]`). Its presence is what marks the table as demultiplexed; such a table never carries `mobility` as well. |
 | `mz_index` | the converter, on sibling tables only | Column of the feature's m/z on the summed MSI table's axis |
-| `mobility_index` | the converter, on mobility-resolved tables only | Rank of the feature's mobility among the table's distinct mobility values |
+| `mobility_index` | the converter, on mobility-resolved tables only | The feature's position on the table's mobility axis: the rank of its mobility among the distinct values a shared-axis source lists, or the channel it fell in on a common grid (`ion_mobility.grid`) |
 | `precursor_mobility` | the converter, on demultiplexed MS/MS tables only | The 1/K0 the precursor was isolated at (the middle of its mobility window). What tells two precursors sharing an m/z apart -- an isomer pair -- so they are never merged |
 | `precursor_index` | the converter, on demultiplexed MS/MS tables only | The precursor's position in **this store's** precursor axis, and the identity of its column block. Means nothing outside the store: align two stores on `(precursor_mz, precursor_mobility)` |
 | `formula` | annotation tools | Molecular formula of the annotation |

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -405,6 +405,23 @@ A grid is refused, at `INFO` or `WARNING` and never as an exception, when:
 | `--mobility-grid` was not given | binning is opt in: it costs a pass over the source and a much larger table |
 | the mobility axis carries no per-scan values | a reader opened without its vendor library cannot supply them, and the declared range is not a substitute |
 | the occupied `(m/z bin, channel)` pairs pass 20,000,000 | the count is printed; resample to fewer mass bins or ask for fewer channels |
+| the table is on course to need more than half the machine's free memory | see the note below; the projection and the free memory are both printed |
+
+!!! warning "This table is held in memory while it is built"
+    The summed MSI table is memory-bounded: the streaming route pre-scans the
+    source, counts, and scatters into a memmap, so it converts an acquisition
+    far larger than RAM. **The mobility grid table is not.** It accumulates its
+    `(pixel, m/z bin, channel)` triples in memory, so what it needs is linear in
+    the table's non-zeros: measured, 400 frames of a timsTOF acquisition peaked
+    at 2.0 GB, and the same acquisition's full 26,000 pixels projects to about
+    109 GB.
+
+    So the conversion projects that number from the pixels it has read, warns
+    past a quarter of the machine's free memory and **refuses past half of it**,
+    early, with the figures printed -- rather than letting the run reach the
+    ceiling below and die there. Convert one `--region` at a time, resample to
+    fewer mass bins, or ask for fewer channels. A memmap-scattered route that
+    removes the limit is the next piece of work on this table.
 
 The size ceiling is on the pairs that carry signal, not on the pairs the grid
 spans. The two differ by an order of magnitude -- 200 frames of a measured

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -276,9 +276,10 @@ panel draws.
 | `mobility_edges` | `float64[k + 1]`, **`k = 256`**: equal-width bins in the axis unit, ascending, spanning the axis `values` |
 | `counts` | `float32[m, k]`: mean intensity per bin over pixels |
 
-`k = 256` is fixed on purpose: the opt-in mobility grid table (a later
-feature) defaults to the same 256 channels over the same edges, so a box drawn
-on the heatmap maps onto grid channels by integer index in both directions.
+`k = 256` is fixed on purpose: the mobility grid table below defaults to the
+same 256 channels over the same edges -- literally the same constant and the
+same generator -- so a box drawn on the heatmap maps onto grid channels by
+integer index in both directions.
 The m/z binning is the converter's own nearest-bin rule, coarsened, so under a
 lossless summed spectrum (`--tdf-spectrum scan_sum`) the heatmap summed over
 mobility, `counts.sum(axis=1)`, equals `uns["average_spectrum"]` coarsened to
@@ -313,7 +314,7 @@ table**, `{table}_mobility`, unless `--no-mobility-table` is given:
 | `var["mz"]` | strictly increasing, unique | **non-decreasing with duplicates** |
 | `var["mobility"]` | absent | the feature's 1/K0 (or drift time) |
 | sort | by `mz` | lexicographic `(mz, mobility)` |
-| also | | `mz_index` (column on the MSI axis), `mobility_index` (rank of the mobility value), `uns["feature_axis"]`, `uns["mobility_axis"]` |
+| also | | `mz_index` (column on the MSI axis), `mobility_index` (rank of the mobility value, or the grid channel), `uns["feature_axis"]`, `uns["mobility_axis"]` |
 
 Two isomers at one m/z that separate in mobility are one column in the MSI
 table and two in the mobility table. The `(mz, mobility)` sort means an m/z
@@ -327,11 +328,93 @@ assumes a unique, strictly increasing `var["mz"]` must not be pointed at it.
 sorted pairs) to tables carrying `mobility` and the strict contract to all
 others.
 
-A source whose mobility values differ per pixel (a processed imzML export,
-the raw point cloud) has no shared feature axis; it gets the summed table
-only, with coincident m/z within a pixel summed into one bin. A
-mobility-resolved table for that case needs a common mobility grid, which
-is a later feature.
+#### The same table from a common mobility grid
+
+A source whose mobility values differ per pixel -- a Bruker TDF, where a
+frame is a point cloud and no two pixels are promised the same `(m/z, 1/K0)`
+pairs -- has no shared feature axis to read off. `--mobility-grid` fills the
+**same** `{table}_mobility` element for it by binning: every pixel's points
+go onto one set of mobility channels shared across the conversion, and
+`(m/z bin, channel)` becomes the feature axis.
+
+The two mechanisms produce the same kind of table -- same element key, same
+`var` columns, same sort, same discriminator -- and a consumer does not need
+to tell them apart to read either. What says which one filled it is
+`uns["mobility_grid"]`, present only on a binned table:
+
+| key | value |
+|---|---|
+| `law` | how the channel edges are spaced; `"linear"` (equal width in the axis unit) is the only law today |
+| `lower`, `upper` | the range the channels span, in the axis unit |
+| `n_channels` | how many channels, **256 by default** |
+| `channel_width` | `(upper - lower) / n_channels`, recorded so a reader can see it without arithmetic |
+| `edges` | `float64[n_channels + 1]`, the channel edges themselves |
+
+`msi_metadata.ms_analysis.ion_mobility.grid` carries `law`, `lower`, `upper`
+and `n_channels` too, so a consumer reading only the summed table finds them.
+
+Three things are worth knowing before asking for one:
+
+- **The edges come from the axis values, never the declared acquisition
+  range.** A real file's per-scan 1/K0 overhangs its declared
+  `OneOverK0AcqRange` by a few scans (1.00003 to 1.29133 against a declared
+  1.0 to 1.29 on one measured acquisition), and `uns["mobility_heatmap"]`
+  already bins over the values. `--mobility-min` / `--mobility-max` override
+  them, at the cost of the alignment below.
+- **256 channels is an alignment anchor, not a tuning knob.** It is the
+  heatmap's own channel count over the heatmap's own edges, so a box drawn on
+  the heatmap selects grid channels by integer index with no resampling and
+  no edge off-by-one. `--mobility-bins` changes it and gives that up. The
+  width the anchor realizes on a typical 0.29 1/K0 span is 0.0011, finer than
+  the 0.002 to 0.02 band TIMS resolving power supports; that is said at
+  `INFO` and the count is not moved for it, because the alignment is worth
+  more than the size.
+- **It forces `--tdf-spectrum scan_sum`,** at `WARNING`, unless that option
+  was given explicitly. A grid table is built from raw scans, so its marginal
+  reproduces the summed table only when the summed table was built from the
+  same scans; the default vendor centroid is a peak-picked spectrum over the
+  same ramp. The switch moves the stored TIC by 13 to 21 percent against a
+  default conversion of the same file, which reads as a bug if it happens
+  quietly.
+
+**The marginal invariant.** Summing a grid table's channels within one m/z
+bin reproduces that bin's column of the summed table, per pixel. That is what
+`uns["mobility_marginal"]` records rather than merely asserting:
+
+| key | value |
+|---|---|
+| `summed_table` | element key of the table the marginal is compared against |
+| `current_ratio` | total ion current of the grid table over the summed table's; exactly `1.0` under `scan_sum` |
+| `current_ratio_pixel_min` / `_max` | the same ratio across pixels |
+| `max_absolute_deviation` | largest disagreement between a marginal and the column it mirrors, over all (pixel, m/z bin) |
+| `max_relative_deviation` | that, relative to the largest value in the summed table |
+
+```python
+grid = sdata.tables["msi_dataset_z0_mobility"]
+mz_index = grid.var["mz_index"].to_numpy()
+marginal = np.zeros(sdata.tables["msi_dataset_z0"].n_vars)
+np.add.at(marginal, mz_index, np.asarray(grid.X[0].todense()).ravel())
+# equals the summed table's row 0, to floating point
+```
+
+A grid is refused, at `INFO` or `WARNING` and never as an exception, when:
+
+| refused when | because |
+|---|---|
+| the source has no mobility dimension | there is nothing to bin |
+| `--mobility-grid` was not given | binning is opt in: it costs a pass over the source and a much larger table |
+| the mobility axis carries no per-scan values | a reader opened without its vendor library cannot supply them, and the declared range is not a substitute |
+| the occupied `(m/z bin, channel)` pairs pass 20,000,000 | the count is printed; resample to fewer mass bins or ask for fewer channels |
+
+The size ceiling is on the pairs that carry signal, not on the pairs the grid
+spans. The two differ by an order of magnitude -- 200 frames of a measured
+timsTOF acquisition occupied 3.9M of a possible 35.5M -- so refusing on the
+span would turn away conversions that fit ninefold over. The span is said at
+`INFO` when it passes the ceiling; the count is what refuses, checked as soon
+as the source has been read and before anything wide is built.
+
+Bruker TDF is the only source that needs a grid today; an imzML export with a
+mobility array already has a shared feature axis and is read off it.
 
 ### Fragmentation (MS/MS)
 

--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -91,7 +91,8 @@ m/z block that repeats a value where mobility splits a feature collapses to
 one column -- and, for a continuous export (one shared feature list), the
 `(m/z, mobility)` pairs are also written as a mobility-resolved sibling
 table; see [Output Format](output-format.md#ion-mobility). A processed export
-(per-pixel point cloud) gets the summed table only. A mobility array declared
+(per-pixel point cloud) gets the summed table only -- `--mobility-grid`
+covers per-pixel mobility for Bruker TDF, not yet for imzML. A mobility array declared
 with zlib compression is refused like the other two.
 
 See [imzML Parser Notes](imzml-parser-notes.md) for the hazards Thyra works
@@ -107,9 +108,9 @@ registration, and per-pixel region annotations for multi-region slides.
 
 A TDF frame is one pixel whose scans are the ion mobility dimension. Thyra
 reads **every scan of the ramp** and collapses them into the one spectrum per
-pixel the MSI table holds; a mobility-resolved table is a separate, later
-feature, and `--msms-table` slices the ramp by precursor instead (below). Two
-collapses are available through `--tdf-spectrum`:
+pixel the MSI table holds; `--mobility-grid` writes what was collapsed as a
+separate table (below), and `--msms-table` slices the ramp by precursor
+instead (below). Two collapses are available through `--tdf-spectrum`:
 
 - `vendor_centroid` (default): Bruker's frame-level peak picker over the full
   ramp, the same one behind the TSF line spectrum and SCiLS Lab's import. It
@@ -136,6 +137,19 @@ skips it. Under `scan_sum` the heatmap summed over mobility is exactly the
 stored mean spectrum; under `vendor_centroid` the two differ by what the
 centroid discards. See [Output Format](output-format.md#ion-mobility). A TSF
 file has no mobility dimension and gets none of this.
+
+**`--mobility-grid` writes the mobility-resolved table.** A TDF pixel is its
+own point cloud, so there is no feature list shared across pixels to write
+directly the way an imzML mobility export has; the flag bins every pixel's
+`(m/z, 1/K0, intensity)` points onto one set of mobility channels shared
+across the conversion and writes the result as `{table}_mobility` -- the same
+element, columns and sort a shared-axis source produces. The default 256
+channels over the axis' own value range are the heatmap's, so a box on the
+heatmap indexes the table's channels. It costs a second pass over the source,
+a table with 1.3 to 4 times the summed table's non-zeros, and a switch to
+`--tdf-spectrum scan_sum` (said at `WARNING`) so the table's marginal over
+channels reproduces the summed table exactly. See
+[Output Format](output-format.md#the-same-table-from-a-common-mobility-grid).
 
 **MS/MS acquisitions convert, and say so.** `Frames.MsMsType` tells a survey
 frame from a fragment one; the precursor detail comes from `PasefFrameMsMsInfo`

--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -146,7 +146,9 @@ across the conversion and writes the result as `{table}_mobility` -- the same
 element, columns and sort a shared-axis source produces. The default 256
 channels over the axis' own value range are the heatmap's, so a box on the
 heatmap indexes the table's channels. It costs a second pass over the source,
-a table with 1.3 to 4 times the summed table's non-zeros, and a switch to
+a table with 1.3 to 4 times the summed table's non-zeros held in memory while
+it is built (so a whole large acquisition may need converting one `--region` at
+a time), and a switch to
 `--tdf-spectrum scan_sum` (said at `WARNING`) so the table's marginal over
 channels reproduces the summed table exactly. See
 [Output Format](output-format.md#the-same-table-from-a-common-mobility-grid).

--- a/tests/integration/test_bruker_tdf_synthetic.py
+++ b/tests/integration/test_bruker_tdf_synthetic.py
@@ -597,6 +597,178 @@ class TestDemultiplexedStore:
         assert "msms_schedule" not in asked.tables["tims_z0"].uns
 
 
+# ----------------------------------------------------------------------
+# The mobility grid table on a TDF, which has no shared feature axis
+# ----------------------------------------------------------------------
+
+
+def _marginal(grid, summed) -> np.ndarray:
+    """The grid table collapsed over mobility channels, per (pixel, m/z bin)."""
+    mz_index = grid.var["mz_index"].to_numpy()
+    out = np.zeros((grid.n_obs, summed.n_vars), dtype=np.float64)
+    rows = _rows(grid)
+    for column, bin_index in enumerate(mz_index):
+        out[:, bin_index] += rows[:, column]
+    return out
+
+
+class TestMobilityGridStore:
+    """The opt-in grid table, built by binning each frame's point cloud.
+
+    A TDF pixel is its own point cloud, so this is the second mechanism
+    that fills ``{table}_mobility`` -- and the first one a Bruker source
+    can use at all. Everything here runs on the committed synthetic
+    fixture through the real library; no new binary data.
+    """
+
+    def test_a_default_conversion_is_untouched(self, tmp_path):
+        out = _convert(tmp_path, "vendor_centroid")
+        spatialdata = pytest.importorskip("spatialdata")
+        from thyra.utils.windows_paths import prepare_zarr_read_path
+
+        sdata = spatialdata.read_zarr(prepare_zarr_read_path(out))
+        assert "tims_z0_mobility" not in sdata.tables
+
+    def test_the_flag_writes_the_sibling_and_forces_the_lossless_sum(self, tmp_path):
+        from thyra.convert import convert_msi
+
+        out = tmp_path / "grid.zarr"
+        # No reader_options: the grid must pick scan_sum itself.
+        assert convert_msi(
+            str(FIXTURE),
+            str(out),
+            dataset_id="tims",
+            pixel_size_um=20.0,
+            mobility_grid=True,
+        )
+        from thyra.metadata.schema import read_msi_metadata_blocks
+        from thyra.utils.windows_paths import prepare_zarr_read_path
+
+        summed = _read_table(out, "tims_z0")
+        grid = _read_table(out, "tims_z0_mobility")
+        blocks = read_msi_metadata_blocks(prepare_zarr_read_path(out))
+        step = blocks["tims_z0"]["processing"][0]
+        assert step["parameters"]["tdf_spectrum"] == "scan_sum"
+        assert summed.n_obs == grid.n_obs
+        assert list(summed.obs.index) == list(grid.obs.index)
+        assert "mobility" in grid.var.columns
+        assert "mobility" not in summed.var.columns
+
+    def test_the_marginal_reproduces_the_summed_table_per_pixel(self, tmp_path):
+        from thyra.convert import convert_msi
+
+        out = tmp_path / "grid.zarr"
+        assert convert_msi(
+            str(FIXTURE),
+            str(out),
+            dataset_id="tims",
+            pixel_size_um=20.0,
+            mobility_grid=True,
+        )
+        summed = _read_table(out, "tims_z0")
+        grid = _read_table(out, "tims_z0_mobility")
+        np.testing.assert_allclose(
+            _marginal(grid, summed), _rows(summed), rtol=0, atol=1e-9
+        )
+        block = grid.uns["mobility_marginal"]
+        assert float(block["current_ratio"]) == pytest.approx(1.0, abs=1e-12)
+        assert float(block["max_absolute_deviation"]) == pytest.approx(0.0, abs=1e-9)
+
+    def test_the_grid_indexes_the_heatmap_by_integer_channel(self, tmp_path):
+        from thyra.convert import convert_msi
+
+        out = tmp_path / "grid.zarr"
+        assert convert_msi(
+            str(FIXTURE),
+            str(out),
+            dataset_id="tims",
+            pixel_size_um=20.0,
+            mobility_grid=True,
+        )
+        summed = _read_table(out, "tims_z0")
+        grid = _read_table(out, "tims_z0_mobility")
+        block = grid.uns["mobility_grid"]
+        assert int(block["n_channels"]) == 256
+        # Equal arrays, not merely close.
+        np.testing.assert_array_equal(
+            np.asarray(block["edges"]),
+            np.asarray(summed.uns["mobility_heatmap"]["mobility_edges"]),
+        )
+        channels = grid.var["mobility_index"].to_numpy()
+        assert channels.min() >= 0 and channels.max() <= 255
+        assert _no_colon_keys(block)
+        # And the schema block names the same grid.
+        schema_grid = summed.uns["msi_metadata"]["ms_analysis"]["ion_mobility"]["grid"]
+        assert int(schema_grid["n_channels"]) == 256
+        assert float(schema_grid["lower"]) == pytest.approx(float(block["lower"]))
+
+    def test_a_tsf_file_is_refused_by_name(self, tmp_path, caplog):
+        """No mobility dimension, so no grid -- and no exception either."""
+        from thyra.converters.spatialdata.mobility_table import grid_refusal
+        from thyra.resampling.mobility_grid import build_mobility_grid
+
+        with _open("vendor_centroid") as reader:
+            assert reader.has_ion_mobility
+            assert not reader.has_shared_mobility_axis
+        grid = build_mobility_grid(1.0, 1.3)
+
+        class _Tsf:
+            has_ion_mobility = False
+
+        assert "no ion mobility" in str(grid_refusal(_Tsf(), np.arange(10.0), grid))
+
+    def test_the_var_ceiling_refuses_the_table_and_keeps_the_store(
+        self, tmp_path, caplog, monkeypatch
+    ):
+        """The ceiling is on occupied pairs, so it is checked on the count."""
+        import thyra.converters.spatialdata.mobility_table as module
+        from thyra.convert import convert_msi
+
+        monkeypatch.setattr(module, "MAX_GRID_VAR_ENTRIES", 8)
+        out = tmp_path / "ceiling.zarr"
+        with caplog.at_level(logging.WARNING):
+            assert convert_msi(
+                str(FIXTURE),
+                str(out),
+                dataset_id="tims",
+                pixel_size_um=20.0,
+                mobility_grid=True,
+            )
+        assert "above the var ceiling" in caplog.text
+        spatialdata = pytest.importorskip("spatialdata")
+        from thyra.utils.windows_paths import prepare_zarr_read_path
+
+        sdata = spatialdata.read_zarr(prepare_zarr_read_path(out))
+        assert "tims_z0_mobility" not in sdata.tables
+        # The summed table is untouched by the refusal.
+        assert sdata.tables["tims_z0"].n_obs == 6
+
+
+def _capped_copy(source: Path, tmp_path: Path, n_frames: int) -> Path:
+    """A copy of a ``.d`` limited to its first ``n_frames`` MALDI frames.
+
+    Everything but ``analysis.tdf`` is hard-linked, so a 27 GB acquisition
+    costs nothing to cap; the database itself is copied because the frame
+    list is trimmed in it. Falls back to a plain copy where hard links are
+    not available.
+    """
+    target = tmp_path / "capped.d"
+    try:
+        shutil.copytree(source, target, copy_function=os.link)
+        (target / "analysis.tdf").unlink()
+        shutil.copy2(source / "analysis.tdf", target / "analysis.tdf")
+    except OSError:
+        shutil.rmtree(target, ignore_errors=True)
+        shutil.copytree(source, target)
+    with sqlite3.connect(target / "analysis.tdf") as conn:
+        conn.execute(
+            "DELETE FROM MaldiFrameInfo WHERE Frame NOT IN "
+            "(SELECT Frame FROM MaldiFrameInfo ORDER BY Frame LIMIT ?)",
+            (int(n_frames),),
+        )
+    return target
+
+
 REAL_DATASET = os.environ.get("THYRA_BRUKER_TDF_DATASET")
 
 
@@ -688,3 +860,72 @@ class TestRealAcquisition:
         mean_k0 = (counts[strong] @ k0_centres) / marginal[strong]
         rho = spearmanr(mz_centres[strong], mean_k0).statistic
         assert rho > 0.3, f"no mass-mobility trend: Spearman {rho:.2f}"
+
+    def test_the_grid_table_holds_the_summed_table_resolved(self, tmp_path):
+        """Acceptance for the grid on real data: both tables, and they agree.
+
+        Frame-capped so the conversion stays short: the ``.tdf_bin`` is
+        hard-linked rather than copied and the frame list is trimmed, so
+        the cap costs no disk and no read of the frames it drops.
+        """
+        from thyra.convert import convert_msi
+
+        source = _capped_copy(Path(REAL_DATASET), tmp_path, n_frames=60)  # type: ignore[arg-type]
+        out = tmp_path / "real_grid.zarr"
+        assert convert_msi(
+            str(source),
+            str(out),
+            dataset_id="real",
+            # As the CLI converts: without resampling a TDF's raw axis is
+            # millions of bins and the grid is refused by the var ceiling,
+            # which is the ceiling doing its job rather than a bad default.
+            resampling_config={
+                "method": "auto",
+                "axis_type": "auto",
+                "reference_mz": 1000.0,
+            },
+            mobility_grid=True,
+        )
+        summed = _read_table(out, "real_z0")
+        grid = _read_table(out, "real_z0_mobility")
+
+        assert summed.n_obs == grid.n_obs
+        assert list(summed.obs.index) == list(grid.obs.index)
+
+        # var: the frozen contract, and channels on the 256-channel grid.
+        mz = grid.var["mz"].to_numpy()
+        mobility = grid.var["mobility"].to_numpy()
+        assert np.all(np.diff(mz) >= 0)
+        order = np.lexsort((mobility, mz))
+        np.testing.assert_array_equal(order, np.arange(order.size))
+        channels = grid.var["mobility_index"].to_numpy()
+        assert channels.min() >= 0 and channels.max() <= 255
+
+        # The heatmap's edges are the grid's, as arrays.
+        np.testing.assert_array_equal(
+            np.asarray(grid.uns["mobility_grid"]["edges"]),
+            np.asarray(summed.uns["mobility_heatmap"]["mobility_edges"]),
+        )
+
+        # The marginal invariant, per pixel and per m/z bin. Row by row:
+        # this table is millions of columns wide and densifying it whole
+        # would need tens of gigabytes.
+        mz_index = grid.var["mz_index"].to_numpy()
+        summed_csr = summed.X.tocsr()
+        grid_csr = grid.X.tocsr()
+        scale = float(np.abs(summed_csr.data).max())
+        for row in range(summed.n_obs):
+            marginal = np.zeros(summed.n_vars, dtype=np.float64)
+            block_row = grid_csr[row]
+            np.add.at(marginal, mz_index[block_row.indices], block_row.data)
+            np.testing.assert_allclose(
+                marginal,
+                np.asarray(summed_csr[row].todense()).ravel(),
+                rtol=0,
+                atol=scale * 1e-9,
+            )
+        block = grid.uns["mobility_marginal"]
+        assert float(block["current_ratio"]) == pytest.approx(1.0, abs=1e-9)
+
+        ratio = grid.X.nnz / summed.X.nnz
+        assert 1.2 <= ratio <= 5, f"unexpected non-zero ratio {ratio:.2f}"

--- a/tests/unit/converters/test_mobility_grid.py
+++ b/tests/unit/converters/test_mobility_grid.py
@@ -25,7 +25,9 @@ from thyra.converters.spatialdata.mobility_table import (
     MAX_GRID_VAR_ENTRIES,
     grid_refusal,
     grid_var_bound,
+    memory_refusal,
     mobility_grid_range,
+    projected_memory_gb,
     var_ceiling_refusal,
 )
 from thyra.core.base_extractor import MetadataExtractor
@@ -337,6 +339,19 @@ class TestVarCeiling:
         assert grid_var_bound(axis, grid) > MAX_GRID_VAR_ENTRIES
         assert grid_refusal(GridStubReader(), axis, grid) is None
 
+    def test_the_ceiling_cannot_protect_the_pass_which_is_why_memory_is_projected(
+        self,
+    ):
+        # The var ceiling sits past the concatenation, so on an image big
+        # enough for it to matter the memory is already committed. That is
+        # what the projection below exists for; this pins the reason.
+        import inspect
+
+        from thyra.converters.spatialdata import mobility_table as module
+
+        source = inspect.getsource(module._GridAccumulator.matrix)
+        assert source.index("np.concatenate") < source.index("var_ceiling_refusal")
+
     def test_the_count_is_what_is_refused_with_the_number_printed(self):
         assert var_ceiling_refusal(MAX_GRID_VAR_ENTRIES) is None
         refusal = var_ceiling_refusal(MAX_GRID_VAR_ENTRIES + 1)
@@ -344,6 +359,98 @@ class TestVarCeiling:
         assert f"{MAX_GRID_VAR_ENTRIES + 1:,}" in refusal
         assert f"{MAX_GRID_VAR_ENTRIES:,}" in refusal
         assert "--mobility-bins" in refusal
+
+
+class TestMemoryProjection:
+    """The stopgap guard on a route that holds its whole table in RAM."""
+
+    def test_nothing_is_projected_from_too_few_pixels(self):
+        assert projected_memory_gb(10_000_000, 4, 26_000) is None
+        assert memory_refusal(10_000_000, 4, 26_000, available_gb=1.0) is None
+
+    def test_nothing_is_projected_once_every_pixel_is_in(self):
+        # By then there is nothing left to warn about.
+        assert projected_memory_gb(10_000_000, 400, 400) is None
+
+    def test_the_projection_scales_the_pixels_read_to_the_whole_image(self):
+        # Measured shape: 20,455,979 non-zeros over 400 pixels of a real
+        # acquisition is 109 GB extrapolated to its 26,000.
+        gb = projected_memory_gb(20_455_979, 400, 26_000)
+        assert gb == pytest.approx(109.0, abs=1.0)
+
+    def test_a_table_that_fits_the_machine_is_not_refused(self):
+        assert memory_refusal(20_455_979, 400, 1_465, available_gb=64.0) is None
+
+    def test_a_table_that_does_not_fit_is_refused_by_the_numbers(self):
+        refusal = memory_refusal(20_455_979, 400, 26_000, available_gb=64.0)
+        assert refusal is not None
+        assert "1,329,638,635" in refusal and "26,000" in refusal
+        assert "109.0 GB" in refusal and "64.0 GB" in refusal
+        assert "--region" in refusal and "--mobility-bins" in refusal
+
+    def test_the_same_table_can_fit_one_machine_and_not_another(self):
+        # Which is why the guard is a fraction of what is free, not a
+        # fixed size: this is routine on a workstation and fatal on a
+        # laptop, and a constant would be wrong on one of them.
+        assert memory_refusal(20_455_979, 400, 1_465, available_gb=64.0) is None
+        assert memory_refusal(20_455_979, 400, 1_465, available_gb=8.0) is not None
+
+    def test_a_fixture_that_fits_is_built(self, monkeypatch):
+        import thyra.converters.spatialdata.mobility_table as module
+
+        monkeypatch.setattr(module, "_PROJECTION_MIN_PIXELS", 2)
+        monkeypatch.setattr(module, "available_memory_gb", lambda: 64.0)
+        assert self._build(module) is not None
+
+    def test_the_accumulator_stops_reading_when_it_refuses(self, monkeypatch, caplog):
+        import thyra.converters.spatialdata.mobility_table as module
+
+        monkeypatch.setattr(module, "_PROJECTION_MIN_PIXELS", 2)
+        # A machine with a few bytes free: the four-pixel fixture is then
+        # on course for more than half of it.
+        monkeypatch.setattr(module, "available_memory_gb", lambda: 1e-9)
+        with caplog.at_level("WARNING"):
+            assert self._build(module) is None
+        assert "on course for" in caplog.text
+        assert "--region" in caplog.text
+
+    def test_a_table_between_the_two_thresholds_warns_and_is_still_built(
+        self, monkeypatch, caplog
+    ):
+        import thyra.converters.spatialdata.mobility_table as module
+
+        monkeypatch.setattr(module, "_PROJECTION_MIN_PIXELS", 2)
+        monkeypatch.setattr(module, "available_memory_gb", lambda: 64.0)
+        # Between the two thresholds: said out loud, and still written.
+        monkeypatch.setattr(module, "GRID_MEMORY_WARN_FRACTION", 0.0)
+        monkeypatch.setattr(module, "GRID_MEMORY_REFUSE_FRACTION", 1e9)
+        with caplog.at_level("WARNING"):
+            assert self._build(module) is not None
+        assert "accumulates the whole table in RAM" in caplog.text
+
+    @staticmethod
+    def _build(module):
+        return module.build_mobility_table(
+            GridStubReader(),
+            _stub_obs(),
+            MASS_AXIS,
+            "stub_z0",
+            "stub_z0_pixels",
+            {},
+            grid=build_mobility_grid(1.1, 1.5),
+        )
+
+
+def _stub_obs():
+    import pandas as pd
+
+    return pd.DataFrame(
+        {
+            "x": [x for x, _y in PIXELS],
+            "y": [y for _x, y in PIXELS],
+        },
+        index=[str(i) for i in range(len(PIXELS))],
+    )
 
 
 # ----------------------------------------------------------------------

--- a/tests/unit/converters/test_mobility_grid.py
+++ b/tests/unit/converters/test_mobility_grid.py
@@ -1,0 +1,627 @@
+"""The common mobility grid, and the table it fills for a per-pixel source.
+
+The grid itself is exercised on hand-picked values first: edges, channel
+assignment, the clamp band, and the alignment with the mass-mobility
+heatmap that the whole 256-channel anchor exists for. Then a stub reader
+whose pixels each carry their own ``(m/z, 1/K0, intensity)`` cloud -- a
+Bruker TDF in miniature, no SDK and no committed data -- goes down the
+in-memory and streaming write routes, so the marginal invariant, the
+``uns`` blocks and the refusals are checked on a real store.
+"""
+
+from pathlib import Path
+from typing import Generator, Optional, Tuple
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from thyra.converters.spatialdata.mobility_heatmap import (
+    HEATMAP_MOBILITY_CHANNELS,
+    MobilityHeatmap,
+    mobility_bin_edges,
+)
+from thyra.converters.spatialdata.mobility_table import (
+    MAX_GRID_VAR_ENTRIES,
+    grid_refusal,
+    grid_var_bound,
+    mobility_grid_range,
+    var_ceiling_refusal,
+)
+from thyra.core.base_extractor import MetadataExtractor
+from thyra.core.base_reader import BaseMSIReader
+from thyra.core.mobility import MobilityAxis
+from thyra.metadata.types import ComprehensiveMetadata, EssentialMetadata
+from thyra.resampling.mobility_grid import (
+    MAX_CHANNEL_WIDTH,
+    MIN_CHANNEL_WIDTH,
+    MOBILITY_CHANNELS,
+    LinearMobilityGridGenerator,
+    MobilityGrid,
+    build_mobility_grid,
+    linear_channel,
+)
+
+# ----------------------------------------------------------------------
+# The grid on its own
+# ----------------------------------------------------------------------
+
+
+class TestTheAnchor:
+    def test_the_channel_count_is_the_heatmap_s_own_constant(self):
+        # Not two constants that happen to agree: one, so a box drawn on
+        # the heatmap maps onto grid channels by integer index.
+        assert MOBILITY_CHANNELS == 256
+        assert HEATMAP_MOBILITY_CHANNELS is MOBILITY_CHANNELS
+
+    def test_default_edges_are_the_heatmap_s_edges_exactly(self):
+        grid = build_mobility_grid(1.00003, 1.29133)
+        edges = mobility_bin_edges(1.00003, 1.29133)
+        # Equal arrays, not merely close: an approximate match would put a
+        # heatmap box half a channel off the grid it is meant to index.
+        np.testing.assert_array_equal(grid.edges, edges)
+
+    def test_assignment_matches_the_heatmap_s_own_channels(self):
+        lower, upper = 1.00003, 1.29133
+        heatmap = MobilityHeatmap(np.linspace(100.0, 200.0, 11), (lower, upper))
+        grid = build_mobility_grid(lower, upper)
+        values = np.linspace(lower - 0.01, upper + 0.01, 5000)
+        heatmap.add(np.full(values.size, 150.0), values, np.ones(values.size))
+        counts = heatmap.finalize()["counts"]
+        occupied_by_heatmap = np.flatnonzero(counts.sum(axis=0))
+        occupied_by_grid = np.unique(grid.assign(values))
+        np.testing.assert_array_equal(occupied_by_grid, occupied_by_heatmap)
+
+
+class TestLinearGrid:
+    def test_edges_and_centres(self):
+        grid = build_mobility_grid(1.0, 1.4, n_channels=4)
+        np.testing.assert_allclose(grid.edges, [1.0, 1.1, 1.2, 1.3, 1.4])
+        np.testing.assert_allclose(grid.centres, [1.05, 1.15, 1.25, 1.35])
+        assert grid.law == "linear"
+        assert grid.channel_width == pytest.approx(0.1)
+
+    def test_assign_places_a_value_in_the_channel_containing_it(self):
+        grid = build_mobility_grid(1.0, 1.4, n_channels=4)
+        channels = grid.assign([1.0, 1.05, 1.1, 1.25, 1.39999])
+        np.testing.assert_array_equal(channels, [0, 0, 1, 2, 3])
+        assert channels.dtype == np.int32
+
+    def test_the_upper_edge_belongs_to_the_last_channel(self):
+        grid = build_mobility_grid(1.0, 1.4, n_channels=4)
+        assert int(grid.assign([1.4])[0]) == 3
+
+    def test_a_value_past_either_edge_is_clipped_not_lost(self):
+        # The per-scan axis overhangs its declared range, and a reader
+        # may clip a scan number; a marginal must still keep every count.
+        grid = build_mobility_grid(1.0, 1.4, n_channels=4)
+        np.testing.assert_array_equal(grid.assign([0.5, 9.0]), [0, 3])
+
+    @pytest.mark.parametrize("lower,upper", [(1.0, 1.0), (1.4, 1.0), (np.nan, 1.0)])
+    def test_a_range_without_extent_is_refused(self, lower, upper):
+        with pytest.raises(ValueError, match="extent"):
+            build_mobility_grid(lower, upper)
+
+    def test_a_channel_count_below_one_is_refused(self):
+        with pytest.raises(ValueError, match="at least one channel"):
+            build_mobility_grid(1.0, 1.4, n_channels=0)
+
+    def test_an_unknown_law_is_refused_rather_than_guessed(self):
+        with pytest.raises(ValueError, match="Unknown mobility grid law"):
+            build_mobility_grid(1.0, 1.4, law="constant_relative")
+
+    def test_a_second_law_is_a_drop_in(self):
+        # A law that supplies its own edges inherits assign() through the
+        # binary search, which is the whole point of the split.
+        class _Quadratic(LinearMobilityGridGenerator):
+            def generate(self, lower, upper, n_channels):
+                fractions = np.linspace(0.0, 1.0, n_channels + 1) ** 2
+                return MobilityGrid(
+                    law="quadratic",
+                    lower=float(lower),
+                    upper=float(upper),
+                    n_channels=int(n_channels),
+                    edges=lower + (upper - lower) * fractions,
+                )
+
+        grid = _Quadratic().generate(1.0, 1.4, 4)
+        np.testing.assert_allclose(grid.edges, [1.0, 1.025, 1.1, 1.225, 1.4])
+        np.testing.assert_array_equal(grid.assign([1.0, 1.03, 1.2, 1.4]), [0, 1, 2, 3])
+
+
+class TestChannelWidthBand:
+    def test_the_band_is_reported_never_moves_the_anchor(self, caplog):
+        # A real acquisition's 0.29 span over 256 channels is finer than
+        # the band's floor. The count is the anchor and does not move for
+        # it; the width is said out loud instead.
+        grid = build_mobility_grid(1.0, 1.29)
+        assert grid.n_channels == MOBILITY_CHANNELS
+        assert grid.channel_width < MIN_CHANNEL_WIDTH
+
+    def test_a_coarse_grid_warns_that_separations_may_merge(self, caplog):
+        from thyra.resampling.mobility_grid import report_channel_width
+
+        grid = build_mobility_grid(1.0, 11.0, n_channels=4)
+        assert grid.channel_width > MAX_CHANNEL_WIDTH
+        with caplog.at_level("WARNING"):
+            report_channel_width(grid)
+        assert "above" in caplog.text
+
+
+class TestLinearChannel:
+    def test_is_the_shared_expression(self):
+        values = np.array([1.0, 1.2, 1.4])
+        np.testing.assert_array_equal(
+            linear_channel(values, 1.0, 1.4, 4),
+            build_mobility_grid(1.0, 1.4, 4).assign(values),
+        )
+
+
+# ----------------------------------------------------------------------
+# A per-pixel mobility source, in miniature
+# ----------------------------------------------------------------------
+
+MASS_AXIS = np.array([100.0, 110.0, 120.0, 130.0])
+PIXELS = [(0, 0), (1, 0), (0, 1), (1, 1)]
+
+#: The per-scan 1/K0 axis: decreasing with scan number, as a TDF's is.
+SCAN_K0 = np.linspace(1.5, 1.1, 9)
+
+#: One pixel's raw cloud. m/z 100 is one column of the summed table and
+#: two channels of the grid; m/z 120 likewise; the two points at 110 fall
+#: in one cell and are collapsed before anything is buffered.
+CLOUD_MZ = np.array([100.0, 100.0, 110.0, 110.0, 120.0, 120.0])
+CLOUD_K0 = np.array([1.12, 1.48, 1.303, 1.3031, 1.201, 1.207])
+
+
+def _cloud(pixel: int) -> Tuple[NDArray, NDArray, NDArray]:
+    intensities = np.array([10.0, 1.0, 5.0, 2.0, 20.0, 3.0]) + pixel
+    return CLOUD_MZ.copy(), CLOUD_K0.copy(), intensities
+
+
+def _summed(pixel: int) -> Tuple[NDArray, NDArray]:
+    """The summed spectrum of that cloud: what ``scan_sum`` produces."""
+    mzs, _, intensities = _cloud(pixel)
+    unique, inverse = np.unique(mzs, return_inverse=True)
+    sums = np.bincount(np.asarray(inverse).ravel(), weights=intensities)
+    keep = sums != 0
+    return unique[keep], sums[keep]
+
+
+class _StubExtractor(MetadataExtractor):
+    def __init__(self):
+        super().__init__(data_source=None)
+
+    def _extract_essential_impl(self) -> EssentialMetadata:
+        return EssentialMetadata(
+            dimensions=(2, 2, 1),
+            coordinate_bounds=(0.0, 1.0, 0.0, 1.0),
+            mass_range=(100.0, 130.0),
+            pixel_size=(10.0, 10.0),
+            n_spectra=4,
+            total_peaks=12,
+            estimated_memory_gb=0.0,
+            source_path="stub_grid",
+            spectrum_type="centroid spectrum",
+        )
+
+    def _extract_comprehensive_impl(self) -> ComprehensiveMetadata:
+        return ComprehensiveMetadata(
+            essential=self._extract_essential_impl(),
+            format_specific={
+                "format": "stub",
+                "ion_mobility": {
+                    "present": True,
+                    "separation": "inverse reduced ion mobility",
+                    "separation_accession": "MS:1002815",
+                    "unit_accession": "MS:1002814",
+                    "range": [1.1, 1.5],
+                    "num_scans": 9,
+                },
+            },
+            acquisition_params={},
+            instrument_info={"instrument": "stub"},
+            raw_metadata={},
+        )
+
+
+class GridStubReader(BaseMSIReader):
+    """A source whose pixels each carry their own mobility point cloud.
+
+    ``has_shared_mobility_axis`` is False, as a Bruker TDF reader's is: a
+    frame is a point cloud and no two pixels are promised the same pairs.
+    """
+
+    def __init__(self, with_values: bool = True, mass_axis: Optional[NDArray] = None):
+        super().__init__(Path("stub_grid"))
+        self._with_values = with_values
+        self._mass_axis = MASS_AXIS if mass_axis is None else mass_axis
+        self.mobility_passes = 0
+
+    def _create_metadata_extractor(self) -> MetadataExtractor:
+        return _StubExtractor()
+
+    @property
+    def has_shared_mass_axis(self) -> bool:
+        return True
+
+    def get_common_mass_axis(self) -> NDArray[np.float64]:
+        return self._mass_axis.copy()
+
+    def iter_spectra(self, batch_size: Optional[int] = None) -> Generator:
+        for p, (x, y) in enumerate(PIXELS):
+            mzs, intensities = _summed(p)
+            yield (x, y, 0), mzs, intensities
+
+    @property
+    def has_ion_mobility(self) -> bool:
+        return True
+
+    @property
+    def has_shared_mobility_axis(self) -> bool:
+        return False
+
+    def get_mobility_axis(self) -> Optional[MobilityAxis]:
+        return MobilityAxis(
+            kind_accession="MS:1002815",
+            kind_name="inverse reduced ion mobility",
+            unit_accession="MS:1002814",
+            unit_name="volt-second per square centimeter",
+            values=SCAN_K0.copy() if self._with_values else None,
+            acq_range=(1.1, 1.5),
+            source="stub",
+        )
+
+    def iter_mobility_spectra(self, batch_size: Optional[int] = None) -> Generator:
+        self.mobility_passes += 1
+        for p, (x, y) in enumerate(PIXELS):
+            mzs, mobility, intensities = _cloud(p)
+            yield (x, y, 0), mzs, mobility, intensities
+
+    def close(self) -> None:
+        pass
+
+
+class _NoMobilityReader(GridStubReader):
+    @property
+    def has_ion_mobility(self) -> bool:
+        return False
+
+
+class TestGridRange:
+    def test_comes_from_the_values_not_the_declared_range(self):
+        # The declared acq_range is (1.1, 1.5) and so are the values here,
+        # but the values are what is read -- a reader that has none gets
+        # no grid rather than the declared range as a fallback.
+        assert mobility_grid_range(GridStubReader()) == pytest.approx((1.1, 1.5))
+        assert mobility_grid_range(GridStubReader(with_values=False)) is None
+
+
+class TestRefusals:
+    def test_a_source_without_mobility(self):
+        grid = build_mobility_grid(1.1, 1.5)
+        assert "no ion mobility" in str(
+            grid_refusal(_NoMobilityReader(), MASS_AXIS, grid)
+        )
+
+    def test_no_grid_at_all(self):
+        assert "no range to bin over" in str(
+            grid_refusal(GridStubReader(), MASS_AXIS, None)
+        )
+
+    def test_an_empty_mass_axis(self):
+        grid = build_mobility_grid(1.1, 1.5)
+        assert "mass axis is empty" in str(
+            grid_refusal(GridStubReader(), np.array([]), grid)
+        )
+
+    def test_a_grid_that_fits_is_not_refused(self):
+        axis = np.linspace(100.0, 1000.0, 78_125)
+        assert (
+            grid_refusal(GridStubReader(), axis, build_mobility_grid(1.1, 1.5)) is None
+        )
+
+
+class TestVarCeiling:
+    def test_the_bound_is_the_pairs_the_grid_spans(self):
+        axis = np.linspace(100.0, 1000.0, 100_000)
+        assert grid_var_bound(axis, build_mobility_grid(1.1, 1.5)) == 100_000 * 256
+
+    def test_a_bound_over_the_ceiling_is_not_itself_a_refusal(self):
+        # Real occupancy runs an order of magnitude below the bound (a
+        # measured 200-frame timsTOF acquisition occupied 3.9M of a
+        # possible 35.5M), so refusing on the bound would turn away
+        # conversions that fit ninefold over.
+        axis = np.linspace(100.0, 1000.0, 100_000)
+        grid = build_mobility_grid(1.1, 1.5)
+        assert grid_var_bound(axis, grid) > MAX_GRID_VAR_ENTRIES
+        assert grid_refusal(GridStubReader(), axis, grid) is None
+
+    def test_the_count_is_what_is_refused_with_the_number_printed(self):
+        assert var_ceiling_refusal(MAX_GRID_VAR_ENTRIES) is None
+        refusal = var_ceiling_refusal(MAX_GRID_VAR_ENTRIES + 1)
+        assert refusal is not None
+        assert f"{MAX_GRID_VAR_ENTRIES + 1:,}" in refusal
+        assert f"{MAX_GRID_VAR_ENTRIES:,}" in refusal
+        assert "--mobility-bins" in refusal
+
+
+# ----------------------------------------------------------------------
+# End to end: the table on a real store, down both write routes
+# ----------------------------------------------------------------------
+
+spatialdata = pytest.importorskip("spatialdata")
+
+
+def _convert(reader: BaseMSIReader, out: Path, streaming: bool, **kwargs):
+    from thyra.utils.windows_paths import prepare_zarr_output_path
+
+    out = prepare_zarr_output_path(out, "stub")
+    if streaming:
+        from thyra.converters.spatialdata.streaming_converter import (
+            StreamingSpatialDataConverter as Converter,
+        )
+    else:
+        from thyra.converters.spatialdata.spatialdata_2d_converter import (
+            SpatialData2DConverter as Converter,
+        )
+
+    converter = Converter(reader, out, dataset_id="stub", pixel_size_um=10.0, **kwargs)
+    assert converter.convert(), "conversion reported failure"
+    return out
+
+
+def _read(out: Path):
+    from thyra.utils.windows_paths import prepare_zarr_read_path
+
+    return spatialdata.read_zarr(prepare_zarr_read_path(out))
+
+
+def _row(table, x: int, y: int) -> np.ndarray:
+    obs = table.obs
+    mask = (obs["x"].to_numpy().astype(int) == x) & (
+        obs["y"].to_numpy().astype(int) == y
+    )
+    rows = np.flatnonzero(mask)
+    assert rows.size == 1
+    X = table.X[rows[0]]
+    return (
+        np.asarray(X.toarray()).ravel()
+        if hasattr(X, "toarray")
+        else np.asarray(X).ravel()
+    )
+
+
+@pytest.mark.parametrize("streaming", [False, True], ids=["in-memory", "streaming"])
+class TestGridTable:
+    def test_off_by_default_the_store_is_exactly_what_it_was(self, tmp_path, streaming):
+        reader = GridStubReader()
+        sdata = _read(_convert(reader, tmp_path / "s.zarr", streaming))
+        assert set(sdata.tables) == {"stub_z0"}
+        # The heatmap still costs its one pass; the grid costs none.
+        assert reader.mobility_passes == 1
+
+    def test_on_request_the_sibling_appears(self, tmp_path, streaming):
+        sdata = _read(
+            _convert(
+                GridStubReader(), tmp_path / "s.zarr", streaming, mobility_grid=True
+            )
+        )
+        assert set(sdata.tables) == {"stub_z0", "stub_z0_mobility"}
+        summed, grid = sdata.tables["stub_z0"], sdata.tables["stub_z0_mobility"]
+        assert summed.n_obs == grid.n_obs == 4
+        assert list(summed.obs.index) == list(grid.obs.index)
+        assert set(grid.obs["region"].astype(str)) == {"stub_z0_pixels"}
+
+    def test_var_is_the_frozen_contract(self, tmp_path, streaming):
+        sdata = _read(
+            _convert(
+                GridStubReader(), tmp_path / "s.zarr", streaming, mobility_grid=True
+            )
+        )
+        var = sdata.tables["stub_z0_mobility"].var
+        # Exactly the columns the shared-axis mechanism writes; a consumer
+        # must not be able to tell the two apart from the table.
+        assert list(var.columns) == ["mz", "mobility", "mz_index", "mobility_index"]
+        mz = var["mz"].to_numpy()
+        mobility = var["mobility"].to_numpy()
+        assert np.all(np.diff(mz) >= 0)
+        pairs = np.stack([mz, mobility], axis=1)
+        assert np.array_equal(pairs, pairs[np.lexsort((mobility, mz))])
+        assert len(set(map(tuple, pairs.tolist()))) == pairs.shape[0]
+        channels = var["mobility_index"].to_numpy()
+        assert channels.min() >= 0 and channels.max() <= MOBILITY_CHANNELS - 1
+        # 100 and 120 each split into two channels; the two points at 110
+        # share a cell and are one feature.
+        np.testing.assert_array_equal(var["mz_index"].to_numpy(), [0, 0, 1, 2, 2])
+        np.testing.assert_array_equal(channels, [12, 243, 129, 64, 68])
+        assert list(var.index) == [
+            "mz0_im12",
+            "mz0_im243",
+            "mz1_im129",
+            "mz2_im64",
+            "mz2_im68",
+        ]
+
+    def test_the_marginal_reproduces_the_summed_table_per_pixel(
+        self, tmp_path, streaming
+    ):
+        sdata = _read(
+            _convert(
+                GridStubReader(), tmp_path / "s.zarr", streaming, mobility_grid=True
+            )
+        )
+        summed = sdata.tables["stub_z0"]
+        grid = sdata.tables["stub_z0_mobility"]
+        mz_index = grid.var["mz_index"].to_numpy()
+        for x, y in PIXELS:
+            marginal = np.zeros(summed.n_vars)
+            np.add.at(marginal, mz_index, _row(grid, x, y))
+            np.testing.assert_allclose(marginal, _row(summed, x, y), rtol=0, atol=1e-12)
+
+    def test_the_mobility_dimension_buys_a_split(self, tmp_path, streaming):
+        sdata = _read(
+            _convert(
+                GridStubReader(), tmp_path / "s.zarr", streaming, mobility_grid=True
+            )
+        )
+        grid = sdata.tables["stub_z0_mobility"]
+        columns = np.flatnonzero(grid.var["mz_index"].to_numpy() == 0)
+        assert columns.size == 2
+        # One column of the summed table, two images that differ.
+        first = np.asarray(grid.X[:, columns[0]].todense()).ravel()
+        second = np.asarray(grid.X[:, columns[1]].todense()).ravel()
+        assert not np.allclose(first, second)
+
+    def test_the_uns_blocks_round_trip(self, tmp_path, streaming):
+        sdata = _read(
+            _convert(
+                GridStubReader(), tmp_path / "s.zarr", streaming, mobility_grid=True
+            )
+        )
+        summed = sdata.tables["stub_z0"]
+        grid = sdata.tables["stub_z0_mobility"]
+
+        block = grid.uns["mobility_grid"]
+        assert set(block) == {
+            "law",
+            "lower",
+            "upper",
+            "n_channels",
+            "channel_width",
+            "edges",
+        }
+        assert str(block["law"]) == "linear"
+        assert int(block["n_channels"]) == MOBILITY_CHANNELS
+        # The heatmap on the summed table and the grid on the sibling share
+        # their edges, which is what makes a box on one index the other.
+        np.testing.assert_array_equal(
+            np.asarray(block["edges"]),
+            np.asarray(summed.uns["mobility_heatmap"]["mobility_edges"]),
+        )
+        assert not any(":" in key for key in grid.uns)
+        # A shared-axis table has no such block; that absence is the only
+        # thing that says which mechanism filled the table.
+        assert "mobility_grid" not in summed.uns
+
+    def test_the_marginal_ratio_is_recorded_not_only_asserted(
+        self, tmp_path, streaming
+    ):
+        sdata = _read(
+            _convert(
+                GridStubReader(), tmp_path / "s.zarr", streaming, mobility_grid=True
+            )
+        )
+        block = sdata.tables["stub_z0_mobility"].uns["mobility_marginal"]
+        assert str(block["summed_table"]) == "stub_z0"
+        assert float(block["current_ratio"]) == pytest.approx(1.0)
+        assert float(block["current_ratio_pixel_min"]) == pytest.approx(1.0)
+        assert float(block["current_ratio_pixel_max"]) == pytest.approx(1.0)
+        if streaming:
+            # The streaming route writes the summed table straight to disk
+            # and never holds it, so the per-column deviation -- which
+            # needs both matrices -- is the one field it cannot state.
+            assert "max_relative_deviation" not in block
+        else:
+            assert float(block["max_relative_deviation"]) < 1e-12
+            assert float(block["max_absolute_deviation"]) < 1e-9
+
+    def test_the_metadata_block_names_the_grid(self, tmp_path, streaming):
+        from thyra.metadata.schema import read_msi_metadata_blocks
+        from thyra.utils.windows_paths import prepare_zarr_read_path
+
+        out = _convert(
+            GridStubReader(), tmp_path / "s.zarr", streaming, mobility_grid=True
+        )
+        blocks = read_msi_metadata_blocks(prepare_zarr_read_path(out))
+        mobility = blocks["stub_z0"]["ms_analysis"]["ion_mobility"]
+        assert mobility["resolved_table"] == "stub_z0_mobility"
+        assert mobility["grid"] == {
+            "law": "linear",
+            "lower": pytest.approx(1.1),
+            "upper": pytest.approx(1.5),
+            "n_channels": MOBILITY_CHANNELS,
+        }
+
+    def test_validate_accepts_the_table(self, tmp_path, streaming):
+        from thyra.metadata.schema import check_store_var_conventions
+        from thyra.utils.windows_paths import prepare_zarr_read_path
+
+        out = _convert(
+            GridStubReader(), tmp_path / "s.zarr", streaming, mobility_grid=True
+        )
+        results = check_store_var_conventions(prepare_zarr_read_path(out))
+        assert results, "no tables were checked"
+        for issues in results.values():
+            assert [i for i in issues if i.severity == "error"] == []
+
+    def test_the_channel_count_and_range_can_be_overridden(self, tmp_path, streaming):
+        sdata = _read(
+            _convert(
+                GridStubReader(),
+                tmp_path / "s.zarr",
+                streaming,
+                mobility_grid=True,
+                mobility_bins=8,
+                mobility_min=1.0,
+                mobility_max=1.5,
+            )
+        )
+        grid = sdata.tables["stub_z0_mobility"]
+        block = grid.uns["mobility_grid"]
+        assert int(block["n_channels"]) == 8
+        assert float(block["lower"]) == pytest.approx(1.0)
+        np.testing.assert_array_equal(
+            grid.var["mobility_index"].to_numpy(), [1, 7, 4, 3]
+        )
+        # Coarser channels merge the 1.201/1.207 pair into one feature.
+        assert grid.n_vars == 4
+
+    def test_a_source_with_no_axis_values_gets_no_table(self, tmp_path, streaming):
+        sdata = _read(
+            _convert(
+                GridStubReader(with_values=False),
+                tmp_path / "s.zarr",
+                streaming,
+                mobility_grid=True,
+            )
+        )
+        assert set(sdata.tables) == {"stub_z0"}
+
+    def test_a_source_over_the_var_ceiling_gets_no_table(
+        self, tmp_path, streaming, monkeypatch
+    ):
+        # The count decides, so the ceiling is lowered to below the count
+        # this fixture reaches rather than the axis being blown up to a
+        # size no test should convert.
+        import thyra.converters.spatialdata.mobility_table as module
+
+        monkeypatch.setattr(module, "MAX_GRID_VAR_ENTRIES", 4)
+        sdata = _read(
+            _convert(
+                GridStubReader(), tmp_path / "s.zarr", streaming, mobility_grid=True
+            )
+        )
+        assert set(sdata.tables) == {"stub_z0"}
+
+    def test_a_source_at_the_var_ceiling_still_gets_its_table(
+        self, tmp_path, streaming, monkeypatch
+    ):
+        import thyra.converters.spatialdata.mobility_table as module
+
+        monkeypatch.setattr(module, "MAX_GRID_VAR_ENTRIES", 5)
+        sdata = _read(
+            _convert(
+                GridStubReader(), tmp_path / "s.zarr", streaming, mobility_grid=True
+            )
+        )
+        assert sdata.tables["stub_z0_mobility"].n_vars == 5
+
+    def test_a_source_without_mobility_gets_no_table(self, tmp_path, streaming):
+        sdata = _read(
+            _convert(
+                _NoMobilityReader(), tmp_path / "s.zarr", streaming, mobility_grid=True
+            )
+        )
+        assert set(sdata.tables) == {"stub_z0"}
+        assert "mobility_grid" not in sdata.tables["stub_z0"].uns

--- a/thyra/__main__.py
+++ b/thyra/__main__.py
@@ -13,6 +13,7 @@ import click  # noqa: E402
 from thyra import __version__  # noqa: E402
 from thyra.convert import convert_msi  # noqa: E402
 from thyra.core.registry import detect_format  # noqa: E402
+from thyra.resampling.mobility_grid import MOBILITY_CHANNELS  # noqa: E402
 from thyra.utils.logging_config import setup_logging  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -387,10 +388,17 @@ class GroupedCommand(click.Command):
             "--no-mobility-table",
             "--mobility-heatmap",
             "--no-mobility-heatmap",
+            "--mobility-grid",
+            "--no-mobility-grid",
             "--msms-table",
             "--no-msms-table",
         ],
         "Logging": ["--log-level", "-v", "--log-file"],
+        "Ion mobility grid (advanced)": [
+            "--mobility-bins",
+            "--mobility-min",
+            "--mobility-max",
+        ],
         "Resampling (advanced)": [
             "--resample-method",
             "--mass-axis-type",
@@ -518,6 +526,18 @@ class GroupedCommand(click.Command):
     ),
 )
 @click.option(
+    "--mobility-grid/--no-mobility-grid",
+    default=False,
+    help=(
+        "When the source carries ion mobility per pixel rather than as a "
+        "shared feature list (Bruker TDF), bin the point cloud onto a common "
+        "mobility grid and write the same mobility-resolved sibling table "
+        "(default: disabled; one extra pass over the source and a much larger "
+        "table). Also switches the summed spectrum to --tdf-spectrum scan_sum "
+        "unless that was given explicitly, which moves the stored TIC"
+    ),
+)
+@click.option(
     "--msms-table/--no-msms-table",
     default=False,
     help=(
@@ -531,6 +551,38 @@ class GroupedCommand(click.Command):
     "--include-optical/--no-optical",
     default=True,
     help="Include optical images in output (default: True)",
+)
+# -- Ion mobility grid (advanced) --
+@click.option(
+    "--mobility-bins",
+    type=int,
+    default=MOBILITY_CHANNELS,
+    show_default=True,
+    help=(
+        "Mobility channels the grid divides the range into, for "
+        "--mobility-grid. The default is the mass-mobility heatmap's own "
+        "channel count over the same edges, so a box drawn on the heatmap "
+        "indexes grid channels directly; another value gives that up"
+    ),
+)
+@click.option(
+    "--mobility-min",
+    type=float,
+    default=None,
+    help=(
+        "Lower edge of the mobility grid, in the axis unit (1/K0 for TIMS). "
+        "Default: the smallest value the source's mobility axis holds, which "
+        "is where the heatmap starts"
+    ),
+)
+@click.option(
+    "--mobility-max",
+    type=float,
+    default=None,
+    help=(
+        "Upper edge of the mobility grid, in the axis unit. Default: the "
+        "largest value the source's mobility axis holds"
+    ),
 )
 # -- Logging --
 @click.option(
@@ -708,6 +760,10 @@ def main(
     include_optical: bool,
     mobility_table: bool,
     mobility_heatmap: bool,
+    mobility_grid: bool,
+    mobility_bins: int,
+    mobility_min: Optional[float],
+    mobility_max: Optional[float],
     msms_table: bool,
     intensity_threshold: Optional[float],
     tdf_spectrum: Optional[str],
@@ -801,6 +857,10 @@ def main(
         region=region,
         write_mobility_table=mobility_table,
         mobility_heatmap=mobility_heatmap,
+        mobility_grid=mobility_grid,
+        mobility_bins=mobility_bins,
+        mobility_min=mobility_min,
+        mobility_max=mobility_max,
         msms_table=msms_table,
     )
 

--- a/thyra/convert.py
+++ b/thyra/convert.py
@@ -96,13 +96,19 @@ def _validate_paths(input_path: Path, output_path: Path) -> bool:
 
 
 def _create_reader(
-    input_path: Path, reader_options: Optional[Dict[str, Any]] = None
+    input_path: Path,
+    reader_options: Optional[Dict[str, Any]] = None,
+    lossless_spectrum: bool = False,
 ) -> Tuple[Any, str]:
     """Create and return a reader for the input format.
 
     Args:
         input_path: Path to the input MSI data
         reader_options: Optional format-specific reader options (e.g., calibration settings)
+        lossless_spectrum: Ask the reader for the summed spectrum that
+            keeps all of the ion current, where it has a choice. Set when
+            a mobility grid table is being written, so the grid's
+            marginal reproduces the summed table exactly.
 
     Returns:
         Tuple of (reader instance, detected format string)
@@ -113,8 +119,53 @@ def _create_reader(
     logger.info(f"Using reader: {reader_class.__name__}")
 
     # Pass reader options to the reader if provided
-    options = reader_options or {}
+    options = dict(reader_options or {})
+    if lossless_spectrum:
+        _force_scan_sum(reader_class, options)
     return reader_class(input_path, **options), input_format
+
+
+def _force_scan_sum(reader_class: Any, options: Dict[str, Any]) -> None:
+    """Switch a TDF reader to the lossless summed spectrum, out loud.
+
+    A mobility grid table is built from the raw scans, so its marginal
+    over channels reproduces the summed table only when that table was
+    built from the same scans. The vendor centroid is a peak-picked
+    spectrum over the same ramp and keeps 80-90% of the ion current, so
+    with it the two tables of one store genuinely do not add up.
+
+    The switch moves the stored TIC by 13-21%, which reads as a bug if it
+    happens quietly, so it is said at WARNING -- and never applied over an
+    explicit ``--tdf-spectrum``, which is the caller saying they want the
+    other one and will live with the mismatch.
+    """
+    import inspect
+
+    if "tdf_spectrum" in options:
+        logger.warning(
+            "A mobility grid was asked for with --tdf-spectrum %s. The grid "
+            "reads raw scans, so its marginal over mobility channels will "
+            "not reproduce the summed table; uns['mobility_marginal'] on the "
+            "grid table records by how much.",
+            options["tdf_spectrum"],
+        )
+        return
+    try:
+        accepted = inspect.signature(reader_class.__init__).parameters
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return
+    if "tdf_spectrum" not in accepted:
+        return
+    options["tdf_spectrum"] = "scan_sum"
+    logger.warning(
+        "Writing a mobility grid table, so the summed spectrum is built with "
+        "--tdf-spectrum scan_sum instead of the default vendor centroid: the "
+        "grid's marginal over mobility channels must reproduce the summed "
+        "table, and only the lossless sum does. This moves the stored TIC by "
+        "13-21% against a default conversion of the same file. Pass "
+        "--tdf-spectrum vendor_centroid to keep the centroid and accept the "
+        "mismatch."
+    )
 
 
 def _determine_pixel_size(
@@ -336,6 +387,14 @@ def convert_msi(
             mass-mobility frame on the summed table as
             ``uns["mobility_heatmap"]`` whenever the source has an ion
             mobility dimension (Bruker TDF, imzML with a mobility array).
+            ``mobility_grid`` (default False) fills that same sibling for
+            a source that carries mobility per pixel rather than as a
+            shared feature axis (Bruker TDF) by binning the point cloud
+            onto a common mobility grid; ``mobility_bins`` (default 256,
+            the heatmap's own channel count), ``mobility_min`` and
+            ``mobility_max`` size that grid. Asking for it also switches
+            a TDF reader to ``tdf_spectrum="scan_sum"`` unless the caller
+            set that option explicitly, which moves the stored TIC.
             ``msms_table`` (default False) writes the demultiplexed MS/MS
             sibling table when the source isolates several precursors per
             pixel in disjoint mobility slices (Bruker PASEF).
@@ -425,8 +484,15 @@ def convert_msi(
         reader_options["region"] = region
 
     try:
-        # Create reader with format-specific options
-        reader, input_format = _create_reader(input_path, reader_options)
+        # Create reader with format-specific options. A mobility grid
+        # table decides the summed spectrum's semantics, so it has to be
+        # known before the reader is opened -- the choice is bound into
+        # the SDK handle.
+        reader, input_format = _create_reader(
+            input_path,
+            reader_options,
+            lossless_spectrum=bool(kwargs.get("mobility_grid", False)),
+        )
 
         # Determine pixel size
         final_pixel_size, pixel_size_source, pixel_size_detection_info = (

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -18,6 +18,12 @@ from ...core.base_reader import BaseMSIReader
 from ...metadata.types import ComprehensiveMetadata, EssentialMetadata
 from ...resampling import ResamplingDecisionTree, ResamplingMethod
 from ...resampling.gaps import zero_across_gaps
+from ...resampling.mobility_grid import (
+    MOBILITY_CHANNELS,
+    MobilityGrid,
+    build_mobility_grid,
+    report_channel_width,
+)
 from ...resampling.tic import preserved_tic, rescale_to_preserved_tic
 from ...resampling.types import ResamplingConfig
 from ...utils.zarr_atomic_write import install_windows_atomic_write_retry
@@ -258,6 +264,81 @@ def _calc_optical_scale_factors(
     return factors
 
 
+#: How far a marginal may sit from the column it mirrors, relative to the
+#: largest value in the summed table, and still be called exact. Summing
+#: the same float64 values in a different order is the only difference
+#: under ``--tdf-spectrum scan_sum``.
+_MARGINAL_TOLERANCE = 1e-9
+
+
+def _marginal_current(
+    table: Any, row_totals: Any, summed_key: str
+) -> Optional[Dict[str, Any]]:
+    """The current ratio alone, against per-pixel totals of the summed table.
+
+    What the streaming route can say without the summed matrix: the ratio
+    is the same number either way, since a marginal over every m/z bin of
+    a pixel is that pixel's row sum.
+    """
+    totals = np.asarray(row_totals, dtype=np.float64).ravel()
+    split = np.asarray(table.X.sum(axis=1)).ravel().astype(np.float64)
+    if split.size != totals.size or not totals.any():
+        return None
+    per_pixel = split / np.where(totals == 0, np.nan, totals)
+    return {
+        "summed_table": summed_key,
+        "current_ratio": float(split.sum() / totals.sum()),
+        "current_ratio_pixel_min": float(np.nanmin(per_pixel)),
+        "current_ratio_pixel_max": float(np.nanmax(per_pixel)),
+    }
+
+
+def _marginal_agreement(
+    table: Any, summed: Any, summed_key: str
+) -> Optional[Dict[str, Any]]:
+    """Compare a grid table's marginal over channels with the summed table.
+
+    The marginal is ``X`` collapsed onto ``var["mz_index"]``, which is a
+    single sparse product rather than a loop over m/z bins, and is
+    compared against the summed table cell by cell. ``None`` when the two
+    cannot be compared at all (an empty table, a summed table with no ion
+    current), which is not a disagreement and so is not recorded as one.
+    """
+    from scipy import sparse
+
+    mz_index = np.asarray(table.var["mz_index"].to_numpy(), dtype=np.int64)
+    n_axis = int(summed.n_vars)
+    if mz_index.size == 0 or int(mz_index.max()) >= n_axis:
+        return None
+    collapse = sparse.csr_matrix(
+        (
+            np.ones(mz_index.size, dtype=np.float64),
+            (np.arange(mz_index.size, dtype=np.int64), mz_index),
+        ),
+        shape=(int(mz_index.size), n_axis),
+    )
+    marginal = sparse.csr_matrix(table.X) @ collapse
+    whole = sparse.csr_matrix(summed.X)
+    if marginal.shape != whole.shape:
+        return None
+    total = np.asarray(whole.sum(axis=1)).ravel().astype(np.float64)
+    if not total.any():
+        return None
+    difference = marginal - whole
+    max_abs = float(np.abs(difference.data).max()) if difference.nnz else 0.0
+    scale = float(np.abs(whole.data).max()) if whole.nnz else 0.0
+    split = np.asarray(marginal.sum(axis=1)).ravel().astype(np.float64)
+    per_pixel = split / np.where(total == 0, np.nan, total)
+    return {
+        "summed_table": summed_key,
+        "current_ratio": float(split.sum() / total.sum()),
+        "current_ratio_pixel_min": float(np.nanmin(per_pixel)),
+        "current_ratio_pixel_max": float(np.nanmax(per_pixel)),
+        "max_absolute_deviation": max_abs,
+        "max_relative_deviation": float(max_abs / scale) if scale else 0.0,
+    }
+
+
 def _nn_map_to_bins(
     axis: NDArray[np.float64], mzs: NDArray[np.float64]
 ) -> NDArray[np.int_]:
@@ -397,6 +478,10 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         apply_optical_alignment: bool = True,
         write_mobility_table: bool = True,
         mobility_heatmap: bool = True,
+        mobility_grid: bool = False,
+        mobility_bins: int = MOBILITY_CHANNELS,
+        mobility_min: Optional[float] = None,
+        mobility_max: Optional[float] = None,
         msms_table: bool = False,
         **kwargs: Any,
     ) -> None:
@@ -432,6 +517,24 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 the raw scan read and store it on the summed table as
                 ``uns["mobility_heatmap"]`` (default: True). Costs one
                 extra pass over the source; see ``mobility_heatmap.py``.
+            mobility_grid: When the reader carries mobility per pixel
+                rather than as a shared feature axis (Bruker TDF), bin
+                the point cloud onto a common mobility grid and write the
+                result as the same ``{table}_mobility`` sibling
+                (default: False -- opt in, it costs an extra pass and a
+                far larger table). Ignored by a source that already
+                shares a feature axis, which needs no grid.
+            mobility_bins: Channels the grid divides the mobility range
+                into (default: 256). The default is the mass-mobility
+                heatmap's own channel count over the same edges, which is
+                what lets a box drawn on the heatmap index grid channels
+                directly; changing it gives that up.
+            mobility_min: Lower edge of the grid, in the axis unit.
+                ``None`` (default) takes the smallest mobility value the
+                source's axis actually holds, which is also where the
+                heatmap starts.
+            mobility_max: Upper edge of the grid; ``None`` takes the
+                largest value the axis holds.
             msms_table: When the source isolates several precursors per
                 pixel in disjoint mobility slices (Bruker PASEF), also
                 write them split apart as a demultiplexed sibling table
@@ -521,6 +624,16 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         # -- the element key it gets, so the MSI table's uns can name it.
         self._write_mobility_table = bool(write_mobility_table)
         self._mobility_table_key: Optional[str] = None
+        # The common mobility grid (see resampling/mobility_grid.py): the
+        # second way to fill the same sibling, for a source whose pixels
+        # each carry their own mobility values. Resolved once by
+        # _plan_mobility_table, so the MSI table's metadata block and the
+        # sibling describe the same grid.
+        self._mobility_grid_enabled = bool(mobility_grid)
+        self._mobility_bins = int(mobility_bins)
+        self._mobility_bounds = (mobility_min, mobility_max)
+        self._mobility_grid: Optional[MobilityGrid] = None
+        self._mobility_grid_resolved = False
         # The mass-mobility heatmap (see mobility_heatmap.py): built once
         # per conversion, on first demand, and shared by every uns block
         # that asks for it. ``_built`` distinguishes "not yet" from
@@ -929,22 +1042,120 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
     def _plan_mobility_table(self, table_key: str) -> Optional[str]:
         """The key of the mobility table this slice gets, or ``None``.
 
-        Decided before the MSI table's ``uns`` is built so the two agree.
+        Decided before the MSI table's ``uns`` is built so the two agree,
+        which for the grid route also means the grid itself is resolved
+        here: the summed table's metadata block names it, and the sibling
+        must be binned onto the very grid that was named.
+
+        Two mechanisms can fill the same key -- a shared feature axis
+        (nothing to decide) or a common grid (opt in) -- and a source that
+        allows neither gets no table, said by name rather than silently.
         """
         if not self._write_mobility_table:
             return None
         try:
-            if not (
-                getattr(self.reader, "has_ion_mobility", False)
-                and self.reader.has_shared_mobility_axis
-            ):
+            if not getattr(self.reader, "has_ion_mobility", False):
                 return None
+            shared = bool(self.reader.has_shared_mobility_axis)
         except Exception as e:  # pragma: no cover - reader-defined
             logger.warning("Could not inspect the mobility axis: %s", e)
             return None
         from .mobility_table import mobility_table_key
 
+        if shared:
+            return mobility_table_key(table_key)
+        if not self._mobility_grid_enabled:
+            logger.info(
+                "No mobility-resolved table: %s carries mobility per pixel "
+                "rather than as a shared feature axis. Pass --mobility-grid "
+                "to bin it onto a common mobility grid.",
+                type(self.reader).__name__,
+            )
+            return None
+        if not self._mobility_grid_resolved:
+            self._mobility_grid_resolved = True
+            self._mobility_grid = self._resolve_mobility_grid()
+        if self._mobility_grid is None:
+            return None
         return mobility_table_key(table_key)
+
+    def _resolve_mobility_grid(self) -> Optional[MobilityGrid]:
+        """The common mobility grid this conversion bins onto, or ``None``.
+
+        Bounds come from the axis values unless the caller overrode them:
+        the per-scan 1/K0 of a real file overhangs its declared
+        acquisition range, and the mass-mobility heatmap already bins over
+        the values, so anything else breaks the index-for-index mapping
+        between the two. Every refusal is said by name.
+        """
+        from .mobility_table import (
+            MAX_GRID_VAR_ENTRIES,
+            grid_refusal,
+            grid_var_bound,
+            mobility_grid_range,
+        )
+
+        if self._common_mass_axis is None:
+            logger.warning(
+                "No mobility-resolved table: the common mass axis is not "
+                "built yet, so the grid's m/z bins are unknown"
+            )
+            return None
+        try:
+            measured = mobility_grid_range(self.reader)
+        except Exception as e:  # pragma: no cover - reader-defined
+            logger.warning("Could not read the mobility axis values: %s", e)
+            return None
+        lower, upper = self._mobility_bounds
+        if measured is None and (lower is None or upper is None):
+            logger.warning(
+                "No mobility-resolved table: the source's mobility axis "
+                "carries no per-scan values to bin over (a reader opened "
+                "without its vendor library cannot supply them). Give "
+                "--mobility-min and --mobility-max to bin over a stated range."
+            )
+            return None
+        span = measured or (0.0, 0.0)
+        try:
+            grid = build_mobility_grid(
+                span[0] if lower is None else float(lower),
+                span[1] if upper is None else float(upper),
+                self._mobility_bins,
+            )
+        except ValueError as e:
+            logger.warning("No mobility-resolved table: %s", e)
+            return None
+        refusal = grid_refusal(self.reader, self._common_mass_axis, grid)
+        if refusal is not None:
+            logger.warning("No mobility-resolved table: %s", refusal)
+            return None
+        unit = None
+        axis = self.reader.get_mobility_axis()
+        if axis is not None and axis.unit_name:
+            unit = str(axis.unit_name)
+        logger.info(
+            "Mobility grid: %d %s channels over [%.5f, %.5f]%s",
+            grid.n_channels,
+            grid.law,
+            grid.lower,
+            grid.upper,
+            "" if unit is None else f" {unit}",
+        )
+        report_channel_width(grid)
+        bound = grid_var_bound(self._common_mass_axis, grid)
+        if bound > MAX_GRID_VAR_ENTRIES:
+            # A bound above the ceiling settles nothing -- real occupancy
+            # runs an order of magnitude below it -- so it is said and the
+            # source is read; the count decides (see var_ceiling_refusal).
+            logger.info(
+                "The mobility grid spans %s (m/z bin, channel) pairs, above "
+                "the var ceiling of %s. Most of them will be empty; the "
+                "table is refused only if the pairs that carry signal pass "
+                "the ceiling too.",
+                f"{bound:,}",
+                f"{MAX_GRID_VAR_ENTRIES:,}",
+            )
+        return grid
 
     def _attach_mobility_table(
         self,
@@ -953,6 +1164,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         region_key: str,
         obs: pd.DataFrame,
         z_value: Optional[int] = None,
+        summed_row_totals: Optional[NDArray[np.float64]] = None,
     ) -> None:
         """Build the mobility-resolved sibling of ``table_key`` and add it.
 
@@ -979,12 +1191,82 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 region_key,
                 sibling_uns,
                 z_value=z_value,
+                grid=self._mobility_grid,
             )
         except Exception as e:
             logger.error("Could not build the mobility-resolved table: %s", e)
             return
-        if table is not None:
-            data_structures["tables"][key] = table
+        if table is None:
+            return
+        if self._mobility_grid is not None:
+            self._record_mobility_marginal(
+                table,
+                data_structures["tables"].get(table_key),
+                table_key,
+                summed_row_totals,
+            )
+        data_structures["tables"][key] = table
+
+    @staticmethod
+    def _record_mobility_marginal(
+        table: Any,
+        summed: Any,
+        summed_key: str,
+        row_totals: Optional[NDArray[np.float64]] = None,
+    ) -> None:
+        """Say how far the grid table's marginal is from the summed table.
+
+        Summing a grid table's channels within one m/z bin must reproduce
+        that bin's column of the summed table: both are the same points,
+        binned the same way, differing only in whether mobility was kept.
+        Under ``--tdf-spectrum scan_sum`` that holds exactly; under the
+        vendor centroid it cannot, because the centroid is a peak-picked
+        spectrum over the same ramp and keeps 80-90% of the ion current
+        while the grid reads raw scans. A store whose two tables disagree
+        must say by how much rather than leave a reader to find it by
+        subtraction.
+
+        The streaming route writes the summed table straight to disk and
+        never holds it, so there ``row_totals`` -- the per-pixel ion
+        current that route already computed for the TIC image -- stands in
+        for it. The current ratio is then exactly the same number; only
+        the per-column deviation, which needs both matrices, is left out.
+        """
+        try:
+            if summed is not None:
+                block = _marginal_agreement(table, summed, summed_key)
+            elif row_totals is not None:
+                block = _marginal_current(table, row_totals, summed_key)
+            else:
+                return
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("Could not compare the mobility marginal: %s", e)
+            return
+        if block is None:
+            return
+        table.uns["mobility_marginal"] = block
+        deviation = block.get("max_relative_deviation")
+        exact = abs(float(block["current_ratio"]) - 1.0) <= _MARGINAL_TOLERANCE and (
+            deviation is None or float(deviation) <= _MARGINAL_TOLERANCE
+        )
+        log = logger.info if exact else logger.warning
+        log(
+            "The mobility grid table holds %.4fx the summed table's ion "
+            "current (per pixel %.4f to %.4f)%s. They agree exactly only "
+            "under --tdf-spectrum scan_sum; the vendor centroid is a "
+            "peak-picked spectrum over the same scans and keeps less of "
+            "the current.",
+            block["current_ratio"],
+            block["current_ratio_pixel_min"],
+            block["current_ratio_pixel_max"],
+            (
+                ""
+                if deviation is None
+                else "; the largest disagreement between a marginal over "
+                f"channels and its summed column is {deviation:.4g} of the "
+                "table's largest value"
+            ),
+        )
 
     def _plan_msms_table(self, table_key: str) -> Optional[str]:
         """The key of the demultiplexed MS/MS table this slice gets, or ``None``.
@@ -1128,6 +1410,11 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 source_format=info.get("source_format"),
                 processing=self._processing_provenance(),
                 mobility_resolved_table=self._mobility_table_key,
+                mobility_grid=(
+                    None
+                    if self._mobility_grid is None
+                    else self._mobility_grid.to_schema_report()
+                ),
                 fragmentation=self._fragmentation_report(),
                 msms_resolved_table=self._msms_table_key,
             )

--- a/thyra/converters/spatialdata/mobility_heatmap.py
+++ b/thyra/converters/spatialdata/mobility_heatmap.py
@@ -31,6 +31,11 @@ import numpy as np
 from numpy.typing import NDArray
 
 from ...core.base_reader import BaseMSIReader
+from ...resampling.mobility_grid import (
+    MOBILITY_CHANNELS,
+    build_mobility_grid,
+    linear_channel,
+)
 from .base_spatialdata_converter import _nn_map_to_bins
 
 logger = logging.getLogger(__name__)
@@ -40,12 +45,13 @@ logger = logging.getLogger(__name__)
 HEATMAP_MZ_BINS = 4000
 
 #: Number of mobility channels, exactly. This is an alignment anchor, not
-#: a rendering choice: the mobility-resolved grid table (the opt-in
-#: table of a later phase) defaults to the same 256 channels over the
-#: same edges, so a box drawn on the heatmap maps onto grid channels by
-#: integer index in both directions, with no resampling and no edge
-#: off-by-one. Change one and the other has to follow.
-HEATMAP_MOBILITY_CHANNELS = 256
+#: a rendering choice: the opt-in mobility grid table defaults to the same
+#: 256 channels over the same edges, so a box drawn on the heatmap maps
+#: onto grid channels by integer index in both directions, with no
+#: resampling and no edge off-by-one. It is literally the grid's own
+#: constant, and :func:`mobility_bin_edges` is the grid's own generator,
+#: so the two cannot drift apart.
+HEATMAP_MOBILITY_CHANNELS = MOBILITY_CHANNELS
 
 #: Points buffered before they are folded into the accumulator. One
 #: ``bincount`` over a few million entries is far cheaper than an
@@ -87,12 +93,13 @@ def mz_bin_edges(
 def mobility_bin_edges(
     lower: float, upper: float, channels: int = HEATMAP_MOBILITY_CHANNELS
 ) -> NDArray[np.float64]:
-    """``channels`` equal-width bins over ``[lower, upper]``, ascending."""
-    if not np.isfinite(lower) or not np.isfinite(upper) or upper <= lower:
-        raise ValueError(
-            f"The mobility range [{lower}, {upper}] has no extent to bin over"
-        )
-    return np.linspace(float(lower), float(upper), int(channels) + 1)
+    """``channels`` equal-width bins over ``[lower, upper]``, ascending.
+
+    The grid table's own linear generator, so the heatmap's edges and a
+    default grid's edges are the same array rather than two arrays that
+    happen to agree.
+    """
+    return build_mobility_grid(lower, upper, channels).edges
 
 
 class MobilityHeatmap:
@@ -168,10 +175,12 @@ class MobilityHeatmap:
             if mzs.size == 0:
                 return
         mz_bin = _nn_map_to_bins(axis, mzs) // self._step
-        channel = np.floor(
-            (mobility - self._mobility_lower) / self._mobility_span * self.n_mobility
+        channel = linear_channel(
+            mobility,
+            self._mobility_lower,
+            self._mobility_lower + self._mobility_span,
+            self.n_mobility,
         )
-        channel = np.clip(channel, 0, self.n_mobility - 1).astype(np.int64)
         self._buffer_cells.append(mz_bin.astype(np.int64) * self.n_mobility + channel)
         self._buffer_weights.append(intensities)
         self._buffered += int(mzs.size)

--- a/thyra/converters/spatialdata/mobility_table.py
+++ b/thyra/converters/spatialdata/mobility_table.py
@@ -274,6 +274,36 @@ def _feature_var(
 #: would turn away conversions that fit ninefold over.
 MAX_GRID_VAR_ENTRIES = 20_000_000
 
+#: Fractions of the memory free when the pass started that a grid table may
+#: be projected to need: warn past the first, refuse past the second.
+#: **This is a stopgap.** The summed table is memory-bounded -- the
+#: streaming route pre-scans, counts and scatters into a memmap -- while
+#: this accumulator holds its triples in RAM, so its memory is linear in
+#: the table's non-zeros with nothing else bounding it. The var ceiling
+#: above cannot help: it is checked after the triples have been
+#: concatenated, by which point the memory is already committed. Until this
+#: route grows a pre-scan of its own, the projection below is what stops a
+#: whole acquisition from taking the machine down instead of the user
+#: finding out the hard way. Fractions rather than a fixed size because the
+#: same table is routine on a workstation and fatal on a laptop.
+GRID_MEMORY_WARN_FRACTION = 0.25
+GRID_MEMORY_REFUSE_FRACTION = 0.5
+
+#: What to assume is free when the machine will not say (no ``psutil``, or
+#: it raised). Deliberately generous: a guess must not be what refuses a
+#: conversion that would have fitted.
+_ASSUMED_AVAILABLE_GB = 8.0
+
+#: Peak bytes per stored non-zero, over the accumulation and the sparse
+#: assembly together. Measured 2026-09-07: 20,455,979 non-zeros peaked at
+#: 1.82 GB above baseline, so 24 bytes of buffered triple carries about
+#: another 65 of concatenation, COO-to-CSC and the var frame built from it.
+_PEAK_BYTES_PER_NONZERO = 88
+
+#: Pixels to accumulate before the projection is trusted, so a refusal is
+#: never extrapolated from a handful of unrepresentative frames.
+_PROJECTION_MIN_PIXELS = 64
+
 
 def grid_var_bound(common_mass_axis: NDArray[np.float64], grid: MobilityGrid) -> int:
     """Every ``(m/z bin, channel)`` pair the grid spans: the size to beat.
@@ -295,6 +325,57 @@ def var_ceiling_refusal(n_features: int) -> Optional[str]:
         f"above the var ceiling of {MAX_GRID_VAR_ENTRIES:,}; resample to "
         f"fewer mass bins or ask for fewer mobility channels "
         f"(--mobility-bins)"
+    )
+
+
+def available_memory_gb() -> float:
+    """Memory free right now, in gibibytes, or a generous assumption."""
+    try:
+        import psutil
+
+        return float(psutil.virtual_memory().available) / 1024**3
+    except Exception as e:  # pragma: no cover - platform-defined
+        logger.debug("Could not read available memory: %s", e)
+        return _ASSUMED_AVAILABLE_GB
+
+
+def projected_memory_gb(n_nonzeros: int, n_pixels: int, n_obs: int) -> Optional[float]:
+    """What the finished table will need, from the pixels read so far.
+
+    Non-zeros per pixel is near enough constant across an image, which is
+    what makes the extrapolation honest. ``None`` until enough pixels have
+    been read for it to mean anything.
+    """
+    if n_pixels < _PROJECTION_MIN_PIXELS or n_pixels >= n_obs or n_pixels <= 0:
+        return None
+    projected = n_nonzeros / n_pixels * n_obs
+    return projected * _PEAK_BYTES_PER_NONZERO / 1024**3
+
+
+def memory_refusal(
+    n_nonzeros: int, n_pixels: int, n_obs: int, available_gb: Optional[float] = None
+) -> Optional[str]:
+    """Why a grid table this large must not be accumulated, or ``None``.
+
+    Projects the memory the finished table needs and refuses while it is
+    still hypothetical, rather than after it has been allocated -- which is
+    the one thing the var ceiling cannot do, sitting as it does past the
+    concatenation.
+    """
+    gb = projected_memory_gb(n_nonzeros, n_pixels, n_obs)
+    if gb is None:
+        return None
+    free = available_memory_gb() if available_gb is None else float(available_gb)
+    if gb <= free * GRID_MEMORY_REFUSE_FRACTION:
+        return None
+    projected = int(n_nonzeros / n_pixels * n_obs)
+    return (
+        f"the table is on course for {projected:,} non-zeros over {n_obs:,} "
+        f"pixels, which needs about {gb:.1f} GB -- more than half the "
+        f"{free:.1f} GB free on this machine. This route holds the whole "
+        f"table in RAM rather than scattering it to disk the way the summed "
+        f"table does. Convert one --region at a time, resample to fewer mass "
+        f"bins, or ask for fewer mobility channels (--mobility-bins)"
     )
 
 
@@ -339,10 +420,12 @@ class _GridAccumulator:
         axis: NDArray[np.float64],
         row_for: RowLookup,
         grid: MobilityGrid,
+        n_obs: int,
     ) -> None:
         self._axis = axis
         self._row_for = row_for
         self._grid = grid
+        self._n_obs = int(n_obs)
         self._rows: List[NDArray[np.int64]] = []
         self._keys: List[NDArray[np.int64]] = []
         self._data: List[NDArray[np.float64]] = []
@@ -350,6 +433,15 @@ class _GridAccumulator:
         self.n_skipped = 0
         self.n_dropped = 0
         self.n_points = 0
+        self.n_nonzeros = 0
+        #: Set once the projected table stops fitting in memory; the caller
+        #: stops reading and writes no table.
+        self.refusal: Optional[str] = None
+        # Read once, not per pixel: the projection is checked every
+        # _PROJECTION_MIN_PIXELS pixels and asking the OS how much memory
+        # is free is a syscall.
+        self._available_gb: Optional[float] = None
+        self._warned_memory = False
 
     def add(
         self,
@@ -387,6 +479,41 @@ class _GridAccumulator:
         self._rows.append(np.full(keys.size, row, dtype=np.int64))
         self._keys.append(keys)
         self._data.append(values)
+        self.n_nonzeros += int(keys.size)
+        if self.refusal is None and self.n_pixels % _PROJECTION_MIN_PIXELS == 0:
+            self._check_memory()
+
+    def _check_memory(self) -> None:
+        """Project the finished table's memory; warn once, then refuse.
+
+        The warning is the point: on a machine that can take the table it
+        is the only notice the user gets that this route holds the whole
+        thing in RAM, and it arrives early enough to stop the run.
+        """
+        gb = projected_memory_gb(self.n_nonzeros, self.n_pixels, self._n_obs)
+        if gb is None:
+            return
+        if self._available_gb is None:
+            self._available_gb = available_memory_gb()
+        free = self._available_gb
+        if gb > free * GRID_MEMORY_REFUSE_FRACTION:
+            self.refusal = memory_refusal(
+                self.n_nonzeros, self.n_pixels, self._n_obs, available_gb=free
+            )
+            return
+        if not self._warned_memory and gb > free * GRID_MEMORY_WARN_FRACTION:
+            self._warned_memory = True
+            logger.warning(
+                "The mobility grid table is on course for about %.1f GB of "
+                "memory (%s free): this route accumulates the whole table in "
+                "RAM rather than scattering it to disk the way the summed "
+                "table does. It will be refused past %.1f GB. Convert one "
+                "--region at a time, or resample to fewer mass bins, if this "
+                "machine cannot take it.",
+                gb,
+                f"{free:.1f} GB",
+                free * GRID_MEMORY_REFUSE_FRACTION,
+            )
 
     def _cells(
         self,
@@ -488,9 +615,19 @@ def _build_from_grid(
 ) -> Optional[Tuple[sparse.csc_matrix, pd.DataFrame]]:
     """Bin every pixel's point cloud onto the grid; ``(matrix, var)`` or ``None``."""
     axis = np.asarray(common_mass_axis, dtype=np.float64)
-    accumulator = _GridAccumulator(axis, row_for, grid)
+    accumulator = _GridAccumulator(axis, row_for, grid, n_obs)
     for coords, mzs, mobility, intensities in reader.iter_mobility_spectra():
         accumulator.add(coords, mzs, mobility, intensities)
+        if accumulator.refusal is not None:
+            # Stop reading rather than finish a pass whose result cannot be
+            # held. Nothing is written and the summed table is untouched.
+            logger.warning(
+                "No mobility-resolved table: %s (projected after %d of %d " "pixels)",
+                accumulator.refusal,
+                accumulator.n_pixels,
+                n_obs,
+            )
+            return None
     accumulated = accumulator.matrix(n_obs)
     if accumulated is None:
         return None

--- a/thyra/converters/spatialdata/mobility_table.py
+++ b/thyra/converters/spatialdata/mobility_table.py
@@ -1,10 +1,25 @@
 """The mobility-resolved table: pixels x (m/z, mobility) features.
 
-The MSI table Thyra always writes is summed over ion mobility. When the
-source shares one set of (m/z, mobility) feature pairs across every pixel
--- a continuous imzML export with a mobility array, as TIMSImaging and
-TIMSCONVERT write -- those pairs are already a feature list, and this
-module writes them as a second table in the same store:
+The MSI table Thyra always writes is summed over ion mobility. This
+module writes what it summed over as a second table in the same store,
+filled by whichever of two mechanisms the source allows:
+
+- **a shared feature axis.** A continuous imzML export with a mobility
+  array (TIMSImaging, TIMSCONVERT) hands every pixel the same set of
+  (m/z, mobility) pairs, so the pairs are already a feature list and
+  nothing is binned.
+- **a common mobility grid.** A Bruker TDF pixel is its own point cloud
+  with no pairs shared across pixels, so the continuum is binned onto the
+  channels of a :class:`~thyra.resampling.mobility_grid.MobilityGrid`
+  and ``(m/z bin, channel)`` becomes the feature axis.
+
+The two produce the *same kind of table* -- same key, same columns, same
+sort, same discriminator -- and a consumer must not need to tell them
+apart to read either. What says which mechanism filled it is
+``uns["mobility_grid"]``, present only for a binned one, and that is a
+description rather than a structural difference.
+
+Either way:
 
 - same ``obs`` rows and the same ``region`` as the MSI table, so every ROI,
   transform and registration already resolves against it;
@@ -28,6 +43,7 @@ from numpy.typing import NDArray
 from scipy import sparse
 
 from ...core.base_reader import BaseMSIReader
+from ...resampling.mobility_grid import MobilityGrid
 
 logger = logging.getLogger(__name__)
 
@@ -246,6 +262,284 @@ def _feature_var(
     return var, int(unique_mobility.size)
 
 
+# ----------------------------------------------------------------------
+# The common-grid mechanism: a per-pixel point cloud, binned
+# ----------------------------------------------------------------------
+
+#: Features a grid table's ``var`` may hold before the grid is refused --
+#: occupied ``(m/z bin, mobility channel)`` pairs, not the pairs the grid
+#: spans. The two differ by an order of magnitude on real data (a measured
+#: 200-frame timsTOF acquisition occupied 3.9M of a possible 35.5M), which
+#: is why the count is checked and not the bound: refusing on the bound
+#: would turn away conversions that fit ninefold over.
+MAX_GRID_VAR_ENTRIES = 20_000_000
+
+
+def grid_var_bound(common_mass_axis: NDArray[np.float64], grid: MobilityGrid) -> int:
+    """Every ``(m/z bin, channel)`` pair the grid spans: the size to beat.
+
+    Knowable before reading anything, and a true upper bound on the
+    table's ``var`` -- so a grid whose bound already fits certainly fits.
+    A bound above the ceiling decides nothing on its own, since real
+    occupancy is far below it; that case is read and then counted.
+    """
+    return int(np.asarray(common_mass_axis).size) * int(grid.n_channels)
+
+
+def var_ceiling_refusal(n_features: int) -> Optional[str]:
+    """Why a grid table this wide must not be built, or ``None``."""
+    if n_features <= MAX_GRID_VAR_ENTRIES:
+        return None
+    return (
+        f"the grid occupies {n_features:,} (m/z bin, mobility channel) pairs, "
+        f"above the var ceiling of {MAX_GRID_VAR_ENTRIES:,}; resample to "
+        f"fewer mass bins or ask for fewer mobility channels "
+        f"(--mobility-bins)"
+    )
+
+
+def grid_refusal(
+    reader: BaseMSIReader,
+    common_mass_axis: NDArray[np.float64],
+    grid: Optional[MobilityGrid],
+) -> Optional[str]:
+    """Why this source must not be binned onto a common grid, or ``None``.
+
+    The refusals knowable before the source is read. Every answer is a
+    property of the source, so the answer is to say which one failed and
+    write no table -- never to bin something that is not a continuum. The
+    size ceiling is not among them: it is a property of the data, checked
+    on the real count in :func:`var_ceiling_refusal`.
+    """
+    if not reader.has_ion_mobility:
+        return "the source has no ion mobility dimension"
+    if grid is None:
+        return (
+            "the source's mobility axis gives no range to bin over; a grid "
+            "needs the per-scan mobility values, which a reader opened "
+            "without its vendor library cannot supply"
+        )
+    if int(np.asarray(common_mass_axis).size) == 0:
+        return "the common mass axis is empty"
+    return None
+
+
+class _GridAccumulator:
+    """The ``(pixel, m/z bin, mobility channel)`` cells of one slice.
+
+    A pixel's raw cloud carries many points per cell -- that is what a
+    TIMS ramp is -- so each pixel is collapsed onto its own occupied cells
+    before anything is buffered. The matrix would sum the duplicates
+    anyway; doing it per pixel is what keeps the accumulator the size of
+    the answer rather than the size of the source.
+    """
+
+    def __init__(
+        self,
+        axis: NDArray[np.float64],
+        row_for: RowLookup,
+        grid: MobilityGrid,
+    ) -> None:
+        self._axis = axis
+        self._row_for = row_for
+        self._grid = grid
+        self._rows: List[NDArray[np.int64]] = []
+        self._keys: List[NDArray[np.int64]] = []
+        self._data: List[NDArray[np.float64]] = []
+        self.n_pixels = 0
+        self.n_skipped = 0
+        self.n_dropped = 0
+        self.n_points = 0
+
+    def add(
+        self,
+        coords: Coords,
+        mzs: NDArray[np.float64],
+        mobility: NDArray[np.float64],
+        intensities: NDArray[np.float64],
+    ) -> None:
+        """Fold one pixel's ``(m/z, mobility, intensity)`` points in."""
+        row = self._row_for(coords)
+        if row is None:
+            self.n_skipped += 1
+            return
+        self.n_pixels += 1
+        mzs = np.asarray(mzs, dtype=np.float64)
+        if mzs.size == 0:
+            return
+        mobility = np.asarray(mobility, dtype=np.float64)
+        intensities = np.asarray(intensities, dtype=np.float64)
+        # "In range" is the summed table's own rule: a peak outside the
+        # mass axis is dropped there and must be dropped here, or the
+        # marginal over channels would exceed the column it mirrors.
+        in_range = (mzs >= self._axis[0]) & (mzs <= self._axis[-1])
+        if not in_range.all():
+            self.n_dropped += int(mzs.size - in_range.sum())
+            mzs = mzs[in_range]
+            mobility = mobility[in_range]
+            intensities = intensities[in_range]
+            if mzs.size == 0:
+                return
+        self.n_points += int(mzs.size)
+        keys, values = self._cells(mzs, mobility, intensities)
+        if keys.size == 0:
+            return
+        self._rows.append(np.full(keys.size, row, dtype=np.int64))
+        self._keys.append(keys)
+        self._data.append(values)
+
+    def _cells(
+        self,
+        mzs: NDArray[np.float64],
+        mobility: NDArray[np.float64],
+        intensities: NDArray[np.float64],
+    ) -> Tuple[NDArray[np.int64], NDArray[np.float64]]:
+        """One entry per occupied cell of this pixel, with its summed current."""
+        from .base_spatialdata_converter import _nn_map_to_bins
+
+        # Ascending flat key is ascending (mz, mobility), which is the
+        # order var wants, for free.
+        keys = _nn_map_to_bins(self._axis, mzs).astype(
+            np.int64
+        ) * self._grid.n_channels + self._grid.assign(mobility).astype(np.int64)
+        unique_keys, inverse = np.unique(keys, return_inverse=True)
+        summed = np.bincount(
+            np.asarray(inverse).ravel(), weights=intensities, minlength=unique_keys.size
+        )
+        nonzero = summed != 0
+        return unique_keys[nonzero], summed[nonzero]
+
+    def matrix(
+        self, n_obs: int
+    ) -> Optional[Tuple[sparse.csc_matrix, NDArray[np.int64]]]:
+        """The pixels x features matrix and the flat cell keys it is built on.
+
+        Only cells that carry ion current somewhere become features: the
+        grid spans mass bins x channels, and a real acquisition occupies a
+        small, structured part of it.
+        """
+        if self.n_skipped:
+            logger.warning(
+                "%d mobility spectra had no row in the MSI table and were skipped",
+                self.n_skipped,
+            )
+        if self.n_dropped:
+            logger.warning(
+                "%d mobility points fell outside the mass axis and were "
+                "dropped from the mobility-resolved table",
+                self.n_dropped,
+            )
+        if not self._rows:
+            logger.warning(
+                "No mobility spectra matched the MSI table; no mobility table written"
+            )
+            return None
+        keys = np.concatenate(self._keys)
+        unique_keys = np.unique(keys)
+        # The var ceiling, on the count rather than on the bound: this is
+        # the first moment the real number is known, and it is checked
+        # before the labels and the matrix are built rather than after.
+        refusal = var_ceiling_refusal(int(unique_keys.size))
+        if refusal is not None:
+            logger.warning("No mobility-resolved table: %s", refusal)
+            return None
+        columns = np.searchsorted(unique_keys, keys)
+        matrix = sparse.coo_matrix(
+            (np.concatenate(self._data), (np.concatenate(self._rows), columns)),
+            shape=(n_obs, int(unique_keys.size)),
+        ).tocsc()
+        return matrix, unique_keys
+
+
+def _grid_feature_var(
+    unique_keys: NDArray[np.int64],
+    axis: NDArray[np.float64],
+    grid: MobilityGrid,
+) -> pd.DataFrame:
+    """The ``var`` of a grid table -- the same columns a shared axis writes.
+
+    ``mz`` is the common axis entry the points were mapped to and
+    ``mobility`` the centre of the channel they fell in, so both are bin
+    representatives rather than measured values. The pair is unique by
+    construction (one feature per occupied cell) and the flat key's order
+    is already lexicographic ``(mz, mobility)``.
+    """
+    n_channels = int(grid.n_channels)
+    mz_index = (unique_keys // n_channels).astype(np.int64)
+    mobility_index = (unique_keys % n_channels).astype(np.int64)
+    centres = grid.centres
+    return pd.DataFrame(
+        {
+            "mz": axis[mz_index],
+            "mobility": centres[mobility_index],
+            "mz_index": mz_index,
+            "mobility_index": mobility_index,
+        },
+        index=_var_labels(mz_index, mobility_index),
+    )
+
+
+def _build_from_grid(
+    reader: BaseMSIReader,
+    row_for: RowLookup,
+    common_mass_axis: NDArray[np.float64],
+    grid: MobilityGrid,
+    n_obs: int,
+) -> Optional[Tuple[sparse.csc_matrix, pd.DataFrame]]:
+    """Bin every pixel's point cloud onto the grid; ``(matrix, var)`` or ``None``."""
+    axis = np.asarray(common_mass_axis, dtype=np.float64)
+    accumulator = _GridAccumulator(axis, row_for, grid)
+    for coords, mzs, mobility, intensities in reader.iter_mobility_spectra():
+        accumulator.add(coords, mzs, mobility, intensities)
+    accumulated = accumulator.matrix(n_obs)
+    if accumulated is None:
+        return None
+    matrix, unique_keys = accumulated
+    var = _grid_feature_var(unique_keys, axis, grid)
+    logger.info(
+        "Mobility grid: %d points over %d pixels onto %d occupied "
+        "(m/z bin, channel) cells of %d x %d, %d channels used",
+        accumulator.n_points,
+        accumulator.n_pixels,
+        int(var.shape[0]),
+        int(axis.size),
+        grid.n_channels,
+        int(np.unique(var["mobility_index"].to_numpy()).size),
+    )
+    return matrix, var
+
+
+# ----------------------------------------------------------------------
+# The shared-axis mechanism, and the entry point over both
+# ----------------------------------------------------------------------
+
+
+def _build_from_shared_axis(
+    reader: BaseMSIReader,
+    row_for: RowLookup,
+    common_mass_axis: NDArray[np.float64],
+    n_obs: int,
+) -> Optional[Tuple[sparse.csc_matrix, pd.DataFrame]]:
+    """Scatter the source's own feature pairs; ``(matrix, var)`` or ``None``."""
+    features = reader.get_shared_mobility_features()
+    if features is None or features[0].size == 0:
+        return None
+    unique_pairs, source_to_feature = _feature_axis(*features)
+    matrix = _accumulate(reader, row_for, unique_pairs, source_to_feature, n_obs)
+    if matrix is None:
+        return None
+    var, n_mobility_values = _feature_var(unique_pairs, common_mass_axis)
+    logger.info(
+        "Mobility-resolved table: %d pixels x %d (m/z, mobility) features, "
+        "%d non-zeros, %d distinct mobility values",
+        n_obs,
+        int(var.shape[0]),
+        int(matrix.nnz),
+        n_mobility_values,
+    )
+    return matrix, var
+
+
 def build_mobility_table(
     reader: BaseMSIReader,
     obs: pd.DataFrame,
@@ -255,14 +549,21 @@ def build_mobility_table(
     uns: Dict[str, Any],
     z_value: Optional[int] = None,
     pixel_key: Optional[Callable[[Coords], Optional[str]]] = None,
+    grid: Optional[MobilityGrid] = None,
 ) -> Optional[Any]:
     """Build the mobility-resolved table for one MSI table, or ``None``.
 
+    A source with a shared feature axis is read off it; one without is
+    binned onto ``grid`` when the caller supplied one, and gets no table
+    when it did not. The two tables are indistinguishable apart from
+    ``uns["mobility_grid"]``.
+
     Args:
-        reader: The source reader; must report a shared mobility axis.
+        reader: The source reader; must report an ion mobility dimension.
         obs: The MSI table's ``obs`` (its rows define this table's rows; it
             needs ``x`` and ``y`` columns, and ``z`` when the store is 3D).
-        common_mass_axis: The MSI table's ``var["mz"]``, for ``mz_index``.
+        common_mass_axis: The MSI table's ``var["mz"]``, for ``mz_index``
+            and, on the grid route, for the m/z binning itself.
         slice_key: The MSI table's element key (``{id}_z0``).
         region_key: The shapes element both tables annotate.
         uns: The provenance block to store on the table (already built).
@@ -270,43 +571,54 @@ def build_mobility_table(
             column; pixels on other planes are skipped.
         pixel_key: Optional override mapping a reader coordinate to an
             ``obs`` index label; the default matches on ``(x, y[, z])``.
+        grid: The common mobility grid to bin a per-pixel source onto.
+            ``None`` (the default) leaves such a source with the summed
+            table only.
 
     Returns:
-        A ``TableModel``-parsed AnnData, or ``None`` when the reader has no
-        shared mobility axis (logged at info level with the reason).
+        A ``TableModel``-parsed AnnData, or ``None`` when no table can be
+        written (logged at info level with the reason).
     """
     if not reader.has_ion_mobility:
         return None
-    if not reader.has_shared_mobility_axis:
-        logger.info(
-            "Source carries ion mobility per pixel rather than a shared feature "
-            "axis; the mobility-resolved table needs a common mobility grid, "
-            "which is not available yet, so only the summed MSI table is written"
-        )
+    n_obs = int(len(obs))
+    row_for = row_lookup(obs, z_value, pixel_key)
+    grid_uns: Optional[Dict[str, Any]] = None
+    if reader.has_shared_mobility_axis:
+        built = _build_from_shared_axis(reader, row_for, common_mass_axis, n_obs)
+    else:
+        refusal = grid_refusal(reader, common_mass_axis, grid)
+        if refusal is not None or grid is None:
+            logger.info(
+                "No mobility-resolved table: the source carries mobility per "
+                "pixel rather than as a shared feature axis, and %s",
+                refusal or "no common mobility grid was asked for",
+            )
+            return None
+        built = _build_from_grid(reader, row_for, common_mass_axis, grid, n_obs)
+        grid_uns = grid.to_uns()
+    if built is None:
         return None
-    features = reader.get_shared_mobility_features()
-    if features is None or features[0].size == 0:
-        return None
+    matrix, var = built
+    return _assemble(matrix, var, obs, region_key, slice_key, uns, grid_uns)
 
+
+def _assemble(
+    matrix: sparse.csc_matrix,
+    var: pd.DataFrame,
+    obs: pd.DataFrame,
+    region_key: str,
+    slice_key: str,
+    uns: Dict[str, Any],
+    grid_uns: Optional[Dict[str, Any]],
+) -> Any:
+    """Wrap a matrix and its ``var`` as the store's mobility table."""
     from anndata import AnnData
     from spatialdata.models import TableModel
 
     from .base_spatialdata_converter import _jsonify_string_lists
 
-    unique_pairs, source_to_feature = _feature_axis(*features)
     n_obs = int(len(obs))
-    matrix = _accumulate(
-        reader,
-        row_lookup(obs, z_value, pixel_key),
-        unique_pairs,
-        source_to_feature,
-        n_obs,
-    )
-    if matrix is None:
-        return None
-
-    var, n_mobility_values = _feature_var(unique_pairs, common_mass_axis)
-
     table_obs = obs.copy()
     table_obs["region"] = pd.Categorical([region_key] * n_obs)
     table_obs["instance_key"] = table_obs.index.astype(str)
@@ -316,18 +628,31 @@ def build_mobility_table(
     # String lists become JSON strings, as everywhere else in uns: a list of
     # strings does not round-trip through zarr on numpy 2.1-2.2.
     adata.uns["feature_axis"] = _jsonify_string_lists(feature_axis_block(slice_key))
-
-    logger.info(
-        "Mobility-resolved table: %d pixels x %d (m/z, mobility) features, "
-        "%d non-zeros, %d distinct mobility values",
-        n_obs,
-        int(var.shape[0]),
-        int(matrix.nnz),
-        n_mobility_values,
-    )
+    if grid_uns is not None:
+        adata.uns["mobility_grid"] = grid_uns
     return TableModel.parse(
         adata,
         region=region_key,
         region_key="region",
         instance_key="instance_key",
     )
+
+
+def mobility_grid_range(reader: BaseMSIReader) -> Optional[Tuple[float, float]]:
+    """The range to bin a per-pixel source's mobility over, or ``None``.
+
+    The axis *values* decide, and only the values: the per-scan 1/K0 of a
+    real Bruker file overhangs its declared ``OneOverK0AcqRange`` by a few
+    scans, the mass-mobility heatmap already bins over the values, and a
+    grid that used the declared range instead would not index the heatmap.
+    A reader that cannot supply per-scan values (opened without its vendor
+    library) has no grid, which is a refusal rather than a fallback.
+    """
+    axis = reader.get_mobility_axis()
+    if axis is None or axis.values is None:
+        return None
+    finite = axis.values[np.isfinite(axis.values)]
+    if not finite.size:
+        return None
+    lower, upper = float(finite.min()), float(finite.max())
+    return (lower, upper) if upper > lower else None

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -1928,7 +1928,17 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
             )
             obs.index.name = "instance_id"
             self._attach_mobility_table(
-                data_structures, slice_id, region_key, obs, z_value=0
+                data_structures,
+                slice_id,
+                region_key,
+                obs,
+                z_value=0,
+                # The summed table went straight to disk on this route and
+                # is not in hand; its per-pixel ion current is, because the
+                # TIC image is exactly that.
+                summed_row_totals=np.asarray(tic_values, dtype=np.float64).ravel()[
+                    kept
+                ],
             )
             self._attach_msms_table(
                 data_structures, slice_id, region_key, obs, z_value=0

--- a/thyra/metadata/schema/builder.py
+++ b/thyra/metadata/schema/builder.py
@@ -16,6 +16,7 @@ from .models import (
     Fragmentation,
     IonMobility,
     IsolationWindow,
+    MobilityGrid,
     MSAnalysis,
     MSIMetadata,
     PixelSizeUm,
@@ -135,6 +136,7 @@ def _build_ms_analysis(
     pixel_size_um: Tuple[float, float],
     source_format: Optional[str],
     mobility_resolved_table: Optional[str] = None,
+    mobility_grid: Optional[Dict[str, Any]] = None,
     fragmentation: Any = None,
     msms_resolved_table: Optional[str] = None,
 ) -> MSAnalysis:
@@ -154,7 +156,7 @@ def _build_ms_analysis(
     )
 
     ion_mobility = _build_ion_mobility(
-        format_specific.get("ion_mobility"), mobility_resolved_table
+        format_specific.get("ion_mobility"), mobility_resolved_table, mobility_grid
     )
     if ion_mobility is not None:
         fields["ion_mobility"] = ion_mobility
@@ -181,7 +183,9 @@ def _optional_term(accession: Any) -> Optional[Any]:
 
 
 def _build_ion_mobility(
-    reported: Any, resolved_table: Optional[str] = None
+    reported: Any,
+    resolved_table: Optional[str] = None,
+    grid: Optional[Dict[str, Any]] = None,
 ) -> Optional[IonMobility]:
     """The mobility block from what a reader's extractor reported.
 
@@ -191,10 +195,20 @@ def _build_ion_mobility(
     is not the same as "no mobility". A resolved table written beside
     the summed one is named here whatever the extractor said, since its
     existence proves the dimension.
+
+    ``grid`` is present only when that table was *binned* onto a common
+    mobility grid rather than read off a shared feature axis. It is the
+    one thing in the store that says which of the two mechanisms filled
+    the table, and it is a description: the table itself is the same
+    shape either way.
     """
     if not isinstance(reported, dict) or "present" not in reported:
         if resolved_table:
-            return IonMobility(present=True, resolved_table=resolved_table)
+            return IonMobility(
+                present=True,
+                resolved_table=resolved_table,
+                grid=_mobility_grid(grid),
+            )
         return None
     present = bool(reported["present"])
     if not present and not resolved_table:
@@ -203,8 +217,32 @@ def _build_ion_mobility(
     fields: Dict[str, Any] = {"present": True}
     if resolved_table:
         fields["resolved_table"] = resolved_table
+    grid_block = _mobility_grid(grid)
+    if grid_block is not None:
+        fields["grid"] = grid_block
     fields.update(_mobility_axis_fields(reported))
     return IonMobility(**fields)
+
+
+def _mobility_grid(reported: Any) -> Optional[MobilityGrid]:
+    """The grid block from what the converter resolved, or ``None``.
+
+    Checked for shape rather than trusted, like everything else here: a
+    grid that will not validate is dropped, since an invented one would
+    let a consumer map a heatmap box onto channels that do not exist.
+    """
+    if not isinstance(reported, dict):
+        return None
+    try:
+        return MobilityGrid(
+            law=str(reported["law"]),
+            lower=float(reported["lower"]),
+            upper=float(reported["upper"]),
+            n_channels=int(reported["n_channels"]),
+        )
+    except (KeyError, TypeError, ValueError) as e:
+        logger.debug("Mobility grid block is not usable and was dropped: %s", e)
+        return None
 
 
 def _mobility_axis_fields(reported: Dict[str, Any]) -> Dict[str, Any]:
@@ -320,6 +358,7 @@ def build_msi_metadata(
     source_format: Optional[str] = None,
     processing: Optional[List[ProcessingStep]] = None,
     mobility_resolved_table: Optional[str] = None,
+    mobility_grid: Optional[Dict[str, Any]] = None,
     fragmentation: Any = None,
     msms_resolved_table: Optional[str] = None,
 ) -> MSIMetadata:
@@ -340,6 +379,11 @@ def build_msi_metadata(
             first (see :class:`ProcessingStep`).
         mobility_resolved_table: Element key of the mobility-resolved
             sibling table written beside the summed table, when one was.
+        mobility_grid: The common mobility grid that table was binned
+            onto, as
+            :meth:`thyra.resampling.mobility_grid.MobilityGrid.to_schema_report`
+            renders it. ``None`` for a table read off a shared feature
+            axis, which was binned onto nothing.
         fragmentation: What the reader reported about fragmentation, as
             :meth:`thyra.core.msms.FragmentationSchedule.to_extractor_report`
             renders it. ``None`` means the reader did not say, which is
@@ -376,6 +420,7 @@ def build_msi_metadata(
             pixel_size_um,
             source_format,
             mobility_resolved_table,
+            mobility_grid,
             fragmentation,
             msms_resolved_table,
         ),

--- a/thyra/resampling/__init__.py
+++ b/thyra/resampling/__init__.py
@@ -19,6 +19,12 @@ from .instrument_detectors import (
     RapiflexDetector,
     TimsTOFDetector,
 )
+from .mobility_grid import (
+    MOBILITY_CHANNELS,
+    MobilityGrid,
+    build_mobility_grid,
+    linear_channel,
+)
 from .strategies import NearestNeighborStrategy, TICPreservingStrategy
 from .types import AxisType, MassAxis, ResamplingConfig, ResamplingMethod
 
@@ -49,4 +55,9 @@ __all__ = [
     "FTICRDetector",
     "OrbitrapDetector",
     "DefaultDetector",
+    # Ion mobility grid
+    "MOBILITY_CHANNELS",
+    "MobilityGrid",
+    "build_mobility_grid",
+    "linear_channel",
 ]

--- a/thyra/resampling/mobility_grid.py
+++ b/thyra/resampling/mobility_grid.py
@@ -1,0 +1,282 @@
+"""The common ion mobility grid: channels every pixel's points land on.
+
+A mobility axis is a **continuum**. A Bruker TDF pixel is its own point
+cloud -- one ``(m/z, 1/K0, intensity)`` triple per digitizer index per
+scan -- and no two pixels are guaranteed to hit the same 1/K0 values, so
+there is no feature list to write until the continuum is binned. This
+module is that binning: a fixed set of channels over one range, shared by
+every pixel of a conversion, so ``(m/z bin, channel)`` becomes a feature
+axis.
+
+This is the one place in the mobility work where binning a continuum is
+correct. The demultiplexed MS/MS table bins nothing, because a precursor
+axis is discrete -- the acquisition schedule names its values.
+
+Two things are fixed rather than tuned:
+
+- **The channel count is an alignment anchor, not a rendering choice.**
+  :data:`MOBILITY_CHANNELS` is the same 256 the mass-mobility heatmap
+  uses, over the same edges, so a box drawn on the heatmap maps onto grid
+  channels by integer index -- no resampling, no edge off-by-one. The
+  heatmap's ``HEATMAP_MOBILITY_CHANNELS`` *is* this constant, and
+  :func:`linear_channel` is the assignment both go through.
+- **Edges come from the axis values, never from the declared acquisition
+  range.** The per-scan 1/K0 of a real file overhangs its declared
+  ``OneOverK0AcqRange`` by a few scans (1.00003..1.29133 against a
+  declared 1.0..1.29 on one measured file); binning over the declared
+  range would pile those scans into an edge channel and the 1:1 mapping
+  onto the heatmap would be a lie. The caller passes the values' range.
+
+The generator/law split mirrors ``thyra.resampling.mass_axis``: a law
+distributes channel edges across a range, and a second law
+(``constant_relative``, say) is a drop-in that supplies its own edges and
+inherits :meth:`MobilityGrid.assign`.
+
+Mobility is a feature coordinate. Nothing here knows where a pixel is.
+"""
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import numpy as np
+from numpy.typing import NDArray
+
+logger = logging.getLogger(__name__)
+
+#: Number of mobility channels, exactly, and the default for a grid table.
+#: An anchor shared with the mass-mobility heatmap
+#: (``HEATMAP_MOBILITY_CHANNELS`` is this constant): change one and the
+#: heatmap no longer indexes the grid table.
+MOBILITY_CHANNELS = 256
+
+#: The channel widths TIMS resolving power supports, in 1/K0. Imaging
+#: separations are 1% to 5% in 1/K0 and the measured FWHM of a strong ion
+#: is 0.01 to 0.02, so a channel wider than :data:`MAX_CHANNEL_WIDTH`
+#: merges separations the instrument resolved, and one narrower than
+#: :data:`MIN_CHANNEL_WIDTH` splits a single peak across channels and pays
+#: for it in table size. The width a grid realizes is derived from the
+#: channel count, recorded in ``uns["mobility_grid"]`` and reported
+#: against this band -- the anchor above is never moved to satisfy it.
+MIN_CHANNEL_WIDTH = 0.002
+MAX_CHANNEL_WIDTH = 0.02
+
+#: The law a grid follows when the caller names none.
+DEFAULT_MOBILITY_GRID_LAW = "linear"
+
+
+def linear_channel(
+    values: Any, lower: float, upper: float, n_channels: int
+) -> NDArray[np.int64]:
+    """Channel of each value on ``n_channels`` equal-width bins over the range.
+
+    Position in the range times the channel count, floored. A value on the
+    upper edge belongs to the last channel, and a value beyond either edge
+    -- an axis that overhangs its declared range, a point the reader
+    clipped -- is clipped into the edge channel rather than lost, so a
+    marginal over channels keeps every count.
+
+    The mass-mobility heatmap assigns its channels through this same
+    function, which is what makes the two agree by construction rather
+    than by coincidence.
+    """
+    channel = np.floor((np.asarray(values) - lower) / (upper - lower) * n_channels)
+    return np.clip(channel, 0, n_channels - 1).astype(np.int64)
+
+
+@dataclass(frozen=True)
+class MobilityGrid:
+    """The channels one conversion bins every pixel's mobility onto.
+
+    ``edges`` has ``n_channels + 1`` entries, ascending; ``centres`` are
+    the values written to ``var["mobility"]``. ``law`` names how the edges
+    were spaced, and is what a second law would change.
+
+    Not to be confused with :class:`thyra.metadata.schema.models.MobilityGrid`,
+    which is the pydantic description of this object inside the versioned
+    metadata block; :meth:`to_schema_report` produces its input.
+    """
+
+    law: str
+    lower: float
+    upper: float
+    n_channels: int
+    edges: NDArray[np.float64]
+
+    @property
+    def centres(self) -> NDArray[np.float64]:
+        """Channel centres, ascending: what ``var["mobility"]`` carries."""
+        return 0.5 * (self.edges[:-1] + self.edges[1:])
+
+    @property
+    def channel_width(self) -> float:
+        """The width one channel spans, in the axis unit.
+
+        Derived from the channel count, not the other way round -- see
+        :data:`MIN_CHANNEL_WIDTH` for the band it is reported against.
+        """
+        return float(self.upper - self.lower) / float(self.n_channels)
+
+    def assign(self, values: Any) -> NDArray[np.int32]:
+        """The channel of each mobility value, as ``int32``.
+
+        A linear law has a closed form, which is the expression the
+        heatmap uses; any other law is resolved against ``edges`` by
+        binary search, so a new law needs no new assignment code.
+        """
+        if self.law == "linear":
+            channel = linear_channel(values, self.lower, self.upper, self.n_channels)
+        else:
+            channel = np.clip(
+                np.searchsorted(self.edges, np.asarray(values), side="right") - 1,
+                0,
+                self.n_channels - 1,
+            )
+        return channel.astype(np.int32)
+
+    def to_uns(self) -> Dict[str, Any]:
+        """The ``uns["mobility_grid"]`` block: plain-name keys, no colons.
+
+        Its presence is what says a mobility-resolved table was *binned*
+        onto a common grid rather than read off a shared feature axis.
+        ``edges`` travels with it so a consumer can map a heatmap box onto
+        channels without recomputing the range.
+        """
+        return {
+            "law": self.law,
+            "lower": float(self.lower),
+            "upper": float(self.upper),
+            "n_channels": int(self.n_channels),
+            "channel_width": self.channel_width,
+            "edges": np.asarray(self.edges, dtype=np.float64),
+        }
+
+    def to_schema_report(self) -> Dict[str, Any]:
+        """The shape ``thyra.metadata.schema.builder`` reads for ``ion_mobility.grid``."""
+        return {
+            "law": self.law,
+            "lower": float(self.lower),
+            "upper": float(self.upper),
+            "n_channels": int(self.n_channels),
+        }
+
+
+class BaseMobilityGridGenerator(ABC):
+    """Distributes channel edges across a mobility range by one law.
+
+    The mobility counterpart of
+    :class:`~thyra.resampling.mass_axis.base_generator.BaseAxisGenerator`:
+    a generator decides *where* the edges fall, never *how many* there are
+    -- that is the anchor in :data:`MOBILITY_CHANNELS` or an explicit
+    override.
+    """
+
+    @abstractmethod
+    def generate(self, lower: float, upper: float, n_channels: int) -> MobilityGrid:
+        """``n_channels`` channels spanning ``[lower, upper]``, ascending."""
+
+    @abstractmethod
+    def get_law(self) -> str:
+        """The name this law is recorded under."""
+
+
+class LinearMobilityGridGenerator(BaseMobilityGridGenerator):
+    """Equal-width channels in the axis unit.
+
+    Right for 1/K0 over an imaging acquisition: the ranges are short
+    (0.3 1/K0 is typical) and TIMS resolving power is near enough constant
+    across one, so equal width and equal relative width differ by less
+    than a channel.
+    """
+
+    def generate(self, lower: float, upper: float, n_channels: int) -> MobilityGrid:
+        """Channels from ``np.linspace``, which is also the heatmap's rule."""
+        return MobilityGrid(
+            law=self.get_law(),
+            lower=float(lower),
+            upper=float(upper),
+            n_channels=int(n_channels),
+            edges=np.linspace(float(lower), float(upper), int(n_channels) + 1),
+        )
+
+    def get_law(self) -> str:
+        """The name this law is recorded under."""
+        return "linear"
+
+
+#: The laws a grid can be built under, by name.
+MOBILITY_GRID_GENERATORS: Dict[str, BaseMobilityGridGenerator] = {
+    "linear": LinearMobilityGridGenerator(),
+}
+
+
+def build_mobility_grid(
+    lower: float,
+    upper: float,
+    n_channels: int = MOBILITY_CHANNELS,
+    law: str = DEFAULT_MOBILITY_GRID_LAW,
+) -> MobilityGrid:
+    """The common mobility grid of one conversion.
+
+    Args:
+        lower: Lower edge of the first channel, in the axis unit. Take it
+            from the axis *values*, never the declared acquisition range.
+        upper: Upper edge of the last channel; must exceed ``lower``.
+        n_channels: Channels to divide the range into. The default is the
+            heatmap anchor, which is what makes a heatmap box index the
+            grid.
+        law: How the edges are spaced; ``"linear"`` is the only law today.
+
+    Raises:
+        ValueError: If the range has no extent, the channel count is not
+            positive, or the law is unknown.
+    """
+    if not np.isfinite(lower) or not np.isfinite(upper) or upper <= lower:
+        raise ValueError(
+            f"The mobility range [{lower}, {upper}] has no extent to bin over"
+        )
+    if int(n_channels) < 1:
+        raise ValueError(
+            f"A mobility grid needs at least one channel, got {n_channels}"
+        )
+    generator = MOBILITY_GRID_GENERATORS.get(law)
+    if generator is None:
+        raise ValueError(
+            f"Unknown mobility grid law {law!r}; known laws are "
+            f"{sorted(MOBILITY_GRID_GENERATORS)}"
+        )
+    return generator.generate(lower, upper, int(n_channels))
+
+
+def report_channel_width(grid: MobilityGrid, unit: Optional[str] = None) -> None:
+    """Say once whether the realized channel width matches the instrument.
+
+    The channel count is an anchor and is never moved to land inside the
+    band; what the band decides is whether the grid is worth its size
+    (too fine) or is losing separations (too coarse), and that is a thing
+    to say out loud rather than leave in a number nobody reads.
+    """
+    width = grid.channel_width
+    where = f" {unit}" if unit else ""
+    if width > MAX_CHANNEL_WIDTH:
+        logger.warning(
+            "Mobility grid channels are %.4g%s wide, above the %.3g the "
+            "instrument resolves: separations TIMS pulled apart may fall in "
+            "one channel. Ask for more channels (--mobility-bins) or a "
+            "narrower range (--mobility-min/--mobility-max).",
+            width,
+            where,
+            MAX_CHANNEL_WIDTH,
+        )
+    elif width < MIN_CHANNEL_WIDTH:
+        logger.info(
+            "Mobility grid channels are %.4g%s wide, finer than the %.3g the "
+            "instrument resolves: a single mobility peak spans several "
+            "channels and the table is larger than the separation needs. "
+            "The count is held at %d so the grid indexes the heatmap.",
+            width,
+            where,
+            MIN_CHANNEL_WIDTH,
+            grid.n_channels,
+        )


### PR DESCRIPTION
## The gap

v3.13.0 shipped ion mobility for Bruker TDF -- `uns["mobility_axis"]`,
`uns["mobility_heatmap"]`, CCS, the versioned `ms_analysis.ion_mobility` block --
but no mobility-resolved *table* for that source. `build_mobility_table` returns
`None` unless the reader shares one set of `(m/z, mobility)` feature pairs across
pixels, and `BrukerReader` correctly reports that it does not: a TDF frame is a
point cloud with no feature list.

So the flagship mobility source got a picture of the whole dataset and no way to
make a mobility-resolved ion image, while a *converted imzML export of the same
acquisition* got a full table. This closes that asymmetry.

## What it does

`--mobility-grid` bins each pixel's `(m/z, 1/K0, intensity)` points onto one set
of mobility channels shared across the conversion, so `(m/z bin, channel)`
becomes a feature axis, and fills the **same** `{table}_mobility` element the
shared-axis mechanism fills: same `var` columns (`mz`, `mobility`, `mz_index`,
`mobility_index`), same lexicographic `(mz, mobility)` sort, same
`"mobility" in var.columns` discriminator, same `obs`, same region.

A consumer does not need to tell the two mechanisms apart to read either. What
says which one filled the table is `uns["mobility_grid"]`, mirrored in
`msi_metadata.ms_analysis.ion_mobility.grid` (modelled since schema 0.3.0, never
written until now -- no version bump). That is a description, not a structural
difference. **Ousia's `is_msi_mobility_table` needs no change.**

A mobility axis is a **continuum**, which is what makes binning right here. The
demultiplexed MS/MS table of #201 bins nothing, because a precursor axis is
discrete -- the schedule names its 15 values. Every sizing decision below follows
from that difference.

## The decisions, and why

- **256 channels, and the anchor is now structural.**
  `HEATMAP_MOBILITY_CHANNELS` *is* `thyra.resampling.mobility_grid.MOBILITY_CHANNELS`;
  `mobility_bin_edges` *is* the grid's own linear generator; both assign a value
  to a channel through the same `linear_channel` expression. So a box drawn on
  `uns["mobility_heatmap"]` indexes grid channels by integer index with no
  resampling and no edge off-by-one. Tests assert the two edge arrays are
  **equal**, not close, on the synthetic fixture and on real data.
- **Edges come from the axis `values`, never the declared `OneOverK0AcqRange`**,
  which the per-scan 1/K0 of a real file overhangs.
- **The `[0.002, 0.02]` 1/K0 width band is reported, never a mover.** On a
  0.29-span acquisition 256 channels realize 0.0011, below the floor; clamping
  the count to satisfy the band would drop it to ~145 and destroy the alignment
  the anchor exists for. The realized width is recorded in
  `uns["mobility_grid"]["channel_width"]`, said at INFO when finer than the
  instrument resolves and at WARNING when coarser (separations may merge).
- **Writing a grid forces `--tdf-spectrum scan_sum`, at WARNING**, unless the
  caller set it explicitly. The grid reads raw scans, so its marginal reproduces
  the summed table only when that table was built the same way. Measured, the
  switch moves the stored TIC by **14.4%** -- inside the predicted 13-21%, and
  exactly the kind of thing that reads as a bug if it happens quietly.
- **The `var` ceiling is on occupied pairs, not on the pairs the grid spans.**
  This is a correction made against measurement. A default-resampled timsTOF axis
  is 138,629 bins, so the grid *spans* 35.5M pairs, while a 400-frame conversion
  actually *occupied* 5.5M and a 200-frame one 3.9M. Refusing on the span would
  have turned away the flagship case ninefold over. The span is logged at INFO
  when it passes the ceiling; the exact count refuses, checked the moment it is
  known and before the labels, the matrix and the `var` are built.
- **The marginal invariant is recorded, not merely asserted in a test.**
  `uns["mobility_marginal"]` carries `current_ratio`, its per-pixel range, and
  `max_absolute_deviation` / `max_relative_deviation` where both matrices are in
  hand. The streaming route writes the summed table straight to disk and never
  holds it, so there the per-pixel TIC it already computes stands in and the
  per-column deviation is the one field it cannot state.
- **Every other refusal is by name**, at INFO or WARNING, never an exception: no
  mobility dimension; no per-scan axis values (a reader opened without its vendor
  library); no grid asked for.

## Measured

400 frames of `05_maldi2_shortramp_26k_px`, default resampling:

| | default | `--mobility-grid` |
|---|---|---|
| wall clock | 39.3 s | 145.9 s |
| store | 22.3 MB | 133.4 MB |
| summed table nnz | 4,144,912 | 11,961,775 (`scan_sum`) |
| grid table | -- | 400 x 5,454,955, nnz 20,455,979 |
| stored TIC | 1.000 | 1.144 |

Against the summed table it resolves (both under `scan_sum`): **nnz 1.71x**
(inside the predicted 1.3-4x), **var 39.4x**, median 36 channels occupied per m/z
bin. `mobility_marginal.current_ratio` exactly 1.0.

**What the resolution bought:** among the 3,000 strongest m/z bins, **2,774 (92%)**
carry two mobility features at least 12 channels (0.038 1/K0) apart with currents
within 5x of each other, and those bins hold **22.5% of the image's ion current**.
The best-sampled example is m/z 601.5161 -- one column of the summed table, two
features at 1/K0 1.2348 and 1.1969 carrying 3.9M and 1.7M counts whose ion images
correlate at r = 0.315. m/z 545.0693 separates by 0.079 1/K0. In the summed table
each of these is a single ion image with nothing to suggest it is two things.

## Two notes

**The gate was let go deliberately.** The original plan deferred this until
someone had looked at a real heatmap in Ousia's panel. Nothing about the sizing
waited on that: the channel count was fixed at 256 by *alignment to the heatmap*,
not by observation, so the gate was dropped rather than met.

**`--mobility-grid` is opt in (default off),** next to `--msms-table`. The local plan's
scope reads as though extending `--mobility-table` should make the grid answer for
TDF under the existing default-on flag; its acceptance ("on a TDF converted
without the flag: nothing changes at all") and the forced `scan_sum` (which moves
the TIC 14.4%) read the other way, and REPORT-13 calls this "the opt-in table"
throughout. Opt in is the reading that cannot silently change an existing user's
stored numbers. If the other was meant it is a one-line default change; say so and
I will flip it.

## Verification

- `pytest tests/` -- 2091 passed, 13 skipped
- `pytest tests/ -m integration` -- 56 passed, 4 skipped (env-gated)
- the real-data acceptance test with `THYRA_BRUKER_TDF_DATASET` set -- passed in
  64 s on a 60-frame cap: both tables, `var` sorted, `mobility_index` in [0, 255],
  the marginal reproducing the summed table per pixel and per m/z bin, edge arrays
  equal, nnz ratio inside [1.2, 5]
- complexity monitor at threshold 15 -- 0 violations
- `pre-commit` -- clean
- deepest Zarr key of a real grid store measured at 101 characters, well under the
  160-character `DEEPEST_KEY_RESERVE`; neither new `uns` block becomes the deepest

Additive throughout: the summed MSI table is unchanged, a TSF file and a TDF
converted without the flag are byte for byte what they were, and the imzML
shared-axis route still produces the table it produced before (its 16 tests pass
untouched).
