### PR TITLE
fix(streaming): sort CSC columns when pixels arrive out of raster order

### DIFF
--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -187,6 +187,12 @@ print(f"Non-zero: {X.nnz:,} ({X.nnz / (X.shape[0] * X.shape[1]) * 100:.2f}%)")
     extracting ion images (column = one m/z across all pixels). If you need fast
     per-pixel access, convert with `--sparse-format csr`.
 
+    The stored matrix is canonical: within every column the row indices are in
+    ascending order, whatever order the source delivered its pixels in (a
+    multi-area Bruker acquisition comes back area by area, for instance). A
+    consumer can binary-search a column's indices directly, and scipy reports
+    `has_sorted_indices` as true without a `sort_indices()` pass.
+
 ### Ion Images
 
 To visualise the spatial distribution of a specific m/z value:

--- a/tests/unit/converters/test_pcs_column_order.py
+++ b/tests/unit/converters/test_pcs_column_order.py
@@ -1,0 +1,338 @@
+"""The streaming PCS matrix is canonical whatever order the reader yields.
+
+``_scatter_spectra_direct`` writes a column's entries in the order the
+reader hands its pixels over, and ``_write_csc_arrays_to_zarr`` copies
+the memmaps to the store unchanged. A raster read makes every column's
+row indices ascending for free, and every synthetic reader in this suite
+reads in raster order -- so nothing here could see that a reader with any
+other order produced a matrix scipy reports as non-canonical
+(``has_sorted_indices`` False), which breaks the binary search a consumer
+does on a column's indices and some of anndata's sparse-dataset paths.
+
+A real one does. A TDF acquisition of several areas measured one after
+another comes back area by area: on a 26,087-pixel, three-area slide,
+2,000 of 2,000 sampled columns of the summed table were unsorted, while
+the sibling mobility table written next to it -- whose assembly sorts its
+columns when rows arrive out of order -- had none.
+
+The fix tracks whether rows arrived ascending during the scatter and,
+only when they did not, sorts each column's ``(indices, data)`` slice a
+bounded chunk of columns at a time before the copy. These tests pin:
+
+* a reader yielding its pixels in shuffled order produces a canonical
+  matrix, checked column by column and not only through scipy's flag;
+* that matrix equals, value for value, both the in-memory route's and
+  the raster-order streaming write's -- the sort permutes within columns
+  and touches nothing else;
+* a raster-order reader is not sorted at all (the fast path stays fast);
+* the chunked sort itself agrees with scipy across chunk boundaries,
+  including a budget smaller than a single column.
+
+The shuffled reader is guarded too: a "shuffle" that happened to be the
+raster order would turn every assertion above into a tautology.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Generator, Optional, Tuple
+
+import numpy as np
+import pytest
+import zarr
+from numpy.typing import NDArray
+from scipy import sparse
+
+from tests.fixtures.mock_msi_generator import MockMSIConfig, MockMSIReader
+from thyra.converters.spatialdata import streaming_converter as mod
+from thyra.converters.spatialdata.spatialdata_2d_converter import SpatialData2DConverter
+from thyra.converters.spatialdata.streaming_converter import (
+    SPATIALDATA_AVAILABLE,
+    StreamingSpatialDataConverter,
+    _sort_csc_columns,
+)
+
+pytestmark = pytest.mark.skipif(
+    not SPATIALDATA_AVAILABLE,
+    reason="SpatialData dependencies not available",
+)
+
+DATASET_ID = "mock"
+TABLE_KEY = f"{DATASET_ID}_z0"
+
+# Non-square, with a fifth of the positions empty: the compacted row
+# offsets then differ from the grid indices, so an arrival order that is
+# wrong in grid terms is also wrong in row terms after the compaction.
+N_X, N_Y = 6, 5
+SPARSITY = 0.2
+SHUFFLE_SEED = 7
+
+
+class ShuffledMockMSIReader(MockMSIReader):
+    """The mock reader, yielding its pixels in a fixed shuffled order.
+
+    The permutation is drawn from a fresh generator on every call, so the
+    two passes of a streaming conversion see the same order -- the
+    contract every two-pass converter relies on.
+    """
+
+    def iter_spectra(self, batch_size: Optional[int] = None) -> Generator[
+        Tuple[Tuple[int, int, int], NDArray[np.float64], NDArray[np.float64]],
+        None,
+        None,
+    ]:
+        """Yield every spectrum, in the same shuffled order each time."""
+        spectra = list(super().iter_spectra(batch_size=batch_size))
+        order = np.random.default_rng(SHUFFLE_SEED).permutation(len(spectra))
+        for position in order:
+            yield spectra[position]
+
+
+def _config() -> MockMSIConfig:
+    return MockMSIConfig(
+        n_x=N_X,
+        n_y=N_Y,
+        n_mz_bins=300,
+        peaks_per_spectrum=(20, 40),
+        sparsity=SPARSITY,
+    )
+
+
+def _grid_order(reader: MockMSIReader) -> list[int]:
+    return [y * N_X + x for (x, y, _z), _mzs, _ints in reader.iter_spectra()]
+
+
+def _convert_streaming(out: Path, reader: MockMSIReader) -> Path:
+    converter = StreamingSpatialDataConverter(
+        reader=reader,
+        output_path=out,
+        dataset_id=DATASET_ID,
+        pixel_size_um=10.0,
+        use_csc=True,
+    )
+    assert converter.convert() is True
+    return out
+
+
+def _convert_in_memory(out: Path, reader: MockMSIReader) -> Path:
+    converter = SpatialData2DConverter(
+        reader=reader,
+        output_path=out,
+        dataset_id=DATASET_ID,
+        pixel_size_um=10.0,
+    )
+    assert converter.convert() is True
+    return out
+
+
+def _stored_csc(store: Path) -> sparse.csc_matrix:
+    """The table's X as written, read straight off the zarr arrays."""
+    group = zarr.open_group(str(store / "tables" / TABLE_KEY), mode="r")
+    x_group = group["X"]
+    assert x_group.attrs["encoding-type"] == "csc_matrix"
+    return sparse.csc_matrix(
+        (
+            np.asarray(x_group["data"]),
+            np.asarray(x_group["indices"]),
+            np.asarray(x_group["indptr"]),
+        ),
+        shape=tuple(x_group.attrs["shape"]),
+    )
+
+
+def _columns_strictly_ascending(matrix: sparse.csc_matrix) -> bool:
+    """Every column's row indices ascend, checked without scipy's flags."""
+    indices = np.asarray(matrix.indices, dtype=np.int64)
+    indptr = np.asarray(matrix.indptr, dtype=np.int64)
+    if indices.size < 2:
+        return True
+    steps = np.diff(indices)
+    # A step that crosses a column boundary compares unrelated entries.
+    boundaries = indptr[1:-1] - 1
+    boundaries = boundaries[(boundaries >= 0) & (boundaries < steps.size)]
+    steps[boundaries] = 1
+    return bool(np.all(steps > 0))
+
+
+def _dense_by_instance(store: Path) -> Tuple[np.ndarray, list[str]]:
+    """The table densified, with rows in ``instance_id`` order."""
+    import spatialdata
+
+    table = spatialdata.read_zarr(str(store)).tables[TABLE_KEY]
+    matrix = table.X
+    dense = matrix.toarray() if sparse.issparse(matrix) else np.asarray(matrix)
+    ids = [str(i) for i in table.obs.index]
+    order = np.argsort(np.asarray(ids, dtype=np.int64))
+    return dense[order], [ids[i] for i in order]
+
+
+# --- the fixture cannot decay into a tautology --------------------------
+
+
+def test_the_shuffled_reader_is_out_of_raster_order():
+    """The shuffle really puts a later grid position before an earlier one."""
+    raster = _grid_order(MockMSIReader(_config()))
+    shuffled = _grid_order(ShuffledMockMSIReader(_config()))
+
+    assert sorted(shuffled) == raster, "same pixels, whatever the order"
+    assert shuffled != raster
+    assert any(a > b for a, b in zip(shuffled, shuffled[1:]))
+
+
+def test_the_shuffled_reader_repeats_its_order():
+    """Both passes of a two-pass conversion must see the same sequence."""
+    reader = ShuffledMockMSIReader(_config())
+    first = _grid_order(reader)
+    reader.reset()
+    assert _grid_order(reader) == first
+
+
+# --- the written matrix ---------------------------------------------------
+
+
+def test_shuffled_arrival_writes_a_canonical_matrix(tmp_path):
+    """Row indices ascend within every column, so scipy calls it canonical."""
+    store = _convert_streaming(
+        tmp_path / "shuffled.zarr", ShuffledMockMSIReader(_config())
+    )
+
+    matrix = _stored_csc(store)
+    assert _columns_strictly_ascending(matrix)
+    assert matrix.has_sorted_indices
+    assert matrix.has_canonical_format
+
+
+def test_shuffled_arrival_matches_the_raster_write_exactly(tmp_path):
+    """The sort permutes within columns and changes nothing else.
+
+    Against the raster-order write of the same pixels -- canonical as
+    scattered -- the three CSC arrays have to come out identical.
+    """
+    shuffled = _stored_csc(
+        _convert_streaming(tmp_path / "shuffled.zarr", ShuffledMockMSIReader(_config()))
+    )
+    raster = _stored_csc(
+        _convert_streaming(tmp_path / "raster.zarr", MockMSIReader(_config()))
+    )
+
+    assert shuffled.shape == raster.shape
+    np.testing.assert_array_equal(shuffled.indptr, raster.indptr)
+    np.testing.assert_array_equal(shuffled.indices, raster.indices)
+    np.testing.assert_array_equal(shuffled.data, raster.data)
+
+
+def test_shuffled_arrival_equals_the_in_memory_route(tmp_path):
+    """Pixel for pixel, value for value, the two routes agree.
+
+    Compared densely, aligned on ``instance_id``: the in-memory route
+    drops explicit zeros where the streaming route keeps them, so neither
+    ``nnz`` nor a positional row lookup would be a fair comparison.
+    """
+    streamed, streamed_ids = _dense_by_instance(
+        _convert_streaming(tmp_path / "shuffled.zarr", ShuffledMockMSIReader(_config()))
+    )
+    in_memory, in_memory_ids = _dense_by_instance(
+        _convert_in_memory(tmp_path / "in_memory.zarr", MockMSIReader(_config()))
+    )
+
+    assert streamed_ids == in_memory_ids
+    assert streamed.shape == in_memory.shape
+    np.testing.assert_array_equal(streamed, in_memory)
+
+
+# --- the fast path stays fast ---------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "reader_type,expected_sorts",
+    [(MockMSIReader, 0), (ShuffledMockMSIReader, 1)],
+    ids=["raster", "shuffled"],
+)
+def test_only_an_out_of_order_arrival_is_sorted(
+    tmp_path, monkeypatch, reader_type, expected_sorts
+):
+    """A raster read is canonical as scattered and must not pay for a sort."""
+    calls: list = []
+    real_sort = mod._sort_csc_columns
+
+    def _counting_sort(*args, **kwargs):
+        calls.append(args)
+        return real_sort(*args, **kwargs)
+
+    monkeypatch.setattr(mod, "_sort_csc_columns", _counting_sort)
+    store = _convert_streaming(tmp_path / "out.zarr", reader_type(_config()))
+
+    assert len(calls) == expected_sorts
+    assert _columns_strictly_ascending(_stored_csc(store))
+
+
+# --- the chunked sort itself ----------------------------------------------
+
+
+def _scrambled_within_columns(
+    matrix: sparse.csc_matrix, seed: int
+) -> Tuple[np.ndarray, np.ndarray]:
+    """``(indices, data)`` of ``matrix`` with each column's entries permuted."""
+    rng = np.random.default_rng(seed)
+    indices = matrix.indices.astype(np.int32).copy()
+    data = matrix.data.copy()
+    indptr = matrix.indptr
+    for column in range(matrix.shape[1]):
+        lo, hi = int(indptr[column]), int(indptr[column + 1])
+        if hi - lo > 1:
+            order = rng.permutation(hi - lo)
+            indices[lo:hi] = indices[lo:hi][order]
+            data[lo:hi] = data[lo:hi][order]
+    return indices, data
+
+
+@pytest.mark.parametrize(
+    "chunk_entries", [1, 7, 10**6], ids=["one-column", "mid-column", "all"]
+)
+def test_sort_csc_columns_matches_scipy_across_chunk_boundaries(
+    tmp_path, chunk_entries
+):
+    """In place on memmaps, the chunked sort reproduces ``sort_indices``.
+
+    A budget of 1 forces one column per chunk (the branch that takes a
+    column exceeding the budget on its own); 7 lands chunk boundaries in
+    the middle of a run of columns; the last sorts everything at once.
+    """
+    n_rows, n_cols = 53, 41
+    expected = sparse.random(
+        n_rows, n_cols, density=0.3, format="csc", random_state=3, dtype=np.float64
+    )
+    expected.sort_indices()
+    # Some empty columns, so the budget arithmetic meets zero-width columns.
+    expected = sparse.csc_matrix(expected)
+    expected[:, [0, 5, 6, n_cols - 1]] = 0
+    expected.eliminate_zeros()
+    expected.sort_indices()
+    assert expected.nnz > 0
+
+    scrambled_indices, scrambled_data = _scrambled_within_columns(expected, seed=11)
+    assert not _columns_strictly_ascending(
+        sparse.csc_matrix(
+            (scrambled_data, scrambled_indices, expected.indptr), shape=expected.shape
+        )
+    )
+
+    indices = np.memmap(
+        tmp_path / "indices.bin", dtype=np.int32, mode="w+", shape=(expected.nnz,)
+    )
+    data = np.memmap(
+        tmp_path / "data.bin", dtype=np.float64, mode="w+", shape=(expected.nnz,)
+    )
+    indices[:] = scrambled_indices
+    data[:] = scrambled_data
+
+    _sort_csc_columns(
+        indices,
+        data,
+        expected.indptr.astype(np.int64),
+        n_rows,
+        chunk_entries=chunk_entries,
+    )
+
+    np.testing.assert_array_equal(np.asarray(indices), expected.indices)
+    np.testing.assert_array_equal(np.asarray(data), expected.data)

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -48,6 +48,70 @@ logger = logging.getLogger(__name__)
 # build, and 32 for an unchunked vectorised one.
 _INDEX_BUILD_CHUNK = 1_000_000
 
