### PR TITLE
feat(mobility): build the sibling tables out of core

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -49,8 +49,8 @@ thyra input.imzML output.zarr && python analyse.py output.zarr
 | `--include-optical / --no-optical` | enabled | Include optical images in output |
 | `--mobility-table / --no-mobility-table` | enabled | Also write the mobility-resolved sibling table when the source shares one set of (m/z, ion mobility) features across pixels (see [Output Format](output-format.md#ion-mobility)) |
 | `--mobility-heatmap / --no-mobility-heatmap` | enabled | When the source has an ion mobility dimension, store the mean mass-mobility frame on the summed table as `uns["mobility_heatmap"]`; one extra pass over the source (see [Output Format](output-format.md#ion-mobility)) |
-| `--mobility-grid / --no-mobility-grid` | **disabled** | When the source carries ion mobility per pixel rather than as a shared feature list (Bruker TDF), bin the point cloud onto a common mobility grid and write the same mobility-resolved sibling table; one extra pass over the source, a much larger table, and it forces `--tdf-spectrum scan_sum` (see [Output Format](output-format.md#the-same-table-from-a-common-mobility-grid)) |
-| `--msms-table / --no-msms-table` | **disabled** | When the source isolates several precursors per pixel in disjoint mobility slices (Bruker PASEF), also write them split apart as a demultiplexed sibling table; one extra pass over the source (see [Output Format](output-format.md#demultiplexed-msms-table)) |
+| `--mobility-grid / --no-mobility-grid` | **disabled** | When the source carries ion mobility per pixel rather than as a shared feature list (Bruker TDF), bin the point cloud onto a common mobility grid and write the same mobility-resolved sibling table; one extra pass over the source beyond the heatmap's, a much larger table built out of core so any acquisition fits, and it forces `--tdf-spectrum scan_sum` (see [Output Format](output-format.md#the-same-table-from-a-common-mobility-grid)) |
+| `--msms-table / --no-msms-table` | **disabled** | When the source isolates several precursors per pixel in disjoint mobility slices (Bruker PASEF), also write them split apart as a demultiplexed sibling table; two extra passes over the source, and it forces `--tdf-spectrum scan_sum` so the split adds back up to the summed table exactly (see [Output Format](output-format.md#demultiplexed-msms-table)) |
 
 ### Examples
 
@@ -133,13 +133,18 @@ thyra tims_data.d output.zarr --mobility-grid
 thyra tims_data.d output.zarr --mobility-grid --mobility-bins 512     --mobility-min 1.05 --mobility-max 1.25
 ```
 
-!!! warning "The grid table is built in memory, and a whole acquisition may not fit"
-    Unlike the summed table, which the streaming route scatters to disk, the
-    mobility grid table is accumulated in RAM. 400 frames of a measured timsTOF
-    acquisition peaked at 2.0 GB; its full 26,000 pixels project to about 109 GB.
-    The conversion projects that figure as it reads, warns past a quarter of the
-    machine's free memory and refuses past half of it. Convert one `--region` at
-    a time if a whole image will not fit.
+!!! note "The grid table is built out of core"
+    Like the summed table on the streaming route, the grid table is built in
+    two passes: the first counts the occupied `(m/z bin, channel)` cells and
+    the second scatters every pixel straight into memmapped CSC arrays in a
+    scratch directory next to the output (`.thyra_mobility_*`, removed once
+    the table is written). Memory is the count array over the grid's span --
+    142 MB on a default-resampled timsTOF axis -- plus one frame, whatever the
+    number of pixels; disk is 12 bytes per stored non-zero while the table is
+    being built. Measured on a whole 26,087-pixel timsTOF acquisition on a
+    40,000-bin axis (7.3M features, 1.59 billion non-zeros, 18 GB of scratch):
+    the table's own phases peaked at 3.2 GB of private memory above the
+    interpreter's baseline, in the `var` frame rather than in the matrix.
 
 !!! note "A mobility-resolved table wants a coarser mass axis than the default"
     The table's features are `(m/z bin, mobility channel)` pairs, so the mass
@@ -315,7 +320,7 @@ These options only apply when converting Bruker `.d` directories.
 | `--use-recalibrated / --no-recalibrated` | enabled | Use recalibrated m/z state |
 | `--interactive-calibration` | off | Display available calibration states |
 | `--intensity-threshold FLOAT` | none | Minimum intensity filter |
-| `--tdf-spectrum {vendor_centroid,scan_sum}` | `vendor_centroid`; `scan_sum` when `--mobility-grid` is given | How a TDF (TIMS) frame's mobility scans collapse into one spectrum per pixel |
+| `--tdf-spectrum {vendor_centroid,scan_sum}` | `vendor_centroid`; `scan_sum` when `--mobility-grid` or `--msms-table` is given | How a TDF (TIMS) frame's mobility scans collapse into one spectrum per pixel |
 
 ### Examples
 

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -404,31 +404,29 @@ A grid is refused, at `INFO` or `WARNING` and never as an exception, when:
 | the source has no mobility dimension | there is nothing to bin |
 | `--mobility-grid` was not given | binning is opt in: it costs a pass over the source and a much larger table |
 | the mobility axis carries no per-scan values | a reader opened without its vendor library cannot supply them, and the declared range is not a substitute |
+| the grid spans more pairs than the counting pass can hold (a raw, unresampled axis of millions of bins) | the count array is `4 bytes x bins x channels`, capped at 1 GB; resample to fewer mass bins |
 | the occupied `(m/z bin, channel)` pairs pass 20,000,000 | the count is printed; resample to fewer mass bins or ask for fewer channels |
-| the table is on course to need more than half the machine's free memory | see the note below; the projection and the free memory are both printed |
 
-!!! warning "This table is held in memory while it is built"
-    The summed MSI table is memory-bounded: the streaming route pre-scans the
-    source, counts, and scatters into a memmap, so it converts an acquisition
-    far larger than RAM. **The mobility grid table is not.** It accumulates its
-    `(pixel, m/z bin, channel)` triples in memory, so what it needs is linear in
-    the table's non-zeros: measured, 400 frames of a timsTOF acquisition peaked
-    at 2.0 GB, and the same acquisition's full 26,000 pixels projects to about
-    109 GB.
-
-    So the conversion projects that number from the pixels it has read, warns
-    past a quarter of the machine's free memory and **refuses past half of it**,
-    early, with the figures printed -- rather than letting the run reach the
-    ceiling below and die there. Convert one `--region` at a time, resample to
-    fewer mass bins, or ask for fewer channels. A memmap-scattered route that
-    removes the limit is the next piece of work on this table.
+**How it is built, and why its size does not matter.** The table is built
+the way the summed table is built on the streaming route, in two passes over
+the raw scans. The first pass counts, per `(m/z bin, channel)` cell of the
+grid, how many pixels occupy it -- a dense count over the grid's span, 142 MB
+on a default-resampled timsTOF axis, sized before the first pixel is read and
+independent of how many pixels there are. That pass is fused with the
+heatmap's: both need every point mapped onto the mass axis, and the mapping
+costs more than the vendor read, so it is done once. The second pass re-reads
+the source and scatters each pixel's cells straight into memmapped CSC arrays
+in a scratch directory next to the output (`.thyra_mobility_*`, removed once
+the table is written), 12 bytes of disk per stored non-zero. Nothing is ever
+held for the whole image: memory is the count array plus one frame.
 
 The size ceiling is on the pairs that carry signal, not on the pairs the grid
 spans. The two differ by an order of magnitude -- 200 frames of a measured
 timsTOF acquisition occupied 3.9M of a possible 35.5M -- so refusing on the
 span would turn away conversions that fit ninefold over. The span is said at
-`INFO` when it passes the ceiling; the count is what refuses, checked as soon
-as the source has been read and before anything wide is built.
+`INFO` when it passes the ceiling; the count is what refuses, checked the
+moment the first pass ends and before a single value has been scattered, so a
+refusal costs one read and no memory.
 
 Bruker TDF is the only source that needs a grid today; an imzML export with a
 mobility array already has a shared feature axis and is read off it.
@@ -508,9 +506,12 @@ precursor's fragments are therefore a contiguous column block whose row
 sums are its ion image, and **the blocks add back up**: summing all
 fragment columns of every precursor reproduces the summed table's TIC per
 pixel, because each recorded point falls in exactly one isolation window.
-(Exactly, under `--tdf-spectrum scan_sum`; the default `vendor_centroid`
-summed spectrum is the vendor peak picker's, which keeps 80 to 90 percent
-of the raw ion current, while the split is built from the raw scans.)
+Exactly, because `--msms-table` selects `--tdf-spectrum scan_sum` for the
+summed table (at `WARNING`, as `--mobility-grid` does, and never over an
+explicit `--tdf-spectrum`): the split is built from the raw scans, and only
+a summed spectrum built from the same scans can add back up to it. The
+vendor centroid keeps 80 to 90 percent of the raw ion current and the two
+tables of one store would genuinely not agree.
 
 ```python
 msms = sdata.tables["msi_z0_msms"]
@@ -570,12 +571,14 @@ split needs today.
 **`uns["demultiplexed_current"]`** records how much of the summed table's
 ion current the split holds: `current_ratio` over the whole image, and
 `current_ratio_pixel_min` / `_max` across pixels. Under
-`--tdf-spectrum scan_sum` it is exactly `1.0`. Under the default
-`vendor_centroid` it is **above** 1 -- the vendor peak picker discards
-single counts while the split reads raw scans, which on a real acquisition
-is about 1.5% overall and up to 1.14x on a single pixel. The two tables
-genuinely do not add up in that mode, and this block is where the store
-says so.
+`--tdf-spectrum scan_sum`, which the table selects, it is exactly `1.0`.
+Under an explicit `--tdf-spectrum vendor_centroid` it is **above** 1 -- the
+vendor peak picker discards single counts while the split reads raw scans,
+which on a real acquisition is about 1.5% overall and up to 1.14x on a
+single pixel. The two tables genuinely do not add up in that mode, and this
+block is where the store says so. It is written on every route, including
+the streaming one, which compares against the per-pixel ion current it
+already holds for the TIC image.
 
 !!! note "Deliberate limits"
     - **The feature axis depends on the data.** Only `(precursor, bin)`
@@ -590,9 +593,13 @@ says so.
       necessity.
     - **Do not select precursors by float equality.** Look the precursor up
       once and slice on `precursor_index` within that store.
-    - **Untested at scale.** The largest acquisition this has run on is 713
-      pixels with 15 precursors. A 100,000-pixel run with 25 has not been
-      measured; `var` grows with the occupied pairs.
+    - **Built out of core, like the mobility grid.** Two passes over the
+      precursor spectra -- count the occupied `(precursor, bin)` pairs,
+      then scatter into memmapped CSC arrays in a scratch directory next to
+      the output (`.thyra_msms_*`) -- so memory is the count array
+      (`4 bytes x precursors x mass bins`) plus one frame, whatever the
+      pixel count. The largest acquisition this has run on is still 713
+      pixels with 15 precursors; `var` grows with the occupied pairs.
 
 !!! note "Relation to other MS/MS imaging representations"
     The open formats solve this at the raw layer by never merging: an

--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -145,10 +145,10 @@ directly the way an imzML mobility export has; the flag bins every pixel's
 across the conversion and writes the result as `{table}_mobility` -- the same
 element, columns and sort a shared-axis source produces. The default 256
 channels over the axis' own value range are the heatmap's, so a box on the
-heatmap indexes the table's channels. It costs a second pass over the source,
-a table with 1.3 to 4 times the summed table's non-zeros held in memory while
-it is built (so a whole large acquisition may need converting one `--region` at
-a time), and a switch to
+heatmap indexes the table's channels. It costs a second pass over the source
+(the first is shared with the heatmap), a table with 1.3 to 4 times the summed
+table's non-zeros -- built out of core, so a whole acquisition converts
+whatever its size -- and a switch to
 `--tdf-spectrum scan_sum` (said at `WARNING`) so the table's marginal over
 channels reproduces the summed table exactly. See
 [Output Format](output-format.md#the-same-table-from-a-common-mobility-grid).

--- a/tests/unit/converters/test_csc_assembly.py
+++ b/tests/unit/converters/test_csc_assembly.py
@@ -1,0 +1,208 @@
+"""The out-of-core CSC engine both sibling tables are built on.
+
+Pinned against scipy: whatever the engine writes through its two passes
+must be the matrix ``coo_matrix(...).tocsc()`` would have built from the
+same triples in one, entry for entry and dtype for dtype -- that is the
+route it replaced, and the stores written by the two must not differ.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from scipy import sparse
+
+from thyra.converters.spatialdata.csc_assembly import (
+    MAX_COUNT_BYTES,
+    CscAssembly,
+    count_refusal,
+    index_dtype,
+    remove_scratch,
+)
+from thyra.converters.spatialdata.mobility_table import (
+    collapse_row,
+    disambiguate_labels,
+    int_strings,
+)
+
+SPAN = 1000
+
+
+def _rows(rng, n_rows, keys_per_row=40):
+    """One row's unique ascending keys and values, for every row."""
+    rows = []
+    for row in range(n_rows):
+        keys = np.unique(rng.integers(0, SPAN, keys_per_row, dtype=np.int64))
+        values = rng.random(keys.size) + 0.5
+        rows.append((row, keys, values))
+    return rows
+
+
+def _reference(rows, n_rows, keep_empty):
+    r = np.concatenate([np.full(k.size, row) for row, k, _v in rows])
+    c = np.concatenate([k for _row, k, _v in rows])
+    d = np.concatenate([v for _row, _k, v in rows])
+    if keep_empty:
+        return sparse.coo_matrix((d, (r, c)), shape=(n_rows, SPAN)).tocsc()
+    occupied = np.unique(c)
+    columns = np.searchsorted(occupied, c)
+    return sparse.coo_matrix((d, (r, columns)), shape=(n_rows, occupied.size)).tocsc()
+
+
+def _build(rows, n_rows, scratch, keep_empty=False, order=None):
+    assembly = CscAssembly(SPAN, n_rows, keep_empty_columns=keep_empty)
+    sequence = rows if order is None else [rows[i] for i in order]
+    for row, keys, _values in sequence:
+        assembly.count(row, keys)
+    assembly.finish_counting()
+    assembly.allocate(scratch)
+    for row, keys, values in sequence:
+        assembly.scatter(row, keys, values)
+    return assembly
+
+
+def _assert_same(built, expected):
+    assert built.shape == expected.shape
+    assert built.indices.dtype == expected.indices.dtype
+    assert built.indptr.dtype == expected.indptr.dtype
+    np.testing.assert_array_equal(built.indptr, expected.indptr)
+    np.testing.assert_array_equal(built.indices, expected.indices)
+    np.testing.assert_array_equal(built.data, expected.data)
+    assert built.has_canonical_format
+
+
+class TestAgainstScipy:
+    @pytest.mark.parametrize("keep_empty", [False, True], ids=["occupied", "all"])
+    def test_rows_in_order_are_the_coo_to_csc_matrix(self, tmp_path, keep_empty):
+        rng = np.random.default_rng(1)
+        rows = _rows(rng, 60)
+        assembly = _build(rows, 60, tmp_path / "s", keep_empty)
+        assert assembly.rows_in_order
+        _assert_same(assembly.matrix(), _reference(rows, 60, keep_empty))
+        assembly.release()
+
+    def test_rows_out_of_order_are_sorted_into_the_same_matrix(self, tmp_path):
+        # A source read in some order other than the table's rows: the
+        # columns are put in row order afterwards, chunk by chunk, so the
+        # stored matrix is canonical either way.
+        from thyra.converters.spatialdata import csc_assembly
+
+        rng = np.random.default_rng(2)
+        rows = _rows(rng, 80)
+        order = rng.permutation(80)
+        assembly = _build(rows, 80, tmp_path / "s", order=order)
+        assert not assembly.rows_in_order
+        csc_assembly.SORT_CHUNK_ENTRIES, kept = 97, csc_assembly.SORT_CHUNK_ENTRIES
+        try:
+            matrix = assembly.matrix()
+        finally:
+            csc_assembly.SORT_CHUNK_ENTRIES = kept
+        _assert_same(matrix, _reference(rows, 80, False))
+        assembly.release()
+
+    def test_a_row_in_several_groups_is_one_row(self, tmp_path):
+        # The demultiplexer hands a pixel in once per precursor, each with
+        # its own disjoint keys; the engine sees the same row twice.
+        rows = [
+            (0, np.array([1, 5]), np.array([1.0, 2.0])),
+            (0, np.array([7, 9]), np.array([3.0, 4.0])),
+            (1, np.array([5]), np.array([5.0])),
+        ]
+        assembly = _build(rows, 2, tmp_path / "s")
+        assert assembly.rows_in_order
+        _assert_same(assembly.matrix(), _reference(rows, 2, False))
+        assembly.release()
+
+    def test_the_matrix_does_not_copy_the_memmaps(self, tmp_path):
+        rows = _rows(np.random.default_rng(3), 5)
+        assembly = _build(rows, 5, tmp_path / "s")
+        matrix = assembly.matrix()
+        assert np.shares_memory(matrix.data, assembly._data)
+        assert np.shares_memory(matrix.indices, assembly._indices)
+        assembly.release()
+
+    def test_an_empty_row_is_a_row(self, tmp_path):
+        rows = [
+            (0, np.array([], dtype=np.int64), np.array([])),
+            (1, np.array([3]), np.array([1.0])),
+        ]
+        assembly = _build(rows, 2, tmp_path / "s")
+        matrix = assembly.matrix()
+        assert matrix.shape == (2, 1)
+        np.testing.assert_array_equal(matrix.toarray(), [[0.0], [1.0]])
+        assembly.release()
+
+
+class TestTheGuards:
+    def test_the_count_array_has_a_budget_naming_the_lever(self):
+        assert count_refusal(MAX_COUNT_BYTES // 4) is None
+        refusal = count_refusal(MAX_COUNT_BYTES // 4 + 1)
+        assert refusal is not None and "--resample-bins" in refusal
+        with pytest.raises(MemoryError):
+            CscAssembly(MAX_COUNT_BYTES // 4 + 1, 1)
+
+    def test_the_index_dtype_is_scipys_rule(self):
+        assert index_dtype(10, 10) is np.int32
+        assert index_dtype(2**31, 10) is np.int64
+        assert index_dtype(10, 2**31) is np.int64
+
+    def test_the_passes_must_agree_on_the_rows(self, tmp_path):
+        assembly = CscAssembly(SPAN, 3)
+        assembly.count(0, np.array([1, 2]))
+        assembly.count(1, np.array([2]))
+        assembly.finish_counting()
+        assembly.allocate(tmp_path / "s")
+        assembly.scatter(0, np.array([1, 2]), np.array([1.0, 1.0]))
+        # Row 1 was counted and never scattered: a reserved slot nothing
+        # wrote, which must not become a silent zero at row 0.
+        with pytest.raises(RuntimeError, match="disagree"):
+            assembly.matrix()
+        assembly.release()
+
+    def test_the_feature_ceiling_is_checkable_before_allocation(self, tmp_path):
+        assembly = CscAssembly(SPAN, 2)
+        assembly.count(0, np.array([1, 4, 9]))
+        assert assembly.finish_counting() == 3
+        np.testing.assert_array_equal(assembly.unique_keys, [1, 4, 9])
+        assert assembly.indptr is None  # nothing sized yet
+
+    def test_release_lets_the_scratch_go(self, tmp_path):
+        scratch = Path(tmp_path / "s")
+        rows = _rows(np.random.default_rng(4), 3)
+        assembly = _build(rows, 3, scratch)
+        matrix = assembly.matrix()
+        del matrix
+        assembly.release()
+        remove_scratch(scratch)
+        assert not scratch.exists()
+
+
+class TestRowHelpers:
+    def test_collapse_row_leaves_a_canonical_row_alone(self):
+        keys = np.array([2, 5, 9])
+        values = np.array([1.0, 2.0, 3.0])
+        out_keys, out_values = collapse_row(keys, values)
+        assert out_keys is keys and out_values is values
+
+    def test_collapse_row_merges_repeats_and_sorts(self):
+        keys = np.array([9, 2, 9, 5, 2])
+        values = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        out_keys, out_values = collapse_row(keys, values)
+        np.testing.assert_array_equal(out_keys, [2, 5, 9])
+        np.testing.assert_array_equal(out_values, [7.0, 4.0, 4.0])
+
+    def test_disambiguation_matches_the_dict_it_replaced(self):
+        rng = np.random.default_rng(5)
+        group = rng.integers(0, 20, 200, dtype=np.int64)
+        labels = np.strings.add("k", int_strings(group))
+        seen = {}
+        expected = []
+        for label in labels.tolist():
+            n = seen.get(label, 0)
+            seen[label] = n + 1
+            expected.append(label if n == 0 else f"{label}_{n}")
+        assert disambiguate_labels(labels, group).tolist() == expected
+
+    def test_unique_labels_pass_through_untouched(self):
+        labels = np.strings.add("k", int_strings([3, 1, 2]))
+        assert disambiguate_labels(labels, np.array([3, 1, 2])) is labels

--- a/tests/unit/converters/test_mobility_grid.py
+++ b/tests/unit/converters/test_mobility_grid.py
@@ -23,11 +23,10 @@ from thyra.converters.spatialdata.mobility_heatmap import (
 )
 from thyra.converters.spatialdata.mobility_table import (
     MAX_GRID_VAR_ENTRIES,
+    build_mobility_table,
     grid_refusal,
     grid_var_bound,
-    memory_refusal,
     mobility_grid_range,
-    projected_memory_gb,
     var_ceiling_refusal,
 )
 from thyra.core.base_extractor import MetadataExtractor
@@ -339,18 +338,49 @@ class TestVarCeiling:
         assert grid_var_bound(axis, grid) > MAX_GRID_VAR_ENTRIES
         assert grid_refusal(GridStubReader(), axis, grid) is None
 
-    def test_the_ceiling_cannot_protect_the_pass_which_is_why_memory_is_projected(
-        self,
-    ):
-        # The var ceiling sits past the concatenation, so on an image big
-        # enough for it to matter the memory is already committed. That is
-        # what the projection below exists for; this pins the reason.
-        import inspect
+    def test_the_count_refuses_before_anything_is_allocated(self, monkeypatch, caplog):
+        # The ceiling is checked the moment the count is known -- the end
+        # of the discovery pass -- and before the memmaps, the labels or
+        # the var exist. Nothing has been committed to when it fires,
+        # which is the whole reason it exists; this pins that allocate()
+        # is never reached on a refusal.
+        import thyra.converters.spatialdata.mobility_table as module
+        from thyra.converters.spatialdata import csc_assembly
 
-        from thyra.converters.spatialdata import mobility_table as module
+        monkeypatch.setattr(module, "MAX_GRID_VAR_ENTRIES", 4)
 
-        source = inspect.getsource(module._GridAccumulator.matrix)
-        assert source.index("np.concatenate") < source.index("var_ceiling_refusal")
+        def never(self, scratch):
+            raise AssertionError("allocate() ran after the ceiling refused")
+
+        monkeypatch.setattr(csc_assembly.CscAssembly, "allocate", never)
+        with caplog.at_level("WARNING"):
+            table = build_mobility_table(
+                GridStubReader(),
+                _stub_obs(),
+                MASS_AXIS,
+                "stub_z0",
+                "stub_z0_pixels",
+                {},
+                grid=build_mobility_grid(1.1, 1.5),
+            )
+        assert table is None
+        assert "above the var ceiling" in caplog.text
+
+    def test_a_span_too_wide_to_count_is_refused_before_the_read(self):
+        # The discovery pass counts every (m/z bin, channel) pair the grid
+        # spans in a dense array; a raw, unresampled axis of millions of
+        # bins would push that into gigabytes. Said before anything is
+        # read, as a property of the source, naming the lever.
+        from thyra.converters.spatialdata.csc_assembly import MAX_COUNT_BYTES
+
+        too_many_bins = MAX_COUNT_BYTES // 4 // MOBILITY_CHANNELS + 1
+        refusal = grid_refusal(
+            GridStubReader(),
+            np.linspace(100.0, 1000.0, too_many_bins),
+            build_mobility_grid(1.1, 1.5),
+        )
+        assert refusal is not None
+        assert "--resample-bins" in refusal
 
     def test_the_count_is_what_is_refused_with_the_number_printed(self):
         assert var_ceiling_refusal(MAX_GRID_VAR_ENTRIES) is None
@@ -359,86 +389,6 @@ class TestVarCeiling:
         assert f"{MAX_GRID_VAR_ENTRIES + 1:,}" in refusal
         assert f"{MAX_GRID_VAR_ENTRIES:,}" in refusal
         assert "--mobility-bins" in refusal
-
-
-class TestMemoryProjection:
-    """The stopgap guard on a route that holds its whole table in RAM."""
-
-    def test_nothing_is_projected_from_too_few_pixels(self):
-        assert projected_memory_gb(10_000_000, 4, 26_000) is None
-        assert memory_refusal(10_000_000, 4, 26_000, available_gb=1.0) is None
-
-    def test_nothing_is_projected_once_every_pixel_is_in(self):
-        # By then there is nothing left to warn about.
-        assert projected_memory_gb(10_000_000, 400, 400) is None
-
-    def test_the_projection_scales_the_pixels_read_to_the_whole_image(self):
-        # Measured shape: 20,455,979 non-zeros over 400 pixels of a real
-        # acquisition is 109 GB extrapolated to its 26,000.
-        gb = projected_memory_gb(20_455_979, 400, 26_000)
-        assert gb == pytest.approx(109.0, abs=1.0)
-
-    def test_a_table_that_fits_the_machine_is_not_refused(self):
-        assert memory_refusal(20_455_979, 400, 1_465, available_gb=64.0) is None
-
-    def test_a_table_that_does_not_fit_is_refused_by_the_numbers(self):
-        refusal = memory_refusal(20_455_979, 400, 26_000, available_gb=64.0)
-        assert refusal is not None
-        assert "1,329,638,635" in refusal and "26,000" in refusal
-        assert "109.0 GB" in refusal and "64.0 GB" in refusal
-        assert "--region" in refusal and "--mobility-bins" in refusal
-
-    def test_the_same_table_can_fit_one_machine_and_not_another(self):
-        # Which is why the guard is a fraction of what is free, not a
-        # fixed size: this is routine on a workstation and fatal on a
-        # laptop, and a constant would be wrong on one of them.
-        assert memory_refusal(20_455_979, 400, 1_465, available_gb=64.0) is None
-        assert memory_refusal(20_455_979, 400, 1_465, available_gb=8.0) is not None
-
-    def test_a_fixture_that_fits_is_built(self, monkeypatch):
-        import thyra.converters.spatialdata.mobility_table as module
-
-        monkeypatch.setattr(module, "_PROJECTION_MIN_PIXELS", 2)
-        monkeypatch.setattr(module, "available_memory_gb", lambda: 64.0)
-        assert self._build(module) is not None
-
-    def test_the_accumulator_stops_reading_when_it_refuses(self, monkeypatch, caplog):
-        import thyra.converters.spatialdata.mobility_table as module
-
-        monkeypatch.setattr(module, "_PROJECTION_MIN_PIXELS", 2)
-        # A machine with a few bytes free: the four-pixel fixture is then
-        # on course for more than half of it.
-        monkeypatch.setattr(module, "available_memory_gb", lambda: 1e-9)
-        with caplog.at_level("WARNING"):
-            assert self._build(module) is None
-        assert "on course for" in caplog.text
-        assert "--region" in caplog.text
-
-    def test_a_table_between_the_two_thresholds_warns_and_is_still_built(
-        self, monkeypatch, caplog
-    ):
-        import thyra.converters.spatialdata.mobility_table as module
-
-        monkeypatch.setattr(module, "_PROJECTION_MIN_PIXELS", 2)
-        monkeypatch.setattr(module, "available_memory_gb", lambda: 64.0)
-        # Between the two thresholds: said out loud, and still written.
-        monkeypatch.setattr(module, "GRID_MEMORY_WARN_FRACTION", 0.0)
-        monkeypatch.setattr(module, "GRID_MEMORY_REFUSE_FRACTION", 1e9)
-        with caplog.at_level("WARNING"):
-            assert self._build(module) is not None
-        assert "accumulates the whole table in RAM" in caplog.text
-
-    @staticmethod
-    def _build(module):
-        return module.build_mobility_table(
-            GridStubReader(),
-            _stub_obs(),
-            MASS_AXIS,
-            "stub_z0",
-            "stub_z0_pixels",
-            {},
-            grid=build_mobility_grid(1.1, 1.5),
-        )
 
 
 def _stub_obs():
@@ -509,12 +459,14 @@ class TestGridTable:
         assert reader.mobility_passes == 1
 
     def test_on_request_the_sibling_appears(self, tmp_path, streaming):
+        reader = GridStubReader()
         sdata = _read(
-            _convert(
-                GridStubReader(), tmp_path / "s.zarr", streaming, mobility_grid=True
-            )
+            _convert(reader, tmp_path / "s.zarr", streaming, mobility_grid=True)
         )
         assert set(sdata.tables) == {"stub_z0", "stub_z0_mobility"}
+        # The grid's discovery shares the heatmap's pass; only the scatter
+        # is a pass of its own. Two reads of the raw points in all.
+        assert reader.mobility_passes == 2
         summed, grid = sdata.tables["stub_z0"], sdata.tables["stub_z0_mobility"]
         assert summed.n_obs == grid.n_obs == 4
         assert list(summed.obs.index) == list(grid.obs.index)

--- a/tests/unit/converters/test_msms_table.py
+++ b/tests/unit/converters/test_msms_table.py
@@ -11,6 +11,7 @@ acquisition whose precursors cannot be told apart must produce no table
 and a reason, never an apportioned guess.
 """
 
+import json
 from types import SimpleNamespace
 
 import numpy as np
@@ -209,9 +210,7 @@ class TestTheRowMirror:
         )
 
     def test_uns_carries_the_provenance_and_the_feature_axis(self):
-        import json
-
-        uns = _build().uns
+        uns = _build(_reader(ramp=RAMP)).uns
 
         assert uns["provenance"] == "unchanged"
         assert json.loads(uns["feature_axis"]["dims"]) == [
@@ -220,6 +219,24 @@ class TestTheRowMirror:
             "mz",
         ]
         assert uns["feature_axis"]["summed_table"] == "msi_z0"
+
+
+class TestTheDescriptorMatchesTheColumns:
+    def test_with_a_ramp_the_mobility_dimension_is_named(self):
+        table = _build(_reader(ramp=RAMP))
+        assert "precursor_mobility" in table.var.columns
+        assert json.loads(table.uns["feature_axis"]["dims"]) == [
+            "precursor_mz",
+            "precursor_mobility",
+            "mz",
+        ]
+
+    def test_without_a_ramp_it_is_not(self):
+        # A descriptor naming a column the table does not carry is a lie
+        # a consumer could act on.
+        table = _build()
+        assert "precursor_mobility" not in table.var.columns
+        assert json.loads(table.uns["feature_axis"]["dims"]) == ["precursor_mz", "mz"]
 
 
 class TestRefusals:

--- a/thyra/__main__.py
+++ b/thyra/__main__.py
@@ -532,9 +532,11 @@ class GroupedCommand(click.Command):
         "When the source carries ion mobility per pixel rather than as a "
         "shared feature list (Bruker TDF), bin the point cloud onto a common "
         "mobility grid and write the same mobility-resolved sibling table "
-        "(default: disabled; one extra pass over the source and a much larger "
-        "table). Also switches the summed spectrum to --tdf-spectrum scan_sum "
-        "unless that was given explicitly, which moves the stored TIC"
+        "(default: disabled; one extra pass over the source beyond the "
+        "heatmap's and a much larger table, built out of core so any "
+        "acquisition fits). Also switches the summed spectrum to "
+        "--tdf-spectrum scan_sum unless that was given explicitly, which "
+        "moves the stored TIC"
     ),
 )
 @click.option(
@@ -544,7 +546,9 @@ class GroupedCommand(click.Command):
         "When the source isolates several precursors per pixel in disjoint "
         "mobility slices (Bruker PASEF), also write them split apart as a "
         "demultiplexed sibling table next to the summed MSI table "
-        "(default: disabled; one extra pass over the source)"
+        "(default: disabled; two extra passes over the source). Also switches "
+        "the summed spectrum to --tdf-spectrum scan_sum unless that was given "
+        "explicitly, so the split adds back up to it exactly"
     ),
 )
 @click.option(

--- a/thyra/convert.py
+++ b/thyra/convert.py
@@ -98,17 +98,17 @@ def _validate_paths(input_path: Path, output_path: Path) -> bool:
 def _create_reader(
     input_path: Path,
     reader_options: Optional[Dict[str, Any]] = None,
-    lossless_spectrum: bool = False,
+    lossless_spectrum: str = "",
 ) -> Tuple[Any, str]:
     """Create and return a reader for the input format.
 
     Args:
         input_path: Path to the input MSI data
         reader_options: Optional format-specific reader options (e.g., calibration settings)
-        lossless_spectrum: Ask the reader for the summed spectrum that
-            keeps all of the ion current, where it has a choice. Set when
-            a mobility grid table is being written, so the grid's
-            marginal reproduces the summed table exactly.
+        lossless_spectrum: Names the sibling table being written that
+            needs the summed spectrum to keep all of the ion current
+            (``"mobility grid"``, ``"demultiplexed MS/MS"``), so that
+            table adds back up to the summed one exactly; empty when none.
 
     Returns:
         Tuple of (reader instance, detected format string)
@@ -121,32 +121,35 @@ def _create_reader(
     # Pass reader options to the reader if provided
     options = dict(reader_options or {})
     if lossless_spectrum:
-        _force_scan_sum(reader_class, options)
+        _force_scan_sum(reader_class, options, lossless_spectrum)
     return reader_class(input_path, **options), input_format
 
 
-def _force_scan_sum(reader_class: Any, options: Dict[str, Any]) -> None:
+def _force_scan_sum(reader_class: Any, options: Dict[str, Any], what: str) -> None:
     """Switch a TDF reader to the lossless summed spectrum, out loud.
 
-    A mobility grid table is built from the raw scans, so its marginal
-    over channels reproduces the summed table only when that table was
-    built from the same scans. The vendor centroid is a peak-picked
-    spectrum over the same ramp and keeps 80-90% of the ion current, so
-    with it the two tables of one store genuinely do not add up.
+    A sibling table -- the mobility grid, the demultiplexed MS/MS table --
+    is built from the raw scans, so it reproduces the summed table (the
+    grid's marginal over channels, the split's blocks added back up) only
+    when that table was built from the same scans. The vendor centroid is
+    a peak-picked spectrum over the same ramp and keeps 80-90% of the ion
+    current, so with it the two tables of one store genuinely do not add
+    up.
 
     The switch moves the stored TIC by 13-21%, which reads as a bug if it
     happens quietly, so it is said at WARNING -- and never applied over an
     explicit ``--tdf-spectrum``, which is the caller saying they want the
-    other one and will live with the mismatch.
+    other one and will live with the mismatch, which the sibling's
+    ``uns`` block then records.
     """
     import inspect
 
     if "tdf_spectrum" in options:
         logger.warning(
-            "A mobility grid was asked for with --tdf-spectrum %s. The grid "
-            "reads raw scans, so its marginal over mobility channels will "
-            "not reproduce the summed table; uns['mobility_marginal'] on the "
-            "grid table records by how much.",
+            "A %s table was asked for with --tdf-spectrum %s. The table reads "
+            "raw scans, so it will not add back up to the summed table; its "
+            "uns block records by how much.",
+            what,
             options["tdf_spectrum"],
         )
         return
@@ -158,14 +161,24 @@ def _force_scan_sum(reader_class: Any, options: Dict[str, Any]) -> None:
         return
     options["tdf_spectrum"] = "scan_sum"
     logger.warning(
-        "Writing a mobility grid table, so the summed spectrum is built with "
+        "Writing a %s table, so the summed spectrum is built with "
         "--tdf-spectrum scan_sum instead of the default vendor centroid: the "
-        "grid's marginal over mobility channels must reproduce the summed "
-        "table, and only the lossless sum does. This moves the stored TIC by "
-        "13-21% against a default conversion of the same file. Pass "
-        "--tdf-spectrum vendor_centroid to keep the centroid and accept the "
-        "mismatch."
+        "table must add back up to the summed table, and only the lossless "
+        "sum does. This moves the stored TIC by 13-21%% against a default "
+        "conversion of the same file. Pass --tdf-spectrum vendor_centroid to "
+        "keep the centroid and accept the mismatch.",
+        what,
     )
+
+
+def _lossless_spectrum_for(kwargs: Dict[str, Any]) -> str:
+    """Which sibling table, if any, needs the lossless summed spectrum."""
+    wanted = []
+    if kwargs.get("mobility_grid", False):
+        wanted.append("mobility grid")
+    if kwargs.get("msms_table", False):
+        wanted.append("demultiplexed MS/MS")
+    return " and ".join(wanted)
 
 
 def _determine_pixel_size(
@@ -491,7 +504,7 @@ def convert_msi(
         reader, input_format = _create_reader(
             input_path,
             reader_options,
-            lossless_spectrum=bool(kwargs.get("mobility_grid", False)),
+            lossless_spectrum=_lossless_spectrum_for(kwargs),
         )
 
         # Determine pixel size

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -271,16 +271,28 @@ def _calc_optical_scale_factors(
 _MARGINAL_TOLERANCE = 1e-9
 
 
-def _marginal_current(
-    table: Any, row_totals: Any, summed_key: str
+def _current_ratio_block(
+    table: Any,
+    summed_key: str,
+    summed: Any = None,
+    row_totals: Any = None,
 ) -> Optional[Dict[str, Any]]:
-    """The current ratio alone, against per-pixel totals of the summed table.
+    """How much of the summed table's ion current a sibling holds, per pixel.
 
-    What the streaming route can say without the summed matrix: the ratio
-    is the same number either way, since a marginal over every m/z bin of
-    a pixel is that pixel's row sum.
+    Against the summed matrix when it is in hand, else against per-pixel
+    totals of it -- which is what the streaming route has, since it writes
+    the summed table straight to disk and never holds it. The ratio is the
+    same number either way: a sibling's row sum over every one of its
+    columns is that pixel's ion current, and so is the summed table's.
+    ``None`` when the two cannot be compared (a row count mismatch, no
+    ion current at all), which is not a disagreement.
     """
-    totals = np.asarray(row_totals, dtype=np.float64).ravel()
+    if summed is not None:
+        totals = np.asarray(summed.X.sum(axis=1)).ravel().astype(np.float64)
+    elif row_totals is not None:
+        totals = np.asarray(row_totals, dtype=np.float64).ravel()
+    else:
+        return None
     split = np.asarray(table.X.sum(axis=1)).ravel().astype(np.float64)
     if split.size != totals.size or not totals.any():
         return None
@@ -317,8 +329,11 @@ def _marginal_agreement(
         ),
         shape=(int(mz_index.size), n_axis),
     )
-    marginal = sparse.csr_matrix(table.X) @ collapse
-    whole = sparse.csr_matrix(summed.X)
+    # The sibling's matrix is left in whatever format it came in (on the
+    # assembly's memmaps, when it was built out of core): scipy converts
+    # the small collapse operator to match rather than the other way round.
+    marginal = table.X @ collapse
+    whole = summed.X
     if marginal.shape != whole.shape:
         return None
     total = np.asarray(whole.sum(axis=1)).ravel().astype(np.float64)
@@ -634,6 +649,13 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         self._mobility_bounds = (mobility_min, mobility_max)
         self._mobility_grid: Optional[MobilityGrid] = None
         self._mobility_grid_resolved = False
+        # The grid's discovery pass for the slice being written, when the
+        # converter ran it fused with the heatmap's pass (see
+        # _prepare_sibling_scans); consumed by _attach_sibling_tables.
+        self._grid_discovery: Any = None
+        # Scratch directories holding the memmapped matrices of sibling
+        # tables until they are written; released by _release_sibling_scratch.
+        self._sibling_scratch: List[Tuple[Any, Path]] = []
         # The mass-mobility heatmap (see mobility_heatmap.py): built once
         # per conversion, on first demand, and shared by every uns block
         # that asks for it. ``_built`` distinguishes "not yet" from
@@ -835,6 +857,13 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                     metadata.update(spec_meta)
         except Exception as e:
             logger.debug(f"Could not extract spectrum metadata: {e}")
+
+    def convert(self) -> bool:
+        """Run the base workflow; release sibling scratch on every exit path."""
+        try:
+            return super().convert()
+        finally:
+            self._release_sibling_scratch()
 
     def build_uns_metadata(self) -> Dict[str, Any]:
         """The provenance block every write path must persist, identically.
@@ -1157,7 +1186,119 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             )
         return grid
 
-    def _attach_mobility_table(
+    def _prepare_sibling_scans(
+        self, obs: pd.DataFrame, z_value: Optional[int] = None
+    ) -> None:
+        """Run the raw mobility pass once for everything that needs it.
+
+        Called by a finalize step right after the sibling tables are
+        planned and before the summed table's ``uns`` is built, with the
+        ``obs`` the siblings will mirror. When a grid table is planned its
+        discovery pass -- which occupied cells there are, and how many
+        rows each holds -- is fused into the heatmap's pass, so the two
+        share one read *and* one mapping of every point onto the mass
+        axis; the mapping is the larger cost of the two. The heatmap is
+        built here once and cached for every ``uns`` block that asks; a
+        route that never calls this still gets it from
+        :meth:`_ensure_mobility_heatmap` on first demand.
+        """
+        self._grid_discovery = None
+        try:
+            if not getattr(self.reader, "has_ion_mobility", False):
+                return
+        except Exception as e:  # pragma: no cover - reader-defined
+            logger.warning("Could not inspect the mobility axis: %s", e)
+            return
+        if self._common_mass_axis is None:
+            return
+        from .mobility_heatmap import finish_mobility_heatmap, scan_mobility
+
+        heatmap = self._pending_heatmap()
+        discovery = self._pending_grid_discovery(obs, z_value)
+        sinks = [sink for sink in (heatmap, discovery) if sink is not None]
+        if not sinks:
+            return
+        try:
+            scan_mobility(
+                self.reader,
+                self._common_mass_axis,
+                *sinks,
+                n_spectra=self._get_total_spectra_count(),
+                description=(
+                    "Mobility heatmap + grid"
+                    if discovery is not None
+                    else "Mobility heatmap"
+                ),
+            )
+        except Exception as e:
+            logger.error("Could not scan the mobility spectra: %s", e)
+            if heatmap is not None:
+                self._mobility_heatmap_built = True
+                self._mobility_heatmap_block = None
+            return
+        if heatmap is not None:
+            self._mobility_heatmap_built = True
+            self._mobility_heatmap_block = finish_mobility_heatmap(heatmap)
+        if discovery is not None:
+            discovery.finish()
+            self._grid_discovery = discovery
+
+    def _pending_heatmap(self) -> Any:
+        """An empty heatmap accumulator, when one is wanted and not yet built."""
+        if not self._mobility_heatmap_enabled or self._mobility_heatmap_built:
+            return None
+        from .mobility_heatmap import prepare_mobility_heatmap
+
+        return prepare_mobility_heatmap(self.reader, self._common_mass_axis)
+
+    def _pending_grid_discovery(self, obs: pd.DataFrame, z_value: Optional[int]) -> Any:
+        """The grid's discovery accumulator, when a grid table is planned."""
+        if self._mobility_table_key is None or self._mobility_grid is None:
+            return None
+        from .mobility_table import GridDiscovery, row_lookup
+
+        try:
+            return GridDiscovery(
+                self._common_mass_axis,
+                self._mobility_grid,
+                row_lookup(obs, z_value, None),
+                int(len(obs)),
+            )
+        except MemoryError as e:
+            logger.warning("No mobility-resolved table: %s", e)
+            return None
+
+    def _new_sibling_scratch(self, prefix: str) -> Path:
+        """A scratch directory for one sibling's memmaps, next to the output."""
+        from .csc_assembly import scratch_directory
+
+        return scratch_directory(f".thyra_{prefix}_", parent=self.output_path.parent)
+
+    def _release_sibling_scratch(self, tables: Optional[Dict[str, Any]] = None) -> None:
+        """Drop the sibling tables' memmaps and remove their scratch directories.
+
+        Called once the siblings are written. ``tables`` is the mapping
+        that still holds them; its sibling entries are removed first,
+        because a mapped file cannot be deleted on Windows and the AnnData
+        is what keeps it mapped. Idempotent, so the ``finally`` of every
+        route can call it too.
+        """
+        from .csc_assembly import remove_scratch
+
+        if not self._sibling_scratch:
+            return
+        if tables is not None:
+            for key in (self._mobility_table_key, self._msms_table_key):
+                if key is not None:
+                    tables.pop(key, None)
+        pending = self._sibling_scratch
+        self._sibling_scratch = []
+        for assembly, path in pending:
+            if assembly is not None:
+                assembly.release()
+            remove_scratch(path)
+
+    def _attach_sibling_tables(
         self,
         data_structures: Dict[str, Any],
         table_key: str,
@@ -1166,46 +1307,108 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         z_value: Optional[int] = None,
         summed_row_totals: Optional[NDArray[np.float64]] = None,
     ) -> None:
-        """Build the mobility-resolved sibling of ``table_key`` and add it.
+        """Build the sibling tables of ``table_key`` and add them.
 
-        No-op unless :meth:`_plan_mobility_table` named one for this slice.
-        A failure here is logged and leaves the summed table untouched: the
-        sibling is additive, and a store without it is still complete.
+        No-op for a sibling :meth:`_plan_mobility_table` or
+        :meth:`_plan_msms_table` did not name for this slice. A failure
+        is logged and leaves the summed table untouched: the siblings are
+        additive, and a store without them is still complete.
+
+        ``summed_row_totals`` is the summed table's per-pixel ion current
+        for a route that does not hold the summed matrix (the streaming
+        route's TIC image is exactly that); with it, every sibling still
+        records how much of that current it holds.
         """
-        key = self._mobility_table_key
-        if key is None or self._common_mass_axis is None:
+        if self._common_mass_axis is None:
             return
-        from .mobility_table import build_mobility_table
-
-        # The sibling carries the same provenance as the summed table,
+        if self._mobility_table_key is None and self._msms_table_key is None:
+            return
+        # The siblings carry the same provenance as the summed table,
         # minus the heatmap: that block is the summed table's navigator
-        # over the very data the sibling holds resolved.
+        # over the very data the siblings hold resolved or split.
         sibling_uns = self.build_uns_metadata()
         sibling_uns.pop("mobility_heatmap", None)
+        summed = data_structures["tables"].get(table_key)
+        if self._mobility_table_key is not None:
+            table = self._build_mobility_sibling(
+                obs, table_key, region_key, dict(sibling_uns), z_value
+            )
+            if table is not None:
+                if self._mobility_grid is not None:
+                    self._record_mobility_marginal(
+                        table, summed, table_key, summed_row_totals
+                    )
+                data_structures["tables"][self._mobility_table_key] = table
+        if self._msms_table_key is not None:
+            table = self._build_msms_sibling(
+                obs, table_key, region_key, dict(sibling_uns), z_value
+            )
+            if table is not None:
+                self._record_demultiplexed_current(
+                    table, summed, table_key, summed_row_totals
+                )
+                data_structures["tables"][self._msms_table_key] = table
+
+    def _build_mobility_sibling(
+        self,
+        obs: pd.DataFrame,
+        table_key: str,
+        region_key: str,
+        uns: Dict[str, Any],
+        z_value: Optional[int],
+    ) -> Optional[Any]:
+        """The mobility sibling of one slice, on a scratch directory of its own."""
+        from .mobility_table import build_mobility_table
+
+        discovery, self._grid_discovery = self._grid_discovery, None
+        scratch = self._new_sibling_scratch("mobility")
+        self._sibling_scratch.append(
+            (None if discovery is None else discovery.assembly, scratch)
+        )
         try:
-            table = build_mobility_table(
+            return build_mobility_table(
                 self.reader,
                 obs,
                 self._common_mass_axis,
                 table_key,
                 region_key,
-                sibling_uns,
+                uns,
                 z_value=z_value,
                 grid=self._mobility_grid,
+                discovery=discovery,
+                scratch=scratch,
             )
         except Exception as e:
             logger.error("Could not build the mobility-resolved table: %s", e)
-            return
-        if table is None:
-            return
-        if self._mobility_grid is not None:
-            self._record_mobility_marginal(
-                table,
-                data_structures["tables"].get(table_key),
+            return None
+
+    def _build_msms_sibling(
+        self,
+        obs: pd.DataFrame,
+        table_key: str,
+        region_key: str,
+        uns: Dict[str, Any],
+        z_value: Optional[int],
+    ) -> Optional[Any]:
+        """The demultiplexed sibling of one slice, on a scratch directory of its own."""
+        from .msms_table import build_msms_table
+
+        scratch = self._new_sibling_scratch("msms")
+        self._sibling_scratch.append((None, scratch))
+        try:
+            return build_msms_table(
+                self.reader,
+                obs,
+                self._common_mass_axis,
                 table_key,
-                summed_row_totals,
+                region_key,
+                uns,
+                z_value=z_value,
+                scratch=scratch,
             )
-        data_structures["tables"][key] = table
+        except Exception as e:
+            logger.error("Could not build the demultiplexed MS/MS table: %s", e)
+            return None
 
     @staticmethod
     def _record_mobility_marginal(
@@ -1235,10 +1438,8 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         try:
             if summed is not None:
                 block = _marginal_agreement(table, summed, summed_key)
-            elif row_totals is not None:
-                block = _marginal_current(table, row_totals, summed_key)
             else:
-                return
+                block = _current_ratio_block(table, summed_key, row_totals=row_totals)
         except Exception as e:  # pragma: no cover - defensive
             logger.debug("Could not compare the mobility marginal: %s", e)
             return
@@ -1338,35 +1539,34 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         data_structures["tables"][key] = table
 
     @staticmethod
-    def _record_demultiplexed_current(table: Any, summed: Any, summed_key: str) -> None:
+    def _record_demultiplexed_current(
+        table: Any,
+        summed: Any,
+        summed_key: str,
+        row_totals: Optional[NDArray[np.float64]] = None,
+    ) -> None:
         """Say how much of the summed table's ion current the split holds.
 
-        The two tables agree exactly under ``--tdf-spectrum scan_sum``, and
-        do not under the default ``vendor_centroid``: the vendor peak
-        picker drops single counts while the split reads raw scans, so the
-        demultiplexed table holds *more*. That is not a defect, but a store
-        whose two tables disagree must say so rather than leave a reader to
-        find it by subtraction.
+        The two tables agree exactly under ``--tdf-spectrum scan_sum``,
+        which writing this table now selects; under an explicit
+        ``vendor_centroid`` they do not, because the vendor peak picker
+        drops single counts while the split reads raw scans, so the
+        demultiplexed table holds *more*. That is not a defect, but a
+        store whose two tables disagree must say so rather than leave a
+        reader to find it by subtraction. ``row_totals`` stands in for the
+        summed matrix on the route that never holds it.
         """
-        if summed is None:
-            return
         try:
-            split = np.asarray(table.X.sum(axis=1)).ravel().astype(np.float64)
-            whole = np.asarray(summed.X.sum(axis=1)).ravel().astype(np.float64)
-            if split.size != whole.size or not whole.any():
-                return
-            per_pixel = split / np.where(whole == 0, np.nan, whole)
-            block: Dict[str, Any] = {
-                "summed_table": summed_key,
-                "current_ratio": float(split.sum() / whole.sum()),
-                "current_ratio_pixel_min": float(np.nanmin(per_pixel)),
-                "current_ratio_pixel_max": float(np.nanmax(per_pixel)),
-            }
+            block = _current_ratio_block(
+                table, summed_key, summed=summed, row_totals=row_totals
+            )
         except Exception as e:  # pragma: no cover - defensive
             logger.debug("Could not compare the demultiplexed current: %s", e)
             return
+        if block is None:
+            return
         table.uns["demultiplexed_current"] = block
-        if abs(float(block["current_ratio"]) - 1.0) > 1e-9:
+        if abs(float(block["current_ratio"]) - 1.0) > _MARGINAL_TOLERANCE:
             logger.info(
                 "The demultiplexed table holds %.4fx the summed table's ion "
                 "current (per pixel %.4f to %.4f). They agree exactly only "
@@ -3222,6 +3422,10 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 sdata.write(str(self.output_path))
                 zarr.consolidate_metadata(str(self.output_path))
             logger.info(f"Successfully saved SpatialData to {self.output_path}")
+            # The sibling tables were written from their memmaps; nothing
+            # holds them now but this object and the caller's mapping.
+            del sdata
+            self._release_sibling_scratch(data_structures.get("tables"))
             return True
         except Exception as e:
             logger.error(f"Error saving SpatialData: {e}")

--- a/thyra/converters/spatialdata/csc_assembly.py
+++ b/thyra/converters/spatialdata/csc_assembly.py
@@ -1,0 +1,365 @@
+"""Out-of-core assembly of a pixels x features CSC matrix, in two passes.
+
+The sibling tables -- the mobility-resolved table and the demultiplexed
+MS/MS table -- are each a sparse matrix whose columns are the *occupied*
+cells of a key space known before anything is read: ``(m/z bin, mobility
+channel)`` for the grid, ``(precursor, m/z bin)`` for the demultiplexer,
+the source's own feature list for a shared mobility axis. A pixel's
+entries can be enumerated from the source in one pass and again in a
+second, identically, so nothing ever needs to be held for the whole
+image. This module is that shape, factored out of the two tables so both
+bound their memory the same way the summed table already does on the
+streaming route (``StreamingSpatialDataConverter._convert_to_csc_no_cache``:
+pre-scan, count, scatter into a memmap).
+
+**Pass 1 -- counting.** :meth:`CscAssembly.count` takes one row's unique
+keys. A dense ``uint32`` count per key over the key span is the whole
+state: ``span * 4`` bytes, known before the first pixel is read and
+independent of how many pixels there are. :meth:`finish_counting` then
+names the occupied keys, and that is the moment a caller checks its
+feature ceiling -- before a single value has been buffered, which is what
+the ceiling is for.
+
+**Pass 2 -- scattering.** :meth:`allocate` sizes CSC ``indices`` and
+``data`` arrays from the counts and backs them with files in a scratch
+directory; :meth:`scatter` writes one row's values straight to their final
+positions. Memory in this pass is one row plus the per-column write
+cursor. When rows arrive in ascending order -- a raster acquisition read
+in acquisition order, which is every source measured so far -- every
+column's row indices come out ascending and the matrix is canonical
+without a sort: the ``COO -> CSC`` conversion the tables used to pay for,
+one scipy call over the whole image and the single largest phase of a
+measured grid conversion, is gone rather than tuned. A source read in
+some other order gets its columns sorted afterwards, a bounded chunk of
+columns at a time, so the stored matrix is canonical either way.
+
+:meth:`matrix` wraps the memmaps as a :class:`scipy.sparse.csc_matrix`
+without copying them (index dtypes are chosen up front by scipy's own
+rule so its constructor takes the arrays as they are), and the AnnData
+built on it is written from disk to disk. The scratch directory has to
+outlive that write; :meth:`release` drops the mappings so the caller can
+remove it, and :func:`release_when_collected` ties the directory's life to
+the table for an API caller who has nowhere else to put it.
+"""
+
+import gc
+import logging
+import shutil
+import tempfile
+import weakref
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+from numpy.typing import NDArray
+from scipy import sparse
+
+logger = logging.getLogger(__name__)
+
+#: Bytes the per-key count array of pass 1 may take. It is ``span * 4``
+#: with ``span`` the key space -- ``mass axis bins x mobility channels``
+#: for the grid, which on a default-resampled timsTOF axis is 35.5M pairs
+#: and 142 MB. A raw, unresampled axis of several million bins would push
+#: it into gigabytes, and that is a source to resample rather than a
+#: table to build: the same axis would also blow the feature ceiling.
+MAX_COUNT_BYTES = 1 << 30
+
+#: Entries loaded at once when a column chunk has to be sorted after the
+#: scatter (a source read out of raster order). Bounds that pass to a few
+#: hundred megabytes whatever the matrix size.
+SORT_CHUNK_ENTRIES = 16_000_000
+
+_COUNT_DTYPE = np.uint32
+
+
+def index_dtype(n_nonzeros: int, n_rows: int) -> Any:
+    """The index dtype scipy would give a CSC matrix of this size.
+
+    Its rule for a ``COO -> CSC`` conversion: ``int32`` unless the
+    non-zero count or the row count needs more. Choosing the same dtype
+    here is what lets the constructor take the memmaps without a copy,
+    and what makes the stored ``indices`` and ``indptr`` identical to what
+    the conversion route used to write.
+    """
+    limit = int(np.iinfo(np.int32).max)
+    return np.int32 if max(int(n_nonzeros), int(n_rows)) < limit else np.int64
+
+
+def count_bytes(span: int) -> int:
+    """What pass 1 allocates for a key space of ``span`` keys."""
+    return int(span) * int(np.dtype(_COUNT_DTYPE).itemsize)
+
+
+def count_refusal(span: int) -> Optional[str]:
+    """Why a key space this wide cannot be counted, or ``None``."""
+    needed = count_bytes(span)
+    if needed <= MAX_COUNT_BYTES:
+        return None
+    return (
+        f"the feature space spans {int(span):,} keys and counting them needs "
+        f"{needed / 1024**3:.1f} GB, above the {MAX_COUNT_BYTES / 1024**3:.0f} GB "
+        f"this pass allows; resample to fewer mass bins (--resample-bins)"
+    )
+
+
+class CscAssembly:
+    """A pixels x keys CSC matrix built out of core, one row at a time.
+
+    Args:
+        span: Size of the key space; every key handed in is in
+            ``[0, span)``.
+        n_rows: Number of rows of the finished matrix.
+        keep_empty_columns: Whether every key of the span is a column of
+            the matrix, occupied or not. Right when the span *is* a
+            declared feature list (a shared mobility axis) whose empty
+            features are still features; wrong for a grid, whose span is
+            mostly empty by construction, so there only the occupied keys
+            become columns.
+
+    Keys within one :meth:`count` or :meth:`scatter` call must be unique
+    and ascending -- one entry per occupied cell of that row, which is
+    what the callers produce by collapsing a row before handing it over.
+    :meth:`scatter` must be called for exactly the rows :meth:`count` was,
+    in the same order; a row may be handed in more than once when its
+    entries come in several disjoint groups (one per precursor, say).
+    """
+
+    def __init__(
+        self, span: int, n_rows: int, keep_empty_columns: bool = False
+    ) -> None:
+        """Allocate the count array; refuses a span too wide to count."""
+        refusal = count_refusal(span)
+        if refusal is not None:
+            raise MemoryError(refusal)
+        self.span = int(span)
+        self.n_rows = int(n_rows)
+        self._keep_empty = bool(keep_empty_columns)
+        self._counts: Optional[NDArray[np.uint32]] = np.zeros(
+            self.span, dtype=_COUNT_DTYPE
+        )
+        self.n_nonzeros = 0
+        #: Whether every row so far arrived at or after the previous one.
+        #: Ascending rows make the scattered columns canonical for free.
+        self.rows_in_order = True
+        self._last_row = -1
+        self.unique_keys: Optional[NDArray[np.int64]] = None
+        self.indptr: Optional[NDArray[Any]] = None
+        self._column_of_key: Optional[NDArray[np.uint32]] = None
+        self._write_pos: Optional[NDArray[np.int64]] = None
+        self._indices: Optional[np.memmap] = None
+        self._data: Optional[np.memmap] = None
+        self._index_dtype: Any = None
+
+    def _note_row(self, row: int) -> None:
+        if row < self._last_row:
+            self.rows_in_order = False
+        self._last_row = int(row)
+
+    # -- pass 1 ----------------------------------------------------------
+
+    def count(self, row: int, keys: NDArray[np.int64]) -> None:
+        """Record the occupied keys of one row."""
+        if self._counts is None:
+            raise RuntimeError("Counting is finished; this row cannot be added")
+        self._note_row(row)
+        if keys.size:
+            # Unique within the row, so a fancy-indexed increment is exact.
+            self._counts[keys] += 1
+            self.n_nonzeros += int(keys.size)
+
+    def finish_counting(self) -> int:
+        """Name the occupied keys; returns how many there are.
+
+        Nothing wide is allocated here beyond the key list itself, so a
+        caller can still refuse the matrix on that number.
+        """
+        if self._counts is None:
+            raise RuntimeError("Counting is already finished")
+        if self._keep_empty:
+            self.unique_keys = np.arange(self.span, dtype=np.int64)
+        else:
+            self.unique_keys = np.flatnonzero(self._counts).astype(np.int64)
+        self._last_row = -1
+        return int(self.unique_keys.size)
+
+    # -- pass 2 ----------------------------------------------------------
+
+    def allocate(self, scratch: Path) -> None:
+        """Size the CSC arrays from the counts and back them with files."""
+        if self._counts is None or self.unique_keys is None:
+            raise RuntimeError("allocate() needs finish_counting() first")
+        counts = self._counts
+        n_cols = int(self.unique_keys.size)
+        self._index_dtype = index_dtype(self.n_nonzeros, self.n_rows)
+        indptr = np.zeros(n_cols + 1, dtype=np.int64)
+        np.cumsum(counts[self.unique_keys], out=indptr[1:])
+        self.indptr = indptr.astype(self._index_dtype, copy=False)
+        self._write_pos = indptr[:-1].copy()
+        if self._keep_empty:
+            # Every key is its own column; no map is needed.
+            self._column_of_key = None
+        else:
+            # The key -> column map, in place of the counts: a running count
+            # of occupied keys, so column = map[key] - 1 (an unoccupied key
+            # would read as the column before it, and is never asked for).
+            np.cumsum(counts != 0, out=counts)
+            self._column_of_key = counts
+        self._counts = None
+        size = max(self.n_nonzeros, 1)
+        scratch = Path(scratch)
+        scratch.mkdir(parents=True, exist_ok=True)
+        self._indices = np.memmap(
+            scratch / "csc_indices.bin",
+            dtype=self._index_dtype,
+            mode="w+",
+            shape=(size,),
+        )
+        self._data = np.memmap(
+            scratch / "csc_data.bin", dtype=np.float64, mode="w+", shape=(size,)
+        )
+        logger.info(
+            "Scattering %s non-zeros over %s columns to %s (%.2f GB on disk)",
+            f"{self.n_nonzeros:,}",
+            f"{n_cols:,}",
+            scratch,
+            size * (np.dtype(self._index_dtype).itemsize + 8) / 1024**3,
+        )
+
+    def scatter(
+        self, row: int, keys: NDArray[np.int64], values: NDArray[np.float64]
+    ) -> None:
+        """Write one row's values to their final CSC positions."""
+        if self._write_pos is None:
+            raise RuntimeError("scatter() needs allocate() first")
+        if self._indices is None or self._data is None:
+            raise RuntimeError("scatter() after release()")
+        self._note_row(row)
+        if not keys.size:
+            return
+        if self._column_of_key is None:
+            columns = keys
+        else:
+            columns = self._column_of_key[keys].astype(np.int64) - 1
+        destinations = self._write_pos[columns]
+        self._indices[destinations] = row
+        self._data[destinations] = values
+        self._write_pos[columns] += 1
+
+    def matrix(self) -> sparse.csc_matrix:
+        """The finished, canonical matrix over the memmaps, without copying them.
+
+        Every reserved slot must have been written: a column short of its
+        count would carry zero-filled entries at row 0, out of order, which
+        scipy reports as a non-canonical matrix. The callers guarantee it
+        by scattering exactly the rows they counted; this checks.
+        """
+        if self.indptr is None or self._write_pos is None:
+            raise RuntimeError("matrix() needs allocate() first")
+        if self._indices is None or self._data is None:
+            raise RuntimeError("matrix() after release()")
+        if not np.array_equal(self._write_pos, self.indptr[1:]):
+            short = int(np.count_nonzero(self._write_pos != self.indptr[1:]))
+            raise RuntimeError(
+                f"{short} columns were counted for more entries than were "
+                "scattered; the two passes disagree on which rows exist"
+            )
+        if not self.rows_in_order:
+            self._sort_columns()
+        self._indices.flush()
+        self._data.flush()
+        n_cols = int(self.indptr.size - 1)
+        return sparse.csc_matrix(
+            (self._data, self._indices, self.indptr), shape=(self.n_rows, n_cols)
+        )
+
+    def _sort_columns(self) -> None:
+        """Put each column's entries in ascending row order, chunk by chunk.
+
+        Only needed when the source handed its rows out of order; the
+        columns are already grouped, so this is a sort *within* columns
+        over a bounded slice of the arrays at a time.
+        """
+        assert self.indptr is not None and self._indices is not None
+        assert self._data is not None
+        indptr = self.indptr.astype(np.int64, copy=False)
+        n_cols = int(indptr.size - 1)
+        logger.info(
+            "Rows arrived out of raster order; sorting %s columns in chunks",
+            f"{n_cols:,}",
+        )
+        start_col = 0
+        while start_col < n_cols:
+            # The largest column range whose entries fit the chunk budget,
+            # and at least one column even when that column alone exceeds it.
+            end_col = int(
+                np.searchsorted(
+                    indptr, indptr[start_col] + SORT_CHUNK_ENTRIES, side="right"
+                )
+            )
+            end_col = max(min(end_col - 1, n_cols), start_col + 1)
+            lo, hi = int(indptr[start_col]), int(indptr[end_col])
+            if hi > lo:
+                rows = np.asarray(self._indices[lo:hi]).astype(np.int64)
+                column = np.repeat(
+                    np.arange(start_col, end_col, dtype=np.int64),
+                    np.diff(indptr[start_col : end_col + 1]),
+                )
+                # One combined key, unique because a row occurs once per
+                # column, sorted stably: the columns are already in order,
+                # so the key is a sequence of nearly sorted runs that
+                # timsort merges in a fraction of a general sort's time
+                # (measured 0.5 s against 3.1 s for lexsort on 16M entries).
+                order = np.argsort(column * self.n_rows + rows, kind="stable")
+                self._indices[lo:hi] = rows[order]
+                self._data[lo:hi] = np.asarray(self._data[lo:hi])[order]
+            start_col = end_col
+        self.rows_in_order = True
+
+    def release(self) -> None:
+        """Drop the mappings so the scratch files can be removed.
+
+        Arrays handed out by :meth:`matrix` are views on the same
+        mappings, so the table built on them has to be dropped too before
+        the directory can go -- Windows will not delete a mapped file.
+        """
+        self._indices = None
+        self._data = None
+        self._write_pos = None
+        self._column_of_key = None
+
+
+def scratch_directory(prefix: str, parent: Optional[Path] = None) -> Path:
+    """A fresh directory for the memmaps of one assembly."""
+    if parent is not None:
+        Path(parent).mkdir(parents=True, exist_ok=True)
+    return Path(
+        tempfile.mkdtemp(prefix=prefix, dir=None if parent is None else str(parent))
+    )
+
+
+def remove_scratch(path: Path) -> None:
+    """Remove a scratch directory; say so if a mapping still pins it."""
+    gc.collect()
+    shutil.rmtree(path, ignore_errors=True)
+    if Path(path).exists():
+        logger.warning(
+            "Could not remove the scratch directory %s (a table built on it "
+            "is still referenced); remove it by hand once the store is written",
+            path,
+        )
+
+
+def release_when_collected(owner: Any, assembly: CscAssembly, scratch: Path) -> None:
+    """Tie a scratch directory's life to the table built on it.
+
+    For callers of the table builders who supplied no scratch directory:
+    the memmaps are released and the directory removed when ``owner`` (the
+    AnnData) is garbage collected, or at interpreter exit, whichever comes
+    first.
+    """
+
+    def _cleanup() -> None:
+        assembly.release()
+        remove_scratch(scratch)
+
+    weakref.finalize(owner, _cleanup)

--- a/thyra/converters/spatialdata/mobility_heatmap.py
+++ b/thyra/converters/spatialdata/mobility_heatmap.py
@@ -21,6 +21,13 @@ bins. Under the vendor centroid it is not, and cannot be: the centroid
 keeps 80-90% of the ion current and merges bins, and the heatmap is built
 from the raw points, not from the centroid.
 
+The raw pass itself is :func:`scan_mobility`, which maps every pixel's
+points onto the mass axis once and hands the result to whichever sinks
+were given -- the heatmap, the mobility grid's discovery pass, or both.
+Mapping is the expensive part of the pass (the vendor read is a fifth of
+it), so a grid conversion that fuses its discovery into the heatmap's
+pass pays for it once rather than twice.
+
 Mobility is a feature coordinate. Nothing here knows where a pixel is.
 """
 
@@ -57,6 +64,8 @@ HEATMAP_MOBILITY_CHANNELS = MOBILITY_CHANNELS
 #: ``bincount`` over a few million entries is far cheaper than an
 #: ``add.at`` per frame; the buffer is bounded so memory stays flat.
 _FLUSH_POINTS = 4_000_000
+
+Coords = Tuple[int, int, int]
 
 
 def mz_bin_edges(
@@ -100,6 +109,44 @@ def mobility_bin_edges(
     happen to agree.
     """
     return build_mobility_grid(lower, upper, channels).edges
+
+
+def map_points_to_axis(
+    axis: NDArray[np.float64],
+    mzs: NDArray[np.float64],
+    mobility: NDArray[np.float64],
+    intensities: NDArray[np.float64],
+) -> Tuple[NDArray[np.int64], NDArray[np.float64], NDArray[np.float64], int]:
+    """One pixel's points onto the common mass axis, the summed table's way.
+
+    "In range" is the strict axis span, and a point outside it is dropped
+    rather than folded onto an edge bin -- the summed table drops it, so
+    a marginal over mobility that kept it would exceed the column it
+    mirrors. Points in range go to their nearest axis entry through the
+    converter's own rule (ties to the right). This is the one place the
+    mapping is written: the heatmap, the grid's discovery pass and the
+    grid's scatter pass all go through it, so they cannot disagree.
+
+    Returns:
+        ``(bins, mobility, intensities, n_dropped)`` -- the axis index of
+        every kept point, the two other arrays masked to match, and how
+        many points were dropped.
+    """
+    mzs = np.asarray(mzs, dtype=np.float64)
+    mobility = np.asarray(mobility, dtype=np.float64)
+    intensities = np.asarray(intensities, dtype=np.float64)
+    if mzs.size == 0:
+        return np.zeros(0, dtype=np.int64), mobility, intensities, 0
+    in_range = (mzs >= axis[0]) & (mzs <= axis[-1])
+    n_dropped = 0
+    if not in_range.all():
+        n_dropped = int(mzs.size - in_range.sum())
+        mzs = mzs[in_range]
+        mobility = mobility[in_range]
+        intensities = intensities[in_range]
+        if mzs.size == 0:
+            return np.zeros(0, dtype=np.int64), mobility, intensities, n_dropped
+    return _nn_map_to_bins(axis, mzs).astype(np.int64), mobility, intensities, n_dropped
 
 
 class MobilityHeatmap:
@@ -159,32 +206,39 @@ class MobilityHeatmap:
         range) is clipped into the edge channel rather than lost, so the
         marginal keeps every count.
         """
+        bins, mobility, intensities, n_dropped = map_points_to_axis(
+            self._axis, mzs, mobility, intensities
+        )
+        self.add_mapped(None, bins, mobility, intensities, n_dropped)
+
+    def add_mapped(
+        self,
+        coords: Optional[Coords],
+        bins: NDArray[np.int64],
+        mobility: NDArray[np.float64],
+        intensities: NDArray[np.float64],
+        n_dropped: int,
+    ) -> None:
+        """Fold in one pixel already mapped by :func:`map_points_to_axis`.
+
+        The sink interface :func:`scan_mobility` feeds; the heatmap does
+        not care where a pixel is, so ``coords`` is ignored.
+        """
         self.n_pixels += 1
-        mzs = np.asarray(mzs, dtype=np.float64)
-        if mzs.size == 0:
+        self.n_out_of_range += int(n_dropped)
+        if bins.size == 0:
             return
-        mobility = np.asarray(mobility, dtype=np.float64)
-        intensities = np.asarray(intensities, dtype=np.float64)
-        axis = self._axis
-        in_range = (mzs >= axis[0]) & (mzs <= axis[-1])
-        if not in_range.all():
-            self.n_out_of_range += int(mzs.size - in_range.sum())
-            mzs = mzs[in_range]
-            mobility = mobility[in_range]
-            intensities = intensities[in_range]
-            if mzs.size == 0:
-                return
-        mz_bin = _nn_map_to_bins(axis, mzs) // self._step
+        mz_bin = bins // self._step
         channel = linear_channel(
             mobility,
             self._mobility_lower,
             self._mobility_lower + self._mobility_span,
             self.n_mobility,
         )
-        self._buffer_cells.append(mz_bin.astype(np.int64) * self.n_mobility + channel)
-        self._buffer_weights.append(intensities)
-        self._buffered += int(mzs.size)
-        self.n_points += int(mzs.size)
+        self._buffer_cells.append(mz_bin * self.n_mobility + channel)
+        self._buffer_weights.append(np.asarray(intensities, dtype=np.float64))
+        self._buffered += int(bins.size)
+        self.n_points += int(bins.size)
         if self._buffered >= _FLUSH_POINTS:
             self._flush()
 
@@ -234,19 +288,14 @@ def _mobility_range(reader: BaseMSIReader) -> Optional[Tuple[float, float]]:
     return None
 
 
-def build_mobility_heatmap(
-    reader: BaseMSIReader,
-    mass_axis: NDArray[np.float64],
-    n_spectra: Optional[int] = None,
-) -> Optional[Dict[str, Any]]:
-    """Accumulate the heatmap over every pixel of ``reader``.
+def prepare_mobility_heatmap(
+    reader: BaseMSIReader, mass_axis: NDArray[np.float64]
+) -> Optional[MobilityHeatmap]:
+    """An empty heatmap sized for ``reader``, or ``None`` with the reason logged.
 
-    One pass over :meth:`BaseMSIReader.iter_mobility_spectra` -- the raw
-    scan read, which a Bruker source needs even when its summed spectrum
-    is the vendor centroid (one extra library call per frame, about a
-    millisecond). Returns ``None``, with the reason logged, when the
-    reader has no mobility dimension or its axis gives no range to bin
-    over (a per-pixel mobility source without a shared axis).
+    ``None`` when the reader has no mobility dimension or its axis gives
+    no range to bin over (a per-pixel mobility source without a shared
+    axis), or when the common mass axis is empty.
     """
     if not getattr(reader, "has_ion_mobility", False):
         return None
@@ -260,15 +309,11 @@ def build_mobility_heatmap(
     if np.asarray(mass_axis).size == 0:
         logger.warning("No mass-mobility heatmap: the common mass axis is empty")
         return None
+    return MobilityHeatmap(np.asarray(mass_axis, dtype=np.float64), mobility_range)
 
-    from tqdm import tqdm
 
-    heatmap = MobilityHeatmap(np.asarray(mass_axis, dtype=np.float64), mobility_range)
-    with tqdm(total=n_spectra, desc="Mobility heatmap", unit="spectrum") as pbar:
-        for _coords, mzs, mobility, intensities in reader.iter_mobility_spectra():
-            heatmap.add(mzs, mobility, intensities)
-            pbar.update(1)
-
+def finish_mobility_heatmap(heatmap: MobilityHeatmap) -> Optional[Dict[str, Any]]:
+    """The ``uns`` block of a heatmap the scan has been run over, or ``None``."""
     if heatmap.n_pixels == 0:
         logger.warning(
             "No mass-mobility heatmap: the source yielded no mobility spectra"
@@ -288,3 +333,55 @@ def build_mobility_heatmap(
         heatmap.n_points,
     )
     return heatmap.finalize()
+
+
+def scan_mobility(
+    reader: BaseMSIReader,
+    mass_axis: NDArray[np.float64],
+    *sinks: Any,
+    n_spectra: Optional[int] = None,
+    description: str = "Mobility scan",
+) -> None:
+    """One raw pass over :meth:`BaseMSIReader.iter_mobility_spectra`.
+
+    Every pixel's points are mapped onto the mass axis once, by
+    :func:`map_points_to_axis`, and handed to each sink's ``add_mapped``.
+    On a Bruker source this is the raw scan read, needed even when the
+    summed spectrum is the vendor centroid (one extra library call per
+    frame, about a millisecond); the mapping costs more than the read,
+    which is why the sinks share a pass rather than each taking one.
+    """
+    from tqdm import tqdm
+
+    axis = np.asarray(mass_axis, dtype=np.float64)
+    with tqdm(total=n_spectra, desc=description, unit="spectrum") as pbar:
+        for coords, mzs, mobility, intensities in reader.iter_mobility_spectra():
+            mapped = map_points_to_axis(axis, mzs, mobility, intensities)
+            for sink in sinks:
+                sink.add_mapped(coords, *mapped)
+            pbar.update(1)
+
+
+def build_mobility_heatmap(
+    reader: BaseMSIReader,
+    mass_axis: NDArray[np.float64],
+    n_spectra: Optional[int] = None,
+) -> Optional[Dict[str, Any]]:
+    """Accumulate the heatmap over every pixel of ``reader``.
+
+    One pass over :meth:`BaseMSIReader.iter_mobility_spectra`. Returns
+    ``None``, with the reason logged, when the reader has no mobility
+    dimension or its axis gives no range to bin over (a per-pixel mobility
+    source without a shared axis).
+    """
+    heatmap = prepare_mobility_heatmap(reader, mass_axis)
+    if heatmap is None:
+        return None
+    scan_mobility(
+        reader,
+        mass_axis,
+        heatmap,
+        n_spectra=n_spectra,
+        description="Mobility heatmap",
+    )
+    return finish_mobility_heatmap(heatmap)

--- a/thyra/converters/spatialdata/mobility_table.py
+++ b/thyra/converters/spatialdata/mobility_table.py
@@ -30,12 +30,21 @@ Either way:
   increasing; this table's ``mz`` is non-decreasing with duplicates, which
   is exactly what mobility splits.
 
+Both mechanisms are built in two passes over the source through
+:class:`~thyra.converters.spatialdata.csc_assembly.CscAssembly` -- count
+the occupied features, then scatter each pixel's values straight into
+memmapped CSC arrays -- so the table's memory is bounded by its feature
+space and one pixel, never by its size. That is the same shape the
+summed table takes on the streaming route, and it is what lets a whole
+acquisition convert rather than the few hundred frames that fit in RAM.
+
 Mobility is a feature coordinate: nothing here touches ``obs`` beyond
 copying it, and nothing enters a coordinate system.
 """
 
 import logging
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -44,14 +53,23 @@ from scipy import sparse
 
 from ...core.base_reader import BaseMSIReader
 from ...resampling.mobility_grid import MobilityGrid
+from .csc_assembly import (
+    CscAssembly,
+    count_refusal,
+    release_when_collected,
+    remove_scratch,
+    scratch_directory,
+)
+from .mobility_heatmap import Coords, scan_mobility
 
 logger = logging.getLogger(__name__)
 
 #: Suffix appended to the MSI table's key for its mobility-resolved sibling.
 MOBILITY_TABLE_SUFFIX = "_mobility"
 
-Coords = Tuple[int, int, int]
 RowLookup = Callable[[Coords], Optional[int]]
+
+_STRING = np.dtypes.StringDType()
 
 
 def mobility_table_key(table_key: str) -> str:
@@ -68,52 +86,83 @@ def feature_axis_block(summed_table_key: str) -> Dict[str, Any]:
     }
 
 
-def _var_labels(mz_index: NDArray[np.int64], mobility_index: NDArray[np.int64]) -> list:
-    """``mz{i}_im{j}`` per feature, disambiguated when two features share both."""
-    labels = [
-        f"mz{i}_im{j}" for i, j in zip(mz_index.tolist(), mobility_index.tolist())
-    ]
-    seen: Dict[str, int] = {}
-    out = []
-    for label in labels:
-        n = seen.get(label, 0)
-        seen[label] = n + 1
-        out.append(label if n == 0 else f"{label}_{n}")
+# ----------------------------------------------------------------------
+# Feature labels, and the row mirror both siblings share
+# ----------------------------------------------------------------------
+
+
+def int_strings(values: Any) -> NDArray[Any]:
+    """Integers as a variable-width string array, without Python objects."""
+    return np.asarray(values, dtype=np.int64).astype(_STRING)
+
+
+def disambiguate_labels(labels: NDArray[Any], group: NDArray[np.int64]) -> NDArray[Any]:
+    """Suffix ``_n`` on the n-th label (n >= 1) of every group, in order seen.
+
+    ``group`` names which labels collide (equal groups, equal labels).
+    Vectorised: the labels of a grid table are unique by construction and
+    there are millions of them, so this must cost a sort rather than a
+    Python dict of every string.
+    """
+    if group.size == 0:
+        return labels
+    order = np.argsort(group, kind="stable")
+    sorted_group = group[order]
+    starts = np.empty(sorted_group.size, dtype=bool)
+    starts[0] = True
+    starts[1:] = sorted_group[1:] != sorted_group[:-1]
+    if starts.all():
+        return labels
+    positions = np.arange(sorted_group.size, dtype=np.int64)
+    run_start = np.maximum.accumulate(np.where(starts, positions, 0))
+    ordinal = positions - run_start
+    repeated = ordinal > 0
+    out = labels.copy()
+    where = order[repeated]
+    out[where] = np.strings.add(
+        np.strings.add(labels[where], "_"), int_strings(ordinal[repeated])
+    )
     return out
+
+
+def _var_labels(
+    mz_index: NDArray[np.int64], mobility_index: NDArray[np.int64], unique: bool
+) -> NDArray[Any]:
+    """``mz{i}_im{j}`` per feature, disambiguated when two features share both.
+
+    ``unique`` says the caller knows every pair is distinct (one feature
+    per occupied grid cell), so the collision check is skipped.
+    """
+    labels = np.strings.add(
+        np.strings.add(np.strings.add("mz", int_strings(mz_index)), "_im"),
+        int_strings(mobility_index),
+    )
+    if unique or mz_index.size == 0:
+        return labels
+    stride = int(mobility_index.max()) + 1
+    return disambiguate_labels(
+        labels, mz_index.astype(np.int64) * stride + mobility_index
+    )
 
 
 def nearest_axis_index(
     axis: NDArray[np.float64], values: NDArray[np.float64]
 ) -> NDArray[np.int64]:
-    """Index of the nearest entry of a sorted ``axis`` for each of ``values``."""
+    """The column of the MSI table each of ``values`` maps to.
+
+    The summed table's own rule -- nearest axis entry, ties to the right --
+    so ``mz_index`` names the column that table put the same m/z in. A
+    value outside the axis span has no such column (the summed table
+    dropped it); it takes the nearest edge, which is the only honest
+    integer there is.
+    """
+    from .base_spatialdata_converter import _nn_map_to_bins
+
+    values = np.asarray(values, dtype=np.float64)
     if axis.size == 0:
         return np.zeros(values.size, dtype=np.int64)
-    right = np.clip(np.searchsorted(axis, values), 0, axis.size - 1)
-    left = np.maximum(right - 1, 0)
-    pick_left = np.abs(axis[left] - values) <= np.abs(axis[right] - values)
-    return np.where(pick_left, left, right).astype(np.int64)
-
-
-def _feature_axis(
-    feature_mz: NDArray[np.float64], feature_mobility: NDArray[np.float64]
-) -> Tuple[NDArray[np.float64], NDArray[np.int64]]:
-    """Unique ``(mz, mobility)`` pairs, sorted, and the source-to-feature map.
-
-    ``np.unique`` on rows sorts lexicographically by (mz, mobility), which
-    is the order the table wants. A source that lists one pair twice has its
-    entries merged (summed) into one feature.
-    """
-    pairs = np.stack(
-        [feature_mz.astype(np.float64), feature_mobility.astype(np.float64)], axis=1
-    )
-    unique_pairs, inverse = np.unique(pairs, axis=0, return_inverse=True)
-    n_merged = int(pairs.shape[0] - unique_pairs.shape[0])
-    if n_merged:
-        logger.info(
-            "%d feature entries repeat an (m/z, mobility) pair and are merged",
-            n_merged,
-        )
-    return unique_pairs, np.asarray(inverse).ravel().astype(np.int64)
+    clipped = np.clip(values, axis[0], axis[-1])
+    return _nn_map_to_bins(axis, clipped).astype(np.int64)
 
 
 def row_lookup(
@@ -158,67 +207,149 @@ def row_lookup(
     return by_xy
 
 
-def _columns_for_subset(
+def collapse_row(
+    keys: NDArray[np.int64], values: NDArray[np.float64]
+) -> Tuple[NDArray[np.int64], NDArray[np.float64]]:
+    """One entry per distinct key, ascending, with its values summed.
+
+    The shape :class:`CscAssembly` takes a row in. Keys already unique
+    and ascending -- a feature list read in its own order -- pass through
+    untouched; anything else is sorted and reduced, which is the merge
+    the ``COO -> CSC`` conversion used to perform.
+    """
+    if keys.size < 2 or bool(np.all(keys[1:] > keys[:-1])):
+        return keys, values
+    unique_keys, inverse = np.unique(keys, return_inverse=True)
+    summed = np.bincount(
+        np.asarray(inverse).ravel(), weights=values, minlength=unique_keys.size
+    )
+    return unique_keys, summed
+
+
+# ----------------------------------------------------------------------
+# The shared-axis mechanism: a feature list every pixel is read off
+# ----------------------------------------------------------------------
+
+
+class _SharedFeatureAxis:
+    """The source's ``(mz, mobility)`` pairs, sorted, and the way back to them.
+
+    ``np.unique`` on rows sorts lexicographically by (mz, mobility), which
+    is the order the table wants. A source that lists one pair twice has
+    its entries merged (summed) into one feature.
+    """
+
+    def __init__(
+        self, feature_mz: NDArray[np.float64], feature_mobility: NDArray[np.float64]
+    ) -> None:
+        """Sort the source's pairs and index them for exact lookup."""
+        pairs = np.stack(
+            [feature_mz.astype(np.float64), feature_mobility.astype(np.float64)],
+            axis=1,
+        )
+        self.unique_pairs, inverse = np.unique(pairs, axis=0, return_inverse=True)
+        self.source_to_feature = np.asarray(inverse).ravel().astype(np.int64)
+        self.n_source = int(pairs.shape[0])
+        n_merged = int(self.n_source - self.unique_pairs.shape[0])
+        if n_merged:
+            logger.info(
+                "%d feature entries repeat an (m/z, mobility) pair and are merged",
+                n_merged,
+            )
+        # Rank keys for a thresholded spectrum, which carries a subset of
+        # the pairs: a pair's column is found by its m/z rank and mobility
+        # rank, exact because the values come from the very arrays the
+        # axis was built from.
+        self._unique_mz, mz_rank = np.unique(
+            self.unique_pairs[:, 0], return_inverse=True
+        )
+        self._unique_mobility, mobility_rank = np.unique(
+            self.unique_pairs[:, 1], return_inverse=True
+        )
+        self._stride = int(self._unique_mobility.size)
+        self._pair_rank = np.asarray(mz_rank).ravel().astype(
+            np.int64
+        ) * self._stride + np.asarray(mobility_rank).ravel().astype(np.int64)
+
+    @property
+    def n_features(self) -> int:
+        return int(self.unique_pairs.shape[0])
+
+    def columns(
+        self, coords: Coords, mzs: NDArray[np.float64], mobility: NDArray[np.float64]
+    ) -> NDArray[np.int64]:
+        """Feature column of every point of one pixel."""
+        if mzs.size == self.n_source:
+            return self.source_to_feature
+        mz_rank = np.clip(
+            np.searchsorted(self._unique_mz, mzs), 0, self._unique_mz.size - 1
+        )
+        mobility_rank = np.clip(
+            np.searchsorted(self._unique_mobility, mobility),
+            0,
+            self._unique_mobility.size - 1,
+        )
+        key = mz_rank.astype(np.int64) * self._stride + mobility_rank.astype(np.int64)
+        column = np.clip(
+            np.searchsorted(self._pair_rank, key), 0, self._pair_rank.size - 1
+        )
+        on_axis = (
+            (self._unique_mz[mz_rank] == mzs)
+            & (self._unique_mobility[mobility_rank] == mobility)
+            & (self._pair_rank[column] == key)
+        )
+        if not on_axis.all():
+            first = int(np.flatnonzero(~on_axis)[0])
+            raise ValueError(
+                f"Pixel {coords}: (m/z {mzs[first]}, mobility {mobility[first]}) "
+                "is not on the shared feature axis"
+            )
+        return column.astype(np.int64)
+
+
+def _shared_axis_row(
+    features: _SharedFeatureAxis,
     coords: Coords,
     mzs: NDArray[np.float64],
     mobility: NDArray[np.float64],
-    unique_pairs: NDArray[np.float64],
-) -> NDArray[np.int64]:
-    """Feature columns of a thresholded spectrum, matched pair by pair.
-
-    Exact matching is correct here: the values come from the very arrays
-    the feature axis was built from.
-    """
-    var_mz = unique_pairs[:, 0]
-    var_mobility = unique_pairs[:, 1]
-    n_features = int(var_mz.size)
-    starts = np.searchsorted(var_mz, mzs, side="left")
-    cols = np.empty(mzs.size, dtype=np.int64)
-    for i, (m, b) in enumerate(zip(mzs.tolist(), mobility.tolist())):
-        j = int(starts[i])
-        while j < n_features and var_mz[j] == m and var_mobility[j] != b:
-            j += 1
-        if j >= n_features or var_mz[j] != m or var_mobility[j] != b:
-            raise ValueError(
-                f"Pixel {coords}: (m/z {m}, mobility {b}) is not on the shared "
-                "feature axis"
-            )
-        cols[i] = j
-    return cols
+    intensities: NDArray[np.float64],
+) -> Tuple[NDArray[np.int64], NDArray[np.float64]]:
+    """One pixel's ``(column, value)`` entries, collapsed, zeros left out."""
+    columns = features.columns(coords, mzs, mobility)
+    intensities = np.asarray(intensities, dtype=np.float64)
+    nonzero = intensities != 0
+    if not np.all(nonzero):
+        columns = columns[nonzero]
+        intensities = intensities[nonzero]
+    return collapse_row(np.asarray(columns, dtype=np.int64), intensities)
 
 
-def _accumulate(
+def _build_from_shared_axis(
     reader: BaseMSIReader,
     row_for: RowLookup,
-    unique_pairs: NDArray[np.float64],
-    source_to_feature: NDArray[np.int64],
+    common_mass_axis: NDArray[np.float64],
     n_obs: int,
-) -> Optional[sparse.csc_matrix]:
-    """Scatter every pixel's intensities onto the feature axis; CSC result."""
-    rows_acc: List[NDArray[np.int64]] = []
-    cols_acc: List[NDArray[np.int64]] = []
-    data_acc: List[NDArray[np.float64]] = []
+    scratch: Path,
+) -> Optional[Tuple[sparse.csc_matrix, pd.DataFrame, CscAssembly]]:
+    """Scatter the source's own feature pairs; ``(matrix, var, assembly)`` or ``None``."""
+    listed = reader.get_shared_mobility_features()
+    if listed is None or listed[0].size == 0:
+        return None
+    features = _SharedFeatureAxis(*listed)
+    # The source's feature list is the table's var, empty features
+    # included: a feature no pixel carries is still a feature the export
+    # declared, and a consumer aligning on the list must find it.
+    assembly = CscAssembly(features.n_features, n_obs, keep_empty_columns=True)
     n_skipped = 0
     n_pixels = 0
-    n_source = int(source_to_feature.size)
     for coords, mzs, mobility, intensities in reader.iter_mobility_spectra():
         row = row_for(coords)
         if row is None:
             n_skipped += 1
             continue
         n_pixels += 1
-        if mzs.size == n_source:
-            cols = source_to_feature
-        else:
-            cols = _columns_for_subset(coords, mzs, mobility, unique_pairs)
-        nonzero = intensities != 0
-        if not np.all(nonzero):
-            cols = cols[nonzero]
-            intensities = intensities[nonzero]
-        rows_acc.append(np.full(cols.size, row, dtype=np.int64))
-        cols_acc.append(np.asarray(cols, dtype=np.int64))
-        data_acc.append(np.asarray(intensities, dtype=np.float64))
-
+        keys, _values = _shared_axis_row(features, coords, mzs, mobility, intensities)
+        assembly.count(row, keys)
     if n_skipped:
         logger.warning(
             "%d mobility spectra had no row in the MSI table and were skipped",
@@ -229,20 +360,31 @@ def _accumulate(
             "No mobility spectra matched the MSI table; no mobility table written"
         )
         return None
-
-    rows = np.concatenate(rows_acc)
-    cols = np.concatenate(cols_acc)
-    data = np.concatenate(data_acc)
-    # COO -> CSC sums coincident entries, which is the merge the unique
-    # pairs call for.
-    n_features = int(unique_pairs.shape[0])
-    return sparse.coo_matrix((data, (rows, cols)), shape=(n_obs, n_features)).tocsc()
+    assembly.finish_counting()
+    assembly.allocate(scratch)
+    for coords, mzs, mobility, intensities in reader.iter_mobility_spectra():
+        row = row_for(coords)
+        if row is None:
+            continue
+        keys, values = _shared_axis_row(features, coords, mzs, mobility, intensities)
+        assembly.scatter(row, keys, values)
+    matrix = assembly.matrix()
+    var, n_mobility_values = _feature_var(features.unique_pairs, common_mass_axis)
+    logger.info(
+        "Mobility-resolved table: %d pixels x %d (m/z, mobility) features, "
+        "%d non-zeros, %d distinct mobility values",
+        n_obs,
+        int(var.shape[0]),
+        int(matrix.nnz),
+        n_mobility_values,
+    )
+    return matrix, var, assembly
 
 
 def _feature_var(
     unique_pairs: NDArray[np.float64], common_mass_axis: NDArray[np.float64]
 ) -> Tuple[pd.DataFrame, int]:
-    """The ``var`` of the mobility table and its count of distinct mobilities."""
+    """The ``var`` of a shared-axis table and its count of distinct mobilities."""
     var_mz = unique_pairs[:, 0]
     var_mobility = unique_pairs[:, 1]
     mz_index = nearest_axis_index(
@@ -257,7 +399,8 @@ def _feature_var(
             "mz_index": mz_index.astype(np.int64),
             "mobility_index": mobility_index,
         },
-        index=_var_labels(mz_index, mobility_index),
+        index=_var_labels(mz_index, mobility_index, unique=False),
+        copy=False,
     )
     return var, int(unique_mobility.size)
 
@@ -273,36 +416,6 @@ def _feature_var(
 #: is why the count is checked and not the bound: refusing on the bound
 #: would turn away conversions that fit ninefold over.
 MAX_GRID_VAR_ENTRIES = 20_000_000
-
-#: Fractions of the memory free when the pass started that a grid table may
-#: be projected to need: warn past the first, refuse past the second.
-#: **This is a stopgap.** The summed table is memory-bounded -- the
-#: streaming route pre-scans, counts and scatters into a memmap -- while
-#: this accumulator holds its triples in RAM, so its memory is linear in
-#: the table's non-zeros with nothing else bounding it. The var ceiling
-#: above cannot help: it is checked after the triples have been
-#: concatenated, by which point the memory is already committed. Until this
-#: route grows a pre-scan of its own, the projection below is what stops a
-#: whole acquisition from taking the machine down instead of the user
-#: finding out the hard way. Fractions rather than a fixed size because the
-#: same table is routine on a workstation and fatal on a laptop.
-GRID_MEMORY_WARN_FRACTION = 0.25
-GRID_MEMORY_REFUSE_FRACTION = 0.5
-
-#: What to assume is free when the machine will not say (no ``psutil``, or
-#: it raised). Deliberately generous: a guess must not be what refuses a
-#: conversion that would have fitted.
-_ASSUMED_AVAILABLE_GB = 8.0
-
-#: Peak bytes per stored non-zero, over the accumulation and the sparse
-#: assembly together. Measured 2026-09-07: 20,455,979 non-zeros peaked at
-#: 1.82 GB above baseline, so 24 bytes of buffered triple carries about
-#: another 65 of concatenation, COO-to-CSC and the var frame built from it.
-_PEAK_BYTES_PER_NONZERO = 88
-
-#: Pixels to accumulate before the projection is trusted, so a refusal is
-#: never extrapolated from a handful of unrepresentative frames.
-_PROJECTION_MIN_PIXELS = 64
 
 
 def grid_var_bound(common_mass_axis: NDArray[np.float64], grid: MobilityGrid) -> int:
@@ -325,57 +438,6 @@ def var_ceiling_refusal(n_features: int) -> Optional[str]:
         f"above the var ceiling of {MAX_GRID_VAR_ENTRIES:,}; resample to "
         f"fewer mass bins or ask for fewer mobility channels "
         f"(--mobility-bins)"
-    )
-
-
-def available_memory_gb() -> float:
-    """Memory free right now, in gibibytes, or a generous assumption."""
-    try:
-        import psutil
-
-        return float(psutil.virtual_memory().available) / 1024**3
-    except Exception as e:  # pragma: no cover - platform-defined
-        logger.debug("Could not read available memory: %s", e)
-        return _ASSUMED_AVAILABLE_GB
-
-
-def projected_memory_gb(n_nonzeros: int, n_pixels: int, n_obs: int) -> Optional[float]:
-    """What the finished table will need, from the pixels read so far.
-
-    Non-zeros per pixel is near enough constant across an image, which is
-    what makes the extrapolation honest. ``None`` until enough pixels have
-    been read for it to mean anything.
-    """
-    if n_pixels < _PROJECTION_MIN_PIXELS or n_pixels >= n_obs or n_pixels <= 0:
-        return None
-    projected = n_nonzeros / n_pixels * n_obs
-    return projected * _PEAK_BYTES_PER_NONZERO / 1024**3
-
-
-def memory_refusal(
-    n_nonzeros: int, n_pixels: int, n_obs: int, available_gb: Optional[float] = None
-) -> Optional[str]:
-    """Why a grid table this large must not be accumulated, or ``None``.
-
-    Projects the memory the finished table needs and refuses while it is
-    still hypothetical, rather than after it has been allocated -- which is
-    the one thing the var ceiling cannot do, sitting as it does past the
-    concatenation.
-    """
-    gb = projected_memory_gb(n_nonzeros, n_pixels, n_obs)
-    if gb is None:
-        return None
-    free = available_memory_gb() if available_gb is None else float(available_gb)
-    if gb <= free * GRID_MEMORY_REFUSE_FRACTION:
-        return None
-    projected = int(n_nonzeros / n_pixels * n_obs)
-    return (
-        f"the table is on course for {projected:,} non-zeros over {n_obs:,} "
-        f"pixels, which needs about {gb:.1f} GB -- more than half the "
-        f"{free:.1f} GB free on this machine. This route holds the whole "
-        f"table in RAM rather than scattering it to disk the way the summed "
-        f"table does. Convert one --region at a time, resample to fewer mass "
-        f"bins, or ask for fewer mobility channels (--mobility-bins)"
     )
 
 
@@ -402,180 +464,97 @@ def grid_refusal(
         )
     if int(np.asarray(common_mass_axis).size) == 0:
         return "the common mass axis is empty"
-    return None
+    return count_refusal(grid_var_bound(common_mass_axis, grid))
 
 
-class _GridAccumulator:
-    """The ``(pixel, m/z bin, mobility channel)`` cells of one slice.
+def grid_cells(
+    bins: NDArray[np.int64],
+    channels: NDArray[np.int64],
+    intensities: NDArray[np.float64],
+    n_channels: int,
+) -> Tuple[NDArray[np.int64], NDArray[np.float64]]:
+    """One entry per occupied cell of a pixel, with its summed current.
 
     A pixel's raw cloud carries many points per cell -- that is what a
-    TIMS ramp is -- so each pixel is collapsed onto its own occupied cells
-    before anything is buffered. The matrix would sum the duplicates
-    anyway; doing it per pixel is what keeps the accumulator the size of
-    the answer rather than the size of the source.
+    TIMS ramp is -- so the pixel is collapsed onto its own occupied cells
+    before anything is counted or scattered. The flat key
+    ``bin * n_channels + channel`` ascends with ``(mz, mobility)``, which
+    is the order ``var`` wants, for free. This is the one place the key is
+    derived: the discovery pass and the scatter pass both come here.
+    """
+    keys = bins * int(n_channels) + channels
+    unique_keys, inverse = np.unique(keys, return_inverse=True)
+    summed = np.bincount(
+        np.asarray(inverse).ravel(), weights=intensities, minlength=unique_keys.size
+    )
+    nonzero = summed != 0
+    return unique_keys[nonzero], summed[nonzero]
+
+
+class GridDiscovery:
+    """Pass 1 of the grid route: which cells are occupied, and by how many rows.
+
+    A sink for :func:`~thyra.converters.spatialdata.mobility_heatmap.scan_mobility`,
+    so a conversion that writes the heatmap can discover the grid in the
+    same raw pass. Its memory is the count array over the grid's span --
+    a few hundred megabytes at most, fixed before the first pixel is read
+    -- and nothing is ever buffered per pixel.
     """
 
     def __init__(
         self,
         axis: NDArray[np.float64],
-        row_for: RowLookup,
         grid: MobilityGrid,
+        row_for: RowLookup,
         n_obs: int,
     ) -> None:
-        self._axis = axis
-        self._row_for = row_for
-        self._grid = grid
-        self._n_obs = int(n_obs)
-        self._rows: List[NDArray[np.int64]] = []
-        self._keys: List[NDArray[np.int64]] = []
-        self._data: List[NDArray[np.float64]] = []
+        """Allocate the count over the grid's span; refuses one too wide."""
+        self.axis = np.asarray(axis, dtype=np.float64)
+        self.grid = grid
+        self.row_for = row_for
+        self.assembly = CscAssembly(grid_var_bound(self.axis, grid), n_obs)
         self.n_pixels = 0
         self.n_skipped = 0
         self.n_dropped = 0
         self.n_points = 0
-        self.n_nonzeros = 0
-        #: Set once the projected table stops fitting in memory; the caller
-        #: stops reading and writes no table.
+        self.n_features: Optional[int] = None
+        #: The var ceiling's answer once the count is known.
         self.refusal: Optional[str] = None
-        # Read once, not per pixel: the projection is checked every
-        # _PROJECTION_MIN_PIXELS pixels and asking the OS how much memory
-        # is free is a syscall.
-        self._available_gb: Optional[float] = None
-        self._warned_memory = False
 
-    def add(
+    def add_mapped(
         self,
         coords: Coords,
-        mzs: NDArray[np.float64],
+        bins: NDArray[np.int64],
         mobility: NDArray[np.float64],
         intensities: NDArray[np.float64],
+        n_dropped: int,
     ) -> None:
-        """Fold one pixel's ``(m/z, mobility, intensity)`` points in."""
-        row = self._row_for(coords)
+        """Count one pixel already mapped by :func:`map_points_to_axis`."""
+        row = self.row_for(coords)
         if row is None:
             self.n_skipped += 1
             return
         self.n_pixels += 1
-        mzs = np.asarray(mzs, dtype=np.float64)
-        if mzs.size == 0:
-            return
-        mobility = np.asarray(mobility, dtype=np.float64)
-        intensities = np.asarray(intensities, dtype=np.float64)
-        # "In range" is the summed table's own rule: a peak outside the
-        # mass axis is dropped there and must be dropped here, or the
-        # marginal over channels would exceed the column it mirrors.
-        in_range = (mzs >= self._axis[0]) & (mzs <= self._axis[-1])
-        if not in_range.all():
-            self.n_dropped += int(mzs.size - in_range.sum())
-            mzs = mzs[in_range]
-            mobility = mobility[in_range]
-            intensities = intensities[in_range]
-            if mzs.size == 0:
-                return
-        self.n_points += int(mzs.size)
-        keys, values = self._cells(mzs, mobility, intensities)
-        if keys.size == 0:
-            return
-        self._rows.append(np.full(keys.size, row, dtype=np.int64))
-        self._keys.append(keys)
-        self._data.append(values)
-        self.n_nonzeros += int(keys.size)
-        if self.refusal is None and self.n_pixels % _PROJECTION_MIN_PIXELS == 0:
-            self._check_memory()
-
-    def _check_memory(self) -> None:
-        """Project the finished table's memory; warn once, then refuse.
-
-        The warning is the point: on a machine that can take the table it
-        is the only notice the user gets that this route holds the whole
-        thing in RAM, and it arrives early enough to stop the run.
-        """
-        gb = projected_memory_gb(self.n_nonzeros, self.n_pixels, self._n_obs)
-        if gb is None:
-            return
-        if self._available_gb is None:
-            self._available_gb = available_memory_gb()
-        free = self._available_gb
-        if gb > free * GRID_MEMORY_REFUSE_FRACTION:
-            self.refusal = memory_refusal(
-                self.n_nonzeros, self.n_pixels, self._n_obs, available_gb=free
-            )
-            return
-        if not self._warned_memory and gb > free * GRID_MEMORY_WARN_FRACTION:
-            self._warned_memory = True
-            logger.warning(
-                "The mobility grid table is on course for about %.1f GB of "
-                "memory (%s free): this route accumulates the whole table in "
-                "RAM rather than scattering it to disk the way the summed "
-                "table does. It will be refused past %.1f GB. Convert one "
-                "--region at a time, or resample to fewer mass bins, if this "
-                "machine cannot take it.",
-                gb,
-                f"{free:.1f} GB",
-                free * GRID_MEMORY_REFUSE_FRACTION,
-            )
-
-    def _cells(
-        self,
-        mzs: NDArray[np.float64],
-        mobility: NDArray[np.float64],
-        intensities: NDArray[np.float64],
-    ) -> Tuple[NDArray[np.int64], NDArray[np.float64]]:
-        """One entry per occupied cell of this pixel, with its summed current."""
-        from .base_spatialdata_converter import _nn_map_to_bins
-
-        # Ascending flat key is ascending (mz, mobility), which is the
-        # order var wants, for free.
-        keys = _nn_map_to_bins(self._axis, mzs).astype(
-            np.int64
-        ) * self._grid.n_channels + self._grid.assign(mobility).astype(np.int64)
-        unique_keys, inverse = np.unique(keys, return_inverse=True)
-        summed = np.bincount(
-            np.asarray(inverse).ravel(), weights=intensities, minlength=unique_keys.size
+        self.n_dropped += int(n_dropped)
+        self.n_points += int(bins.size)
+        keys, _values = grid_cells(
+            bins,
+            self.grid.assign(mobility).astype(np.int64),
+            intensities,
+            self.grid.n_channels,
         )
-        nonzero = summed != 0
-        return unique_keys[nonzero], summed[nonzero]
+        self.assembly.count(row, keys)
 
-    def matrix(
-        self, n_obs: int
-    ) -> Optional[Tuple[sparse.csc_matrix, NDArray[np.int64]]]:
-        """The pixels x features matrix and the flat cell keys it is built on.
+    def finish(self) -> Optional[str]:
+        """Close the count; the var ceiling's refusal, if any, is the answer.
 
-        Only cells that carry ion current somewhere become features: the
-        grid spans mass bins x channels, and a real acquisition occupies a
-        small, structured part of it.
+        Checked here, before the labels, the memmaps and the ``var`` exist:
+        this is the first moment the real number is known and nothing has
+        been committed to yet, which is the whole point of the ceiling.
         """
-        if self.n_skipped:
-            logger.warning(
-                "%d mobility spectra had no row in the MSI table and were skipped",
-                self.n_skipped,
-            )
-        if self.n_dropped:
-            logger.warning(
-                "%d mobility points fell outside the mass axis and were "
-                "dropped from the mobility-resolved table",
-                self.n_dropped,
-            )
-        if not self._rows:
-            logger.warning(
-                "No mobility spectra matched the MSI table; no mobility table written"
-            )
-            return None
-        keys = np.concatenate(self._keys)
-        unique_keys = np.unique(keys)
-        # The var ceiling, on the count rather than on the bound: this is
-        # the first moment the real number is known, and it is checked
-        # before the labels and the matrix are built rather than after.
-        refusal = var_ceiling_refusal(int(unique_keys.size))
-        if refusal is not None:
-            logger.warning("No mobility-resolved table: %s", refusal)
-            return None
-        columns = np.searchsorted(unique_keys, keys)
-        matrix = sparse.coo_matrix(
-            (np.concatenate(self._data), (np.concatenate(self._rows), columns)),
-            shape=(n_obs, int(unique_keys.size)),
-        ).tocsc()
-        return matrix, unique_keys
+        self.n_features = self.assembly.finish_counting()
+        self.refusal = var_ceiling_refusal(self.n_features)
+        return self.refusal
 
 
 def _grid_feature_var(
@@ -595,6 +574,8 @@ def _grid_feature_var(
     mz_index = (unique_keys // n_channels).astype(np.int64)
     mobility_index = (unique_keys % n_channels).astype(np.int64)
     centres = grid.centres
+    # copy=False: a frame of millions of rows is built once from arrays
+    # nothing else holds, and pandas would otherwise duplicate every column.
     return pd.DataFrame(
         {
             "mz": axis[mz_index],
@@ -602,8 +583,33 @@ def _grid_feature_var(
             "mz_index": mz_index,
             "mobility_index": mobility_index,
         },
-        index=_var_labels(mz_index, mobility_index),
+        index=_var_labels(mz_index, mobility_index, unique=True),
+        copy=False,
     )
+
+
+def _report_discovery(discovery: GridDiscovery) -> bool:
+    """Say what pass 1 found; whether there is a table to build at all."""
+    if discovery.n_skipped:
+        logger.warning(
+            "%d mobility spectra had no row in the MSI table and were skipped",
+            discovery.n_skipped,
+        )
+    if discovery.n_dropped:
+        logger.warning(
+            "%d mobility points fell outside the mass axis and were "
+            "dropped from the mobility-resolved table",
+            discovery.n_dropped,
+        )
+    if discovery.n_pixels == 0 or discovery.assembly.n_nonzeros == 0:
+        logger.warning(
+            "No mobility spectra matched the MSI table; no mobility table written"
+        )
+        return False
+    if discovery.refusal is not None:
+        logger.warning("No mobility-resolved table: %s", discovery.refusal)
+        return False
+    return True
 
 
 def _build_from_grid(
@@ -612,69 +618,59 @@ def _build_from_grid(
     common_mass_axis: NDArray[np.float64],
     grid: MobilityGrid,
     n_obs: int,
-) -> Optional[Tuple[sparse.csc_matrix, pd.DataFrame]]:
-    """Bin every pixel's point cloud onto the grid; ``(matrix, var)`` or ``None``."""
+    discovery: Optional[GridDiscovery],
+    scratch: Path,
+) -> Optional[Tuple[sparse.csc_matrix, pd.DataFrame, CscAssembly]]:
+    """Bin every pixel's point cloud onto the grid; ``(matrix, var, assembly)`` or ``None``.
+
+    ``discovery`` is pass 1 already run (fused into the heatmap's pass by
+    the converter); without it the pass runs here. Pass 2 then re-reads
+    the source and scatters each pixel straight into the CSC arrays.
+    """
     axis = np.asarray(common_mass_axis, dtype=np.float64)
-    accumulator = _GridAccumulator(axis, row_for, grid, n_obs)
-    for coords, mzs, mobility, intensities in reader.iter_mobility_spectra():
-        accumulator.add(coords, mzs, mobility, intensities)
-        if accumulator.refusal is not None:
-            # Stop reading rather than finish a pass whose result cannot be
-            # held. Nothing is written and the summed table is untouched.
-            logger.warning(
-                "No mobility-resolved table: %s (projected after %d of %d " "pixels)",
-                accumulator.refusal,
-                accumulator.n_pixels,
-                n_obs,
-            )
-            return None
-    accumulated = accumulator.matrix(n_obs)
-    if accumulated is None:
+    if discovery is None:
+        discovery = GridDiscovery(axis, grid, row_for, n_obs)
+        scan_mobility(reader, axis, discovery, description="Mobility grid: counting")
+        discovery.finish()
+    elif discovery.n_features is None:
+        discovery.finish()
+    if not _report_discovery(discovery):
         return None
-    matrix, unique_keys = accumulated
-    var = _grid_feature_var(unique_keys, axis, grid)
+    assembly = discovery.assembly
+    assembly.allocate(scratch)
+    n_channels = int(grid.n_channels)
+
+    class _Scatter:
+        def add_mapped(
+            self, coords: Coords, bins: Any, mobility: Any, intensities: Any, _n: int
+        ) -> None:
+            row = row_for(coords)
+            if row is None:
+                return
+            keys, values = grid_cells(
+                bins, grid.assign(mobility).astype(np.int64), intensities, n_channels
+            )
+            assembly.scatter(row, keys, values)
+
+    scan_mobility(reader, axis, _Scatter(), description="Mobility grid: scattering")
+    matrix = assembly.matrix()
+    var = _grid_feature_var(assembly.unique_keys, axis, grid)
     logger.info(
         "Mobility grid: %d points over %d pixels onto %d occupied "
         "(m/z bin, channel) cells of %d x %d, %d channels used",
-        accumulator.n_points,
-        accumulator.n_pixels,
+        discovery.n_points,
+        discovery.n_pixels,
         int(var.shape[0]),
         int(axis.size),
-        grid.n_channels,
+        n_channels,
         int(np.unique(var["mobility_index"].to_numpy()).size),
     )
-    return matrix, var
+    return matrix, var, assembly
 
 
 # ----------------------------------------------------------------------
-# The shared-axis mechanism, and the entry point over both
+# The entry point over both mechanisms
 # ----------------------------------------------------------------------
-
-
-def _build_from_shared_axis(
-    reader: BaseMSIReader,
-    row_for: RowLookup,
-    common_mass_axis: NDArray[np.float64],
-    n_obs: int,
-) -> Optional[Tuple[sparse.csc_matrix, pd.DataFrame]]:
-    """Scatter the source's own feature pairs; ``(matrix, var)`` or ``None``."""
-    features = reader.get_shared_mobility_features()
-    if features is None or features[0].size == 0:
-        return None
-    unique_pairs, source_to_feature = _feature_axis(*features)
-    matrix = _accumulate(reader, row_for, unique_pairs, source_to_feature, n_obs)
-    if matrix is None:
-        return None
-    var, n_mobility_values = _feature_var(unique_pairs, common_mass_axis)
-    logger.info(
-        "Mobility-resolved table: %d pixels x %d (m/z, mobility) features, "
-        "%d non-zeros, %d distinct mobility values",
-        n_obs,
-        int(var.shape[0]),
-        int(matrix.nnz),
-        n_mobility_values,
-    )
-    return matrix, var
 
 
 def build_mobility_table(
@@ -687,6 +683,8 @@ def build_mobility_table(
     z_value: Optional[int] = None,
     pixel_key: Optional[Callable[[Coords], Optional[str]]] = None,
     grid: Optional[MobilityGrid] = None,
+    discovery: Optional[GridDiscovery] = None,
+    scratch: Optional[Path] = None,
 ) -> Optional[Any]:
     """Build the mobility-resolved table for one MSI table, or ``None``.
 
@@ -711,33 +709,54 @@ def build_mobility_table(
         grid: The common mobility grid to bin a per-pixel source onto.
             ``None`` (the default) leaves such a source with the summed
             table only.
+        discovery: The grid's discovery pass, when the caller already ran
+            it (the converter fuses it into the heatmap's pass); ``None``
+            runs it here.
+        scratch: Directory for the memmapped CSC arrays the table is built
+            on. The table's ``X`` stays backed by them until it is written,
+            so the directory must outlive the write; a caller who passes
+            one owns its removal. ``None`` makes a temporary one that is
+            removed when the returned table is garbage collected.
 
     Returns:
         A ``TableModel``-parsed AnnData, or ``None`` when no table can be
-        written (logged at info level with the reason).
+        written (logged with the reason).
     """
     if not reader.has_ion_mobility:
         return None
     n_obs = int(len(obs))
     row_for = row_lookup(obs, z_value, pixel_key)
+    axis = np.asarray(common_mass_axis, dtype=np.float64)
     grid_uns: Optional[Dict[str, Any]] = None
-    if reader.has_shared_mobility_axis:
-        built = _build_from_shared_axis(reader, row_for, common_mass_axis, n_obs)
-    else:
-        refusal = grid_refusal(reader, common_mass_axis, grid)
-        if refusal is not None or grid is None:
-            logger.info(
-                "No mobility-resolved table: the source carries mobility per "
-                "pixel rather than as a shared feature axis, and %s",
-                refusal or "no common mobility grid was asked for",
+    owns_scratch = scratch is None
+    workdir = scratch_directory("thyra_mobility_") if scratch is None else Path(scratch)
+    built = None
+    try:
+        if reader.has_shared_mobility_axis:
+            built = _build_from_shared_axis(reader, row_for, axis, n_obs, workdir)
+        else:
+            refusal = grid_refusal(reader, axis, grid)
+            if refusal is not None or grid is None:
+                logger.info(
+                    "No mobility-resolved table: the source carries mobility per "
+                    "pixel rather than as a shared feature axis, and %s",
+                    refusal or "no common mobility grid was asked for",
+                )
+                return None
+            built = _build_from_grid(
+                reader, row_for, axis, grid, n_obs, discovery, workdir
             )
-            return None
-        built = _build_from_grid(reader, row_for, common_mass_axis, grid, n_obs)
-        grid_uns = grid.to_uns()
+            grid_uns = grid.to_uns()
+    finally:
+        if built is None and owns_scratch:
+            remove_scratch(workdir)
     if built is None:
         return None
-    matrix, var = built
-    return _assemble(matrix, var, obs, region_key, slice_key, uns, grid_uns)
+    matrix, var, assembly = built
+    table = _assemble(matrix, var, obs, region_key, slice_key, uns, grid_uns)
+    if owns_scratch:
+        release_when_collected(table, assembly, workdir)
+    return table
 
 
 def _assemble(
@@ -750,6 +769,31 @@ def _assemble(
     grid_uns: Optional[Dict[str, Any]],
 ) -> Any:
     """Wrap a matrix and its ``var`` as the store's mobility table."""
+    extra: Dict[str, Any] = {}
+    if grid_uns is not None:
+        extra["mobility_grid"] = grid_uns
+    return assemble_sibling_table(
+        matrix, var, obs, region_key, uns, feature_axis_block(slice_key), extra
+    )
+
+
+def assemble_sibling_table(
+    matrix: sparse.csc_matrix,
+    var: pd.DataFrame,
+    obs: pd.DataFrame,
+    region_key: str,
+    uns: Dict[str, Any],
+    feature_axis: Dict[str, Any],
+    extra_uns: Optional[Dict[str, Any]] = None,
+) -> Any:
+    """Wrap a matrix and its ``var`` as a sibling of the MSI table.
+
+    Shared by both siblings: the same ``obs`` rows and ``region`` as the
+    summed table, the provenance block it was given, ``uns["feature_axis"]``
+    saying what the columns are, and whatever block says which mechanism
+    filled it. ``X`` is taken as it comes -- on the assembly's memmaps --
+    so the table is written from disk to disk.
+    """
     from anndata import AnnData
     from spatialdata.models import TableModel
 
@@ -764,9 +808,9 @@ def _assemble(
     adata.uns.update(uns)
     # String lists become JSON strings, as everywhere else in uns: a list of
     # strings does not round-trip through zarr on numpy 2.1-2.2.
-    adata.uns["feature_axis"] = _jsonify_string_lists(feature_axis_block(slice_key))
-    if grid_uns is not None:
-        adata.uns["mobility_grid"] = grid_uns
+    adata.uns["feature_axis"] = _jsonify_string_lists(feature_axis)
+    for key, value in (extra_uns or {}).items():
+        adata.uns[key] = value
     return TableModel.parse(
         adata,
         region=region_key,

--- a/thyra/converters/spatialdata/msms_table.py
+++ b/thyra/converters/spatialdata/msms_table.py
@@ -29,10 +29,17 @@ The fragment axis is the MSI table's own mass axis: a feature is a
 and the corresponding column of the summed table are the same m/z bin, and
 the demultiplexed columns of a pixel add back up to what the summed table
 holds there.
+
+Like its mobility sibling, the table is built in two passes through
+:class:`~thyra.converters.spatialdata.csc_assembly.CscAssembly` -- count
+the occupied ``(precursor, bin)`` pairs, then scatter every pixel's values
+into memmapped CSC arrays -- so a 100,000-pixel acquisition with 25
+precursors costs the same memory as a 700-pixel one with 15.
 """
 
 import logging
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -41,12 +48,28 @@ from scipy import sparse
 
 from ...core.base_reader import BaseMSIReader
 from ...core.msms import FragmentationSchedule, windows_overlap
-from .mobility_table import Coords, RowLookup, row_lookup
+from .csc_assembly import (
+    CscAssembly,
+    release_when_collected,
+    remove_scratch,
+    scratch_directory,
+)
+from .mobility_table import (
+    Coords,
+    RowLookup,
+    assemble_sibling_table,
+    collapse_row,
+    disambiguate_labels,
+    int_strings,
+    row_lookup,
+)
 
 logger = logging.getLogger(__name__)
 
 #: Suffix appended to the MSI table's key for its demultiplexed sibling.
 MSMS_TABLE_SUFFIX = "_msms"
+
+_STRING = np.dtypes.StringDType()
 
 
 def msms_table_key(table_key: str) -> str:
@@ -54,13 +77,21 @@ def msms_table_key(table_key: str) -> str:
     return f"{table_key}{MSMS_TABLE_SUFFIX}"
 
 
-def feature_axis_block(summed_table_key: str) -> Dict[str, Any]:
-    """The ``uns["feature_axis"]`` descriptor of a demultiplexed table."""
-    return {
-        "dims": ["precursor_mz", "precursor_mobility", "mz"],
-        "sorted": True,
-        "summed_table": summed_table_key,
-    }
+def feature_axis_block(
+    summed_table_key: str, with_mobility: bool = True
+) -> Dict[str, Any]:
+    """The ``uns["feature_axis"]`` descriptor of a demultiplexed table.
+
+    ``dims`` names the ``var`` columns the sort runs over, in order --
+    and only the ones the table carries: ``precursor_mobility`` is absent
+    when the source has no per-scan mobility axis to look the isolation
+    position up in, and a descriptor naming a column that is not there
+    would be a lie a consumer could act on.
+    """
+    dims = ["precursor_mz", "precursor_mobility", "mz"]
+    if not with_mobility:
+        dims.remove("precursor_mobility")
+    return {"dims": dims, "sorted": True, "summed_table": summed_table_key}
 
 
 def demultiplex_refusal(schedule: Optional[FragmentationSchedule]) -> Optional[str]:
@@ -149,7 +180,11 @@ def _precursor_axis(
     return targets[order], mobility[order], rank
 
 
-def _var_labels(precursor_mz: NDArray[np.float64], mz_index: NDArray[np.int64]) -> list:
+def _var_labels(
+    precursor_mz: NDArray[np.float64],
+    precursor_index: NDArray[np.int64],
+    mz_index: NDArray[np.int64],
+) -> NDArray[Any]:
     """``p{precursor}_mz{i}`` per feature, disambiguated where two collide.
 
     Named after the precursor's m/z rather than its position in the
@@ -159,14 +194,14 @@ def _var_labels(precursor_mz: NDArray[np.float64], mz_index: NDArray[np.int64]) 
     m/z and so share a stem; they are disambiguated in mobility order,
     which is the same order in any dataset acquired the same way.
     """
-    seen: Dict[str, int] = {}
-    out = []
-    for mz, index in zip(precursor_mz.tolist(), mz_index.tolist()):
-        label = f"p{mz:g}_mz{index}"
-        n = seen.get(label, 0)
-        seen[label] = n + 1
-        out.append(label if n == 0 else f"{label}_{n}")
-    return out
+    stems = np.array([f"p{mz:g}" for mz in precursor_mz.tolist()], dtype=_STRING)
+    labels = np.strings.add(
+        np.strings.add(stems[precursor_index], "_mz"), int_strings(mz_index)
+    )
+    _unique_stems, stem_id = np.unique(stems, return_inverse=True)
+    stem_id = np.asarray(stem_id).ravel().astype(np.int64)
+    stride = int(mz_index.max()) + 1 if mz_index.size else 1
+    return disambiguate_labels(labels, stem_id[precursor_index] * stride + mz_index)
 
 
 def _bin_indices(
@@ -187,89 +222,40 @@ def _bin_indices(
     return _nn_map_to_bins(axis, kept).astype(np.int64), in_range
 
 
-class _Accumulator:
-    """The ``(pixel, precursor, mass axis column)`` triples of one slice."""
+class _Demultiplexer:
+    """The ``(precursor, mass axis column)`` entries of one pixel-precursor pair.
+
+    One key per pair: ascending key is ascending ``(precursor_mz, mz)``,
+    which is the order ``var`` wants. This is the one place the key is
+    derived; the counting pass and the scatter pass both come here, so
+    they cannot disagree on what a row holds.
+    """
 
     def __init__(
-        self,
-        axis: NDArray[np.float64],
-        row_for: RowLookup,
-        window_rank: NDArray[np.int64],
+        self, axis: NDArray[np.float64], window_rank: NDArray[np.int64]
     ) -> None:
-        self._axis = axis
-        self._row_for = row_for
-        self._window_rank = window_rank
-        self._rows: List[NDArray[np.int64]] = []
-        self._keys: List[NDArray[np.int64]] = []
-        self._data: List[NDArray[np.float64]] = []
-        self.n_skipped = 0
+        self.axis = axis
+        self.window_rank = window_rank
         self.n_dropped = 0
 
-    def add(
+    def entries(
         self,
-        coords: Coords,
         window_index: int,
         mzs: NDArray[np.float64],
         intensities: NDArray[np.float64],
-    ) -> None:
-        row = self._row_for(coords)
-        if row is None:
-            self.n_skipped += 1
-            return
-        columns, in_range = _bin_indices(self._axis, mzs)
+    ) -> Tuple[NDArray[np.int64], NDArray[np.float64]]:
+        columns, in_range = _bin_indices(self.axis, mzs)
         if columns.size == 0:
             self.n_dropped += int(mzs.size)
-            return
+            return columns, np.zeros(0, dtype=np.float64)
         if columns.size != mzs.size:
             self.n_dropped += int(mzs.size - columns.size)
             intensities = intensities[in_range]
-        rank = int(self._window_rank[window_index])
-        self._rows.append(np.full(columns.size, row, dtype=np.int64))
-        # One key per (precursor, mass axis column) pair. Ascending key is
-        # ascending (precursor_mz, mz), which is the order var wants.
-        self._keys.append(rank * self._axis.size + columns)
-        self._data.append(np.asarray(intensities, dtype=np.float64))
-
-    def matrix(
-        self, n_obs: int
-    ) -> Optional[Tuple[sparse.csc_matrix, NDArray[np.int64]]]:
-        """The pixels x features matrix and the feature keys it is built on.
-
-        Only the ``(precursor, column)`` pairs that carry ion current
-        somewhere become features: the precursor axis is discrete but the
-        fragment axis is the whole MSI mass axis, and a precursor's
-        fragments occupy a small part of it.
-        """
-        if self.n_skipped:
-            logger.warning(
-                "%d demultiplexed spectra had no row in the MSI table and "
-                "were skipped",
-                self.n_skipped,
-            )
-        if self.n_dropped:
-            logger.warning(
-                "%d fragment peaks fell outside the mass axis and were "
-                "dropped from the demultiplexed table",
-                self.n_dropped,
-            )
-        if not self._rows:
-            logger.warning(
-                "No demultiplexed spectra matched the MSI table; no MS/MS "
-                "table written"
-            )
-            return None
-
-        keys = np.concatenate(self._keys)
-        unique_keys = np.unique(keys)
-        columns = np.searchsorted(unique_keys, keys)
-        matrix = sparse.coo_matrix(
-            (
-                np.concatenate(self._data),
-                (np.concatenate(self._rows), columns),
-            ),
-            shape=(n_obs, int(unique_keys.size)),
-        ).tocsc()
-        return matrix, unique_keys
+        rank = int(self.window_rank[window_index])
+        return collapse_row(
+            rank * int(self.axis.size) + columns,
+            np.asarray(intensities, dtype=np.float64),
+        )
 
 
 def _feature_var(
@@ -296,8 +282,66 @@ def _feature_var(
     if np.isfinite(precursor_mobility).any():
         columns["precursor_mobility"] = precursor_mobility[precursor_index]
     return pd.DataFrame(
-        columns, index=_var_labels(precursor_mz[precursor_index], mz_index)
+        columns,
+        index=_var_labels(precursor_mz, precursor_index, mz_index),
+        copy=False,
     )
+
+
+def _demultiplex(
+    reader: BaseMSIReader,
+    row_for: RowLookup,
+    axis: NDArray[np.float64],
+    window_rank: NDArray[np.int64],
+    n_obs: int,
+    scratch: Path,
+) -> Optional[Tuple[sparse.csc_matrix, NDArray[np.int64], CscAssembly]]:
+    """Two passes over the precursor spectra; ``(matrix, keys, assembly)`` or ``None``."""
+    from tqdm import tqdm
+
+    n_windows = int(window_rank.size)
+    demux = _Demultiplexer(axis, window_rank)
+    assembly = CscAssembly(n_windows * int(axis.size), n_obs)
+    n_skipped = 0
+    n_rows_seen = 0
+    with tqdm(desc="MS/MS table: counting", unit="spectrum") as pbar:
+        for coords, window_index, mzs, intensities in reader.iter_precursor_spectra():
+            pbar.update(1)
+            row = row_for(coords)
+            if row is None:
+                n_skipped += 1
+                continue
+            keys, _values = demux.entries(window_index, mzs, intensities)
+            if keys.size:
+                n_rows_seen += 1
+            assembly.count(row, keys)
+    if n_skipped:
+        logger.warning(
+            "%d demultiplexed spectra had no row in the MSI table and were skipped",
+            n_skipped,
+        )
+    if demux.n_dropped:
+        logger.warning(
+            "%d fragment peaks fell outside the mass axis and were dropped "
+            "from the demultiplexed table",
+            demux.n_dropped,
+        )
+    if n_rows_seen == 0:
+        logger.warning(
+            "No demultiplexed spectra matched the MSI table; no MS/MS table written"
+        )
+        return None
+    assembly.finish_counting()
+    assembly.allocate(scratch)
+    with tqdm(desc="MS/MS table: scattering", unit="spectrum") as pbar:
+        for coords, window_index, mzs, intensities in reader.iter_precursor_spectra():
+            pbar.update(1)
+            row = row_for(coords)
+            if row is None:
+                continue
+            keys, values = demux.entries(window_index, mzs, intensities)
+            assembly.scatter(row, keys, values)
+    return assembly.matrix(), assembly.unique_keys, assembly
 
 
 def build_msms_table(
@@ -309,6 +353,7 @@ def build_msms_table(
     uns: Dict[str, Any],
     z_value: Optional[int] = None,
     pixel_key: Optional[Callable[[Coords], Optional[str]]] = None,
+    scratch: Optional[Path] = None,
 ) -> Optional[Any]:
     """Build the demultiplexed MS/MS table for one MSI table, or ``None``.
 
@@ -325,6 +370,8 @@ def build_msms_table(
             column; pixels on other planes are skipped.
         pixel_key: Optional override mapping a reader coordinate to an
             ``obs`` index label; the default matches on ``(x, y[, z])``.
+        scratch: Directory for the memmapped CSC arrays the table is built
+            on; see :func:`~thyra.converters.spatialdata.mobility_table.build_mobility_table`.
 
     Returns:
         A ``TableModel``-parsed AnnData, or ``None`` when the acquisition
@@ -340,34 +387,42 @@ def build_msms_table(
     if axis.size == 0:
         return None
 
-    from anndata import AnnData
-    from spatialdata.models import TableModel
-
-    from .base_spatialdata_converter import _jsonify_string_lists
-
     precursor_mz, precursor_mobility, window_rank = _precursor_axis(
         schedule, _window_mobility(reader)
     )
-    accumulator = _Accumulator(axis, row_lookup(obs, z_value, pixel_key), window_rank)
-    for coords, window_index, mzs, intensities in reader.iter_precursor_spectra():
-        accumulator.add(coords, window_index, mzs, intensities)
-    accumulated = accumulator.matrix(int(len(obs)))
-    if accumulated is None:
+    n_obs = int(len(obs))
+    owns_scratch = scratch is None
+    workdir = scratch_directory("thyra_msms_") if scratch is None else Path(scratch)
+    built = None
+    try:
+        built = _demultiplex(
+            reader,
+            row_lookup(obs, z_value, pixel_key),
+            axis,
+            window_rank,
+            n_obs,
+            workdir,
+        )
+    finally:
+        if built is None and owns_scratch:
+            remove_scratch(workdir)
+    if built is None:
         return None
-    matrix, unique_keys = accumulated
+    matrix, unique_keys, assembly = built
 
     var = _feature_var(unique_keys, axis, precursor_mz, precursor_mobility)
-    table_obs = obs.copy()
-    n_obs = int(len(obs))
-    table_obs["region"] = pd.Categorical([region_key] * n_obs)
-    table_obs["instance_key"] = table_obs.index.astype(str)
-
-    adata = AnnData(X=matrix, obs=table_obs, var=var)
-    adata.uns.update(uns)
-    # String lists become JSON strings, as everywhere else in uns: a list of
-    # strings does not round-trip through zarr on numpy 2.1-2.2.
-    adata.uns["feature_axis"] = _jsonify_string_lists(feature_axis_block(slice_key))
-
+    table = assemble_sibling_table(
+        matrix,
+        var,
+        obs,
+        region_key,
+        uns,
+        feature_axis_block(
+            slice_key, with_mobility="precursor_mobility" in var.columns
+        ),
+    )
+    if owns_scratch:
+        release_when_collected(table, assembly, workdir)
     logger.info(
         "Demultiplexed MS/MS table: %d pixels x %d (precursor, fragment) "
         "features over %d precursors, %d non-zeros",
@@ -376,9 +431,4 @@ def build_msms_table(
         int(precursor_mz.size),
         int(matrix.nnz),
     )
-    return TableModel.parse(
-        adata,
-        region=region_key,
-        region_key="region",
-        instance_key="instance_key",
-    )
+    return table

--- a/thyra/converters/spatialdata/spatialdata_2d_converter.py
+++ b/thyra/converters/spatialdata/spatialdata_2d_converter.py
@@ -315,9 +315,14 @@ class SpatialData2DConverter(BaseSpatialDataConverter):
                 # Add per-region mean spectra for multi-region datasets
                 self._store_per_region_avg(adata, data_structures)
 
-                # Decide on the sibling tables first so uns can name them.
+                # Decide on the sibling tables first so uns can name them,
+                # then run the raw mobility pass once for the heatmap and
+                # the grid's discovery together, before uns is built.
                 self._mobility_table_key = self._plan_mobility_table(slice_id)
                 self._msms_table_key = self._plan_msms_table(slice_id)
+                self._prepare_sibling_scans(
+                    adata.obs, z_value=slice_data.get("z_value")
+                )
 
                 # Add MSI metadata to .uns
                 self._add_metadata_to_uns(adata)
@@ -343,14 +348,7 @@ class SpatialData2DConverter(BaseSpatialDataConverter):
                 # Add to tables and create shapes
                 data_structures["tables"][slice_id] = table
                 data_structures["shapes"][region_key] = self._create_pixel_shapes(adata)
-                self._attach_mobility_table(
-                    data_structures,
-                    slice_id,
-                    region_key,
-                    adata.obs,
-                    z_value=slice_data.get("z_value"),
-                )
-                self._attach_msms_table(
+                self._attach_sibling_tables(
                     data_structures,
                     slice_id,
                     region_key,

--- a/thyra/converters/spatialdata/spatialdata_3d_converter.py
+++ b/thyra/converters/spatialdata/spatialdata_3d_converter.py
@@ -229,9 +229,12 @@ class SpatialData3DConverter(BaseSpatialDataConverter):
                     per_region[str(r)] = total / max(count, 1)
                 adata.uns["average_spectrum_per_region"] = per_region
 
-            # Decide on the sibling tables first so uns can name them.
+            # Decide on the sibling tables first so uns can name them,
+            # then run the raw mobility pass once for the heatmap and the
+            # grid's discovery together, before uns is built.
             self._mobility_table_key = self._plan_mobility_table(self.dataset_id)
             self._msms_table_key = self._plan_msms_table(self.dataset_id)
+            self._prepare_sibling_scans(adata.obs)
 
             # Add MSI metadata to .uns. The 2D and streaming paths have
             # always done this; the 3D one never did, so a volume came
@@ -259,10 +262,7 @@ class SpatialData3DConverter(BaseSpatialDataConverter):
             # Add to tables and create shapes
             data_structures["tables"][self.dataset_id] = table
             data_structures["shapes"][region_key] = self._create_pixel_shapes(adata)
-            self._attach_mobility_table(
-                data_structures, self.dataset_id, region_key, adata.obs
-            )
-            self._attach_msms_table(
+            self._attach_sibling_tables(
                 data_structures, self.dataset_id, region_key, adata.obs
             )
 

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -284,6 +284,7 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
             # being set), so calling it from the PCS path where temp
             # storage was never created is a no-op.
             self._cleanup_temp_storage()
+            self._release_sibling_scratch()
             self.reader.close()
 
     def _refuse_multiple_z_planes(self) -> None:
@@ -989,9 +990,12 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                 if avg_per_region is not None:
                     adata.uns["average_spectrum_per_region"] = avg_per_region
 
-                # Decide on the sibling tables first so uns can name them.
+                # Decide on the sibling tables first so uns can name them,
+                # then run the raw mobility pass once for the heatmap and
+                # the grid's discovery together, before uns is built.
                 self._mobility_table_key = self._plan_mobility_table(slice_id)
                 self._msms_table_key = self._plan_msms_table(slice_id)
+                self._prepare_sibling_scans(adata.obs, z_value=0)
 
                 # Add MSI metadata to .uns
                 self._add_metadata_to_uns(adata)
@@ -1017,10 +1021,7 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                 # Add to tables and create shapes
                 data_structures["tables"][slice_id] = table
                 data_structures["shapes"][region_key] = self._create_pixel_shapes(adata)
-                self._attach_mobility_table(
-                    data_structures, slice_id, region_key, adata.obs, z_value=0
-                )
-                self._attach_msms_table(
+                self._attach_sibling_tables(
                     data_structures, slice_id, region_key, adata.obs, z_value=0
                 )
 
@@ -1550,9 +1551,14 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         n_x, n_y, _ = self._dimensions
         n_rows = int(kept_grid.size)
         # Decide on the sibling tables before uns is written, so the
-        # table's uns can name them (see _collect_mobility_axis).
+        # table's uns can name them (see _collect_mobility_axis), and run
+        # the raw mobility pass once for the heatmap and the grid's
+        # discovery together. The siblings' obs mirrors this table's rows:
+        # one per kept grid position, indexed by the grid index as a string.
         self._mobility_table_key = self._plan_mobility_table(slice_id)
         self._msms_table_key = self._plan_msms_table(slice_id)
+        sibling_obs = self._sibling_obs(kept_grid, n_x, region_key)
+        self._prepare_sibling_scans(sibling_obs, z_value=0)
 
         # Clean output directory
         if self.output_path.exists():
@@ -1793,13 +1799,30 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         # Add TIC image and pixel shapes using SpatialData
         logger.info("  Adding TIC image and pixel shapes...")
         self._add_tic_image_and_shapes_to_store(
-            tic_values, kept_grid, n_x, n_y, slice_id, region_key
+            tic_values, kept_grid, n_x, n_y, slice_id, region_key, sibling_obs
         )
 
         # Consolidate metadata after all elements are written
         logger.info("  Consolidating metadata...")
         with _suppress_upstream_warnings():
             zarr.consolidate_metadata(str(self.output_path))
+
+    @staticmethod
+    def _sibling_obs(
+        kept_grid: NDArray[np.int64], n_x: int, region_key: str
+    ) -> pd.DataFrame:
+        """The ``obs`` a sibling table mirrors on this route."""
+        kept = np.asarray(kept_grid, dtype=np.int64)
+        obs = pd.DataFrame(
+            {
+                "x": kept % n_x,
+                "y": kept // n_x,
+                "region": np.full(kept.size, region_key),
+            },
+            index=kept.astype(str),
+        )
+        obs.index.name = "instance_id"
+        return obs
 
     def _add_tic_image_and_shapes_to_store(
         self,
@@ -1809,6 +1832,7 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         n_y: int,
         slice_id: str,
         region_key: str,
+        sibling_obs: Optional[pd.DataFrame] = None,
     ) -> None:
         """Add TIC image and pixel shapes to the Zarr store using SpatialData.
 
@@ -1828,6 +1852,8 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
             n_y: Number of pixels in y dimension.
             slice_id: Identifier for this slice (e.g., "msi_dataset_z0").
             region_key: Region key for shapes (e.g., "msi_dataset_z0_pixels").
+            sibling_obs: The ``obs`` the sibling tables mirror, when the
+                caller already built it for the scans; built here otherwise.
         """
         if not SPATIALDATA_AVAILABLE:
             logger.warning("SpatialData not available, skipping TIC image and shapes")
@@ -1914,24 +1940,16 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         }
 
         # The sibling tables, when the source supports one. Their obs
-        # mirrors the hand-written table's rows: one per kept grid
-        # position, indexed by the grid index as a string.
+        # mirrors the hand-written table's rows (see _sibling_obs).
         if self._mobility_table_key is not None or self._msms_table_key is not None:
             kept = np.asarray(kept_grid, dtype=np.int64)
-            obs = pd.DataFrame(
-                {
-                    "x": kept % n_x,
-                    "y": kept // n_x,
-                    "region": np.full(kept.size, region_key),
-                },
-                index=kept.astype(str),
-            )
-            obs.index.name = "instance_id"
-            self._attach_mobility_table(
+            if sibling_obs is None:
+                sibling_obs = self._sibling_obs(kept, n_x, region_key)
+            self._attach_sibling_tables(
                 data_structures,
                 slice_id,
                 region_key,
-                obs,
+                sibling_obs,
                 z_value=0,
                 # The summed table went straight to disk on this route and
                 # is not in hand; its per-pixel ion current is, because the
@@ -1939,9 +1957,6 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                 summed_row_totals=np.asarray(tic_values, dtype=np.float64).ravel()[
                     kept
                 ],
-            )
-            self._attach_msms_table(
-                data_structures, slice_id, region_key, obs, z_value=0
             )
 
         # Load optical images through the COO converter's path so they get
@@ -1971,6 +1986,10 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
             )
             with table_write_config():
                 sdata.write_element(element_names, overwrite=True)
+        # The siblings were written from their memmaps; drop every
+        # reference so their scratch directories can go.
+        del sdata
+        self._release_sibling_scratch(data_structures["tables"])
 
         n_optical = len(data_structures["images"]) - 1
         logger.info(

--- a/thyra/readers/bruker/timstof/timstof_reader.py
+++ b/thyra/readers/bruker/timstof/timstof_reader.py
@@ -1344,19 +1344,22 @@ class BrukerReader(BrukerBaseMSIReader):
             inverse = np.asarray(inverse).ravel()
             intensities = raw_intensities.astype(np.float64)
             window_of_point = np.take(scan_map, scans, mode="clip")
-            for window_index in range(n_windows):
-                selected = window_of_point == window_index
-                if not selected.any():
-                    continue
-                # Sum over the window's scans per digitizer index: the
-                # mobility dimension is collapsed inside the window, the
-                # way iter_spectra collapses it over the whole ramp.
-                sums = np.bincount(
-                    inverse[selected],
-                    weights=intensities[selected],
-                    minlength=unique_indices.size,
+            isolated = window_of_point >= 0
+            n_unique = int(unique_indices.size)
+            # Sum over each window's scans per digitizer index, every
+            # window at once: the mobility dimension is collapsed inside
+            # the window, the way iter_spectra collapses it over the whole
+            # ramp. One bincount over (window, index) keys instead of one
+            # pass over the frame per window.
+            sums = np.bincount(
+                window_of_point[isolated] * n_unique + inverse[isolated],
+                weights=intensities[isolated],
+                minlength=n_windows * n_unique,
+            ).reshape(n_windows, n_unique)
+            for window_index in np.flatnonzero(sums.any(axis=1)).tolist():
+                mzs, window_intensities = self._apply_intensity_filter(
+                    unique_mz, sums[window_index]
                 )
-                mzs, window_intensities = self._apply_intensity_filter(unique_mz, sums)
                 nonzero = np.flatnonzero(window_intensities)
                 if nonzero.size:
                     yield (


### PR DESCRIPTION
Adversarial review of the ion mobility and MS/MS work (v3.13 to v3.16), with the fixes. Implements the local plan and closes the memory gap the previous report left open. Full measurements in a local report.

## What was wrong

- Neither sibling table (mobility grid, shared-axis mobility, demultiplexed MS/MS) was memory-bounded: every `(row, key, value)` triple was held in RAM and handed to `coo_matrix(...).tocsc()`. The 26,000-pixel acquisition projected to about 109 GB; the guard from `1c92b1b` could refuse it, never convert it.
- The var ceiling was checked after the triples were concatenated, so on the acquisition it existed for the process would have died first.
- `COO -> CSC` was the single largest phase (22 percent); feature labels were 5.45M Python f-strings through a dedup dict; `_columns_for_subset` was a Python `while` loop per point; the heatmap and the grid each paid their own raw pass although the mapping onto the mass axis, not the vendor read, is the cost.
- `uns["feature_axis"]["dims"]` on the MS/MS table named `precursor_mobility` even when the column was absent; `uns["demultiplexed_current"]` was never written on the streaming route; `--msms-table` did not select `scan_sum` the way `--mobility-grid` does, so the two tables of one store did not add up by default; the shared-axis `mz_index` used a different tie and range rule from the summed table.

## What this does

- New `thyra/converters/spatialdata/csc_assembly.py`: one two-pass, memmap-backed CSC engine for all three sibling mechanisms. Pass 1 counts occupied keys in a dense `uint32` array over the key span (142 MB on the default timsTOF axis, sized before the first pixel, capped at 1 GiB and refused by name above it); the var ceiling fires the moment the count is known, before any memmap. Pass 2 scatters each pixel straight into memmapped CSC arrays next to the output; scipy's index-dtype rule is followed so the matrix wraps the memmaps without a copy and `X` is byte-identical to what `tocsc()` wrote. Rows out of raster order are sorted a bounded chunk of columns at a time.
- The heatmap and the grid's discovery share one raw pass (`scan_mobility`, `_prepare_sibling_scans` on all three write routes, before `uns` is built); `map_points_to_axis` and `grid_cells` are the single places the mapping and the key are derived.
- Labels vectorised (`np.strings` on `StringDType`; the disambiguation reproduces the old loop exactly, tested); rank-key lookup replaces the per-point loop; one `_attach_sibling_tables` / `assemble_sibling_table` / `_current_ratio_block` for both siblings; `demultiplexed_current` on every route; `--msms-table` forces `scan_sum` through the same code path as the grid (explicit `--tdf-spectrum` still wins, with the WARNING); `feature_axis.dims` follows the columns actually written; `iter_precursor_spectra` splits all windows with one `bincount`.
- Deleted: the memory projection guard and its constants, the two accumulators, `_columns_for_subset`, their tests and the two "held in memory" doc warnings.

## Verified

- Value-for-value against dumps written by the pre-change code (old HEAD in a separate worktree): 400 real frames with `--mobility-grid` IDENTICAL (`X` data/indices/indptr and dtypes, `var` including labels, `obs`, every `uns` block incl. `mobility_marginal`); synthetic grid on both routes IDENTICAL; `mobility_continuous.imzML` IDENTICAL; real 713-pixel PASEF `--msms-table` identical except the new `demultiplexed_current` block.
- Whole 26,087-pixel acquisition: at the default 138,629-bin axis the grid occupies 21,101,151 cells (5.5 percent over the 20M ceiling) and is refused after the one fused read with no allocation; with `--resample-bins 40000` it converts: var 7,334,857, nnz 1,592,582,731, 1,400 s, marginal exactly 1.0, store 7.1 GB; private memory peaked at 4.8 GB through the table's phases (baseline 1.6 GB, the step is the 7.3M-row `var` frame) with 18 GB of scratch on disk, released afterwards.
- 400 frames warm, same machine, alternating: old 36.0 s / new 26.8 s; peak private bytes 3.58 GB / 3.05 GB. 4,000 frames: 167 s, private peak 4.7 GB, of which the `var` build is 2 GB (O(features), no longer O(non-zeros)).
- `pytest tests/` green; Bruker integration tests green; new `tests/unit/converters/test_csc_assembly.py` pins the engine against scipy's `coo -> csc`; complexity monitor 0 violations at 15; pre-commit clean.

## Not changed, flagged

- The var ceiling stays at 20,000,000 (earlier decision). The flagship acquisition lands at 21.1M at the default axis; whether to raise it (a one-line change, the cost is now only the `var` frame at about 150 bytes per feature) is a maintainer's call.
- Optical image loading spikes private memory by about 5 GB on a 313 MB slide TIFF, at the end of the conversion, independently of the tables. Pre-existing; separate task.
- On acquisitions whose frames are not read in raster order (this one: three areas), the summed table written by the streaming route has unsorted row indices within its columns (non-canonical CSC); the sibling engine detects the case and sorts its own columns in bounded chunks. Pre-existing in the summed route; separate task.