+# Entries loaded at once when the scattered columns have to be sorted (a
+# reader that hands its pixels over out of raster order). Bounds that pass
+# to a few hundred megabytes whatever the matrix size.
+_SORT_CHUNK_ENTRIES = 16_000_000
+
+
+def _sort_csc_columns(
+    indices: Any,
+    data: Any,
+    indptr: NDArray[np.int64],
+    n_rows: int,
+    chunk_entries: int = _SORT_CHUNK_ENTRIES,
+) -> None:
+    """Put each column's entries in ascending row order, in place, chunk by chunk.
+
+    The scatter writes a column's entries in the order the reader handed
+    its pixels over. A raster read makes that ascending and the matrix
+    canonical for free. Any other order -- a TDF acquisition of several
+    areas measured one after another, whose frames come back area by
+    area -- leaves the row indices within a column unsorted, which scipy
+    reports as non-canonical and which breaks every consumer that
+    binary-searches a column. The columns are already grouped, so this is
+    a sort *within* columns over a bounded slice of the arrays at a time.
+
+    Args:
+        indices: CSC row indices, one array-like (a memmap) of the
+            non-zero count.
+        data: CSC values, aligned with ``indices``.
+        indptr: Column pointers, ``n_cols + 1`` entries.
+        n_rows: Row count of the matrix; every row index is below it.
+        chunk_entries: Entries a chunk may hold. A column larger than
+            this is sorted on its own.
+    """
+    indptr = np.asarray(indptr, dtype=np.int64)
+    n_cols = int(indptr.size - 1)
+    logger.info(
+        "Rows arrived out of raster order; sorting %s columns in chunks",
+        f"{n_cols:,}",
+    )
+    start_col = 0
+    while start_col < n_cols:
+        # The largest column range whose entries fit the chunk budget,
+        # and at least one column even when that column alone exceeds it.
+        end_col = int(
+            np.searchsorted(indptr, indptr[start_col] + chunk_entries, side="right")
+        )
+        end_col = max(min(end_col - 1, n_cols), start_col + 1)
+        lo, hi = int(indptr[start_col]), int(indptr[end_col])
+        if hi > lo:
+            rows = np.asarray(indices[lo:hi]).astype(np.int64)
+            column = np.repeat(
+                np.arange(start_col, end_col, dtype=np.int64),
+                np.diff(indptr[start_col : end_col + 1]),
+            )
+            # One combined key, unique because a row occurs once per
+            # column, sorted stably: the columns are already in order, so
+            # the key is a sequence of nearly sorted runs that timsort
+            # merges in a fraction of a general sort's time (measured
+            # 0.5 s against 3.1 s for lexsort on 16M entries).
+            order = np.argsort(column * n_rows + rows, kind="stable")
+            indices[lo:hi] = rows[order]
+            data[lo:hi] = np.asarray(data[lo:hi])[order]
+        start_col = end_col
+
 
 class StreamingSpatialDataConverter(BaseSpatialDataConverter):
     """Memory-efficient streaming converter for MSI data to SpatialData format.
@@ -1099,6 +1163,10 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
            - Light pass: just resampling and counting, no disk I/O
         2. Allocate memory-mapped files for CSC arrays
         3. Main pass: Process spectra again and scatter directly to CSC
+           - If the reader handed its pixels over out of raster order,
+             sort each column's rows afterwards, in place on the memmap
+             (see :func:`_sort_csc_columns`), so the stored matrix is
+             canonical either way
         4. Write CSC arrays to Zarr
 
         This works because nearest-neighbor resampling is deterministic -
@@ -1163,9 +1231,11 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
 
             # Step 3: Main pass - process and scatter directly to CSC
             logger.info("Step 3/3: Processing spectra and scattering to CSC...")
-            self._scatter_spectra_direct(
+            rows_in_order = self._scatter_spectra_direct(
                 mm_indices, mm_data, indptr, n_x, n_y, row_of_grid, pixel_count
             )
+            if not rows_in_order:
+                _sort_csc_columns(mm_indices, mm_data, indptr, n_rows)
 
             # Write CSC arrays to Zarr
             logger.info("Writing CSC arrays to Zarr...")
@@ -1372,7 +1442,7 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         n_y: int,
         row_of_grid: NDArray[np.int64],
         pixel_count: int,
-    ) -> None:
+    ) -> bool:
         """Process spectra and scatter directly to CSC arrays.
 
         This is the main pass that processes spectra again (same resampling
@@ -1387,9 +1457,19 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
             row_of_grid: Table row for each grid position, -1 for the
                 positions dropped as empty (from the pre-scan occupancy).
             pixel_count: Number of spectra to process
+
+        Returns:
+            Whether every scattered row came at or after the previous one,
+            which is to say whether the reader handed its pixels over in
+            raster order. Rows are numbered in raster order, so when it
+            did, every column's row indices are already ascending and the
+            matrix is canonical as scattered; when it did not, the caller
+            sorts the columns before writing them.
         """
         # Current write position for each column
         write_pos = indptr[:-1].copy()
+        rows_in_order = True
+        last_row = -1
 
         # Reset reader for second pass
         # For real readers (ImzML, Bruker), iter_spectra() is a generator factory
@@ -1424,6 +1504,10 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                     row_idx = int(row_of_grid[y * n_x + x])
 
                 if row_idx >= 0:
+                    if row_idx < last_row:
+                        rows_in_order = False
+                    last_row = row_idx
+
                     # Vectorized scatter
                     destinations = write_pos[mz_indices]
                     mm_indices[destinations] = row_idx
@@ -1444,6 +1528,7 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         mm_data.flush()
 
         logger.info("  Scatter complete, memmap flushed")
+        return rows_in_order
 
     def _allocate_csc_memmap_arrays(
         self, total_nnz: int, temp_dir: Path


### PR DESCRIPTION
## Summary

The streaming route's summed table (`tables/<id>_z0/X`) is scattered straight into memmapped CSC arrays in the order the reader hands its pixels over, and copied to zarr unchanged. Rows are numbered in raster order, so a raster-order reader produces ascending row indices within every column for free. A reader with any other order produces a **non-canonical** matrix: scipy reports `has_sorted_indices` False, a binary search on a column's indices gives wrong answers, and some anndata sparse-dataset paths assume sorted indices.

A Bruker TDF acquisition of several areas measured one after another is such a reader: its frames come back area by area, so the row sequence goes backwards at every area boundary. On the 26,087-pixel, three-area slide in the local TIMS corpus (`--resample-bins 40000`), 39,997 of the 40,000 columns of the summed table were unsorted. The mobility sibling written next to it by the out-of-core assembly on #203, which sorts its columns when rows arrive out of order, had none.

## Fix

- `_scatter_spectra_direct` now tracks whether every scattered row came at or after the previous one and returns that.
- Only when it did not, `_sort_csc_columns` sorts each column's `(indices, data)` slice in place on the memmaps before the zarr copy, a bounded chunk of columns at a time (16M entries per chunk, so a few hundred MB whatever the matrix size). Within a chunk it is a stable argsort on one combined `column * n_rows + row` key, the approach `CscAssembly._sort_columns` on #203 uses (timsort over nearly sorted runs, about six times faster than a lexsort there). A raster read pays nothing.
- `docs/output-format.md` now states the canonical order as part of the sparse-format contract.

Once #203 is merged, the two chunked sorts should become one shared function; that is a follow-up, not this PR.

## Verification on the real dataset

Pre-fix store (main, `e890eec`) against post-fix store, same input, `--streaming true --resample-bins 40000 --no-optical`, table 26,087 x 40,000 with 276,482,550 non-zeros:

| check | pre-fix | post-fix |
|---|---|---|
| columns whose row indices are not strictly ascending | 39,997 of 40,000 | 0 of 40,000 |
| scipy `has_sorted_indices` / `has_canonical_format` | False / - | True / True |
| `indptr` | identical | |
| old `indices`/`data` after scipy `sort_indices()` vs new | identical (exact) | |
| column sums, row sums | identical | |
| every other array of the table + TIC image (143 arrays) | identical | |
| root attrs | only `conversion_timestamp` differs | |
| `spatialdata.read_zarr` / `anndata.experimental.read_lazy` column | reads, sorted | |

The sort of 40,000 columns over 276M entries took 4.3 s of a 6 min 20 s conversion.

## Tests

- New `tests/unit/converters/test_pcs_column_order.py` (10 tests): a mock reader yielding its pixels in a fixed shuffled order writes a canonical matrix (checked column by column, not only through scipy's flag) that equals the raster-order write's three arrays exactly and the in-memory route densely; a raster reader is never sorted; the chunked sort matches scipy's `sort_indices` with budgets of one column, mid-column and all at once; the shuffle itself is guarded against decaying into raster order. With the sort disabled the canonical assertions fail.
- Full suite: 2111 passed, 13 skipped. Complexity monitor at threshold 15: 0 violations. pre-commit: all hooks pass on the changed files.
