### PR TITLE
refactor(converters): one chunked CSC column sort for both routes

### DIFF
--- a/tests/unit/converters/test_csc_assembly.py
+++ b/tests/unit/converters/test_csc_assembly.py
@@ -18,6 +18,7 @@ from thyra.converters.spatialdata.csc_assembly import (
     count_refusal,
     index_dtype,
     remove_scratch,
+    sort_csc_columns,
 )
 from thyra.converters.spatialdata.mobility_table import (
     collapse_row,
@@ -206,3 +207,73 @@ class TestRowHelpers:
     def test_unique_labels_pass_through_untouched(self):
         labels = np.strings.add("k", int_strings([3, 1, 2]))
         assert disambiguate_labels(labels, np.array([3, 1, 2])) is labels
+
+
+def _scrambled_within_columns(matrix, seed):
+    """``(indices, data)`` of ``matrix`` with each column's entries permuted."""
+    rng = np.random.default_rng(seed)
+    indices = matrix.indices.astype(np.int32).copy()
+    data = matrix.data.copy()
+    indptr = matrix.indptr
+    for column in range(matrix.shape[1]):
+        lo, hi = int(indptr[column]), int(indptr[column + 1])
+        if hi - lo > 1:
+            order = rng.permutation(hi - lo)
+            indices[lo:hi] = indices[lo:hi][order]
+            data[lo:hi] = data[lo:hi][order]
+    return indices, data
+
+
+class TestTheChunkedSort:
+    """The in-place sort the assembly and the streaming route share."""
+
+    @pytest.mark.parametrize(
+        "chunk_entries", [1, 7, 10**6], ids=["one-column", "mid-column", "all"]
+    )
+    def test_sort_csc_columns_matches_scipy_across_chunk_boundaries(
+        self, tmp_path, chunk_entries
+    ):
+        """In place on memmaps, the chunked sort reproduces ``sort_indices``.
+
+        A budget of 1 forces one column per chunk (the branch that takes a
+        column exceeding the budget on its own); 7 lands chunk boundaries
+        in the middle of a run of columns; the last sorts everything at
+        once.
+        """
+        n_rows, n_cols = 53, 41
+        expected = sparse.random(
+            n_rows, n_cols, density=0.3, format="csc", random_state=3, dtype=np.float64
+        )
+        expected.sort_indices()
+        # Some empty columns, so the budget arithmetic meets zero-width columns.
+        expected = sparse.csc_matrix(expected)
+        expected[:, [0, 5, 6, n_cols - 1]] = 0
+        expected.eliminate_zeros()
+        expected.sort_indices()
+        assert expected.nnz > 0
+
+        scrambled_indices, scrambled_data = _scrambled_within_columns(expected, seed=11)
+        scrambled = sparse.csc_matrix(
+            (scrambled_data, scrambled_indices, expected.indptr), shape=expected.shape
+        )
+        assert not scrambled.has_sorted_indices
+
+        indices = np.memmap(
+            tmp_path / "indices.bin", dtype=np.int32, mode="w+", shape=(expected.nnz,)
+        )
+        data = np.memmap(
+            tmp_path / "data.bin", dtype=np.float64, mode="w+", shape=(expected.nnz,)
+        )
+        indices[:] = scrambled_indices
+        data[:] = scrambled_data
+
+        sort_csc_columns(
+            indices,
+            data,
+            expected.indptr.astype(np.int64),
+            n_rows,
+            chunk_entries=chunk_entries,
+        )
+
+        np.testing.assert_array_equal(np.asarray(indices), expected.indices)
+        np.testing.assert_array_equal(np.asarray(data), expected.data)

--- a/tests/unit/converters/test_pcs_column_order.py
+++ b/tests/unit/converters/test_pcs_column_order.py
@@ -24,9 +24,10 @@ bounded chunk of columns at a time before the copy. These tests pin:
 * that matrix equals, value for value, both the in-memory route's and
   the raster-order streaming write's -- the sort permutes within columns
   and touches nothing else;
-* a raster-order reader is not sorted at all (the fast path stays fast);
-* the chunked sort itself agrees with scipy across chunk boundaries,
-  including a budget smaller than a single column.
+* a raster-order reader is not sorted at all (the fast path stays fast).
+
+The chunked sort itself is the sibling tables' ``sort_csc_columns`` and
+is pinned against scipy in ``test_csc_assembly.py``.
 
 The shuffled reader is guarded too: a "shuffle" that happened to be the
 raster order would turn every assertion above into a tautology.
@@ -49,7 +50,6 @@ from thyra.converters.spatialdata.spatialdata_2d_converter import SpatialData2DC
 from thyra.converters.spatialdata.streaming_converter import (
     SPATIALDATA_AVAILABLE,
     StreamingSpatialDataConverter,
-    _sort_csc_columns,
 )
 
 pytestmark = pytest.mark.skipif(
@@ -253,86 +253,14 @@ def test_only_an_out_of_order_arrival_is_sorted(
 ):
     """A raster read is canonical as scattered and must not pay for a sort."""
     calls: list = []
-    real_sort = mod._sort_csc_columns
+    real_sort = mod.sort_csc_columns
 
     def _counting_sort(*args, **kwargs):
         calls.append(args)
         return real_sort(*args, **kwargs)
 
-    monkeypatch.setattr(mod, "_sort_csc_columns", _counting_sort)
+    monkeypatch.setattr(mod, "sort_csc_columns", _counting_sort)
     store = _convert_streaming(tmp_path / "out.zarr", reader_type(_config()))
 
     assert len(calls) == expected_sorts
     assert _columns_strictly_ascending(_stored_csc(store))
-
-
-# --- the chunked sort itself ----------------------------------------------
-
-
-def _scrambled_within_columns(
-    matrix: sparse.csc_matrix, seed: int
-) -> Tuple[np.ndarray, np.ndarray]:
-    """``(indices, data)`` of ``matrix`` with each column's entries permuted."""
-    rng = np.random.default_rng(seed)
-    indices = matrix.indices.astype(np.int32).copy()
-    data = matrix.data.copy()
-    indptr = matrix.indptr
-    for column in range(matrix.shape[1]):
-        lo, hi = int(indptr[column]), int(indptr[column + 1])
-        if hi - lo > 1:
-            order = rng.permutation(hi - lo)
-            indices[lo:hi] = indices[lo:hi][order]
-            data[lo:hi] = data[lo:hi][order]
-    return indices, data
-
-
-@pytest.mark.parametrize(
-    "chunk_entries", [1, 7, 10**6], ids=["one-column", "mid-column", "all"]
-)
-def test_sort_csc_columns_matches_scipy_across_chunk_boundaries(
-    tmp_path, chunk_entries
-):
-    """In place on memmaps, the chunked sort reproduces ``sort_indices``.
-
-    A budget of 1 forces one column per chunk (the branch that takes a
-    column exceeding the budget on its own); 7 lands chunk boundaries in
-    the middle of a run of columns; the last sorts everything at once.
-    """
-    n_rows, n_cols = 53, 41
-    expected = sparse.random(
-        n_rows, n_cols, density=0.3, format="csc", random_state=3, dtype=np.float64
-    )
-    expected.sort_indices()
-    # Some empty columns, so the budget arithmetic meets zero-width columns.
-    expected = sparse.csc_matrix(expected)
-    expected[:, [0, 5, 6, n_cols - 1]] = 0
-    expected.eliminate_zeros()
-    expected.sort_indices()
-    assert expected.nnz > 0
-
-    scrambled_indices, scrambled_data = _scrambled_within_columns(expected, seed=11)
-    assert not _columns_strictly_ascending(
-        sparse.csc_matrix(
-            (scrambled_data, scrambled_indices, expected.indptr), shape=expected.shape
-        )
-    )
-
-    indices = np.memmap(
-        tmp_path / "indices.bin", dtype=np.int32, mode="w+", shape=(expected.nnz,)
-    )
-    data = np.memmap(
-        tmp_path / "data.bin", dtype=np.float64, mode="w+", shape=(expected.nnz,)
-    )
-    indices[:] = scrambled_indices
-    data[:] = scrambled_data
-
-    _sort_csc_columns(
-        indices,
-        data,
-        expected.indptr.astype(np.int64),
-        n_rows,
-        chunk_entries=chunk_entries,
-    )
-
-    np.testing.assert_array_equal(np.asarray(indices), expected.indices)
-    np.testing.assert_array_equal(np.asarray(data), expected.data)

--- a/thyra/converters/spatialdata/csc_assembly.py
+++ b/thyra/converters/spatialdata/csc_assembly.py
@@ -31,7 +31,8 @@ without a sort: the ``COO -> CSC`` conversion the tables used to pay for,
 one scipy call over the whole image and the single largest phase of a
 measured grid conversion, is gone rather than tuned. A source read in
 some other order gets its columns sorted afterwards, a bounded chunk of
-columns at a time, so the stored matrix is canonical either way.
+columns at a time (:func:`sort_csc_columns`, which the streaming route's
+summed table shares), so the stored matrix is canonical either way.
 
 :meth:`matrix` wraps the memmaps as a :class:`scipy.sparse.csc_matrix`
 without copying them (index dtypes are chosen up front by scipy's own
@@ -70,6 +71,69 @@ MAX_COUNT_BYTES = 1 << 30
 SORT_CHUNK_ENTRIES = 16_000_000
 
 _COUNT_DTYPE = np.uint32
+
+
+def sort_csc_columns(
+    indices: Any,
+    data: Any,
+    indptr: NDArray[Any],
+    n_rows: int,
+    chunk_entries: int = SORT_CHUNK_ENTRIES,
+) -> None:
+    """Put each column's entries in ascending row order, in place, chunk by chunk.
+
+    A scatter writes a column's entries in the order the source handed its
+    rows over. A raster read makes that ascending and the matrix canonical
+    for free. Any other order -- a TDF acquisition of several areas
+    measured one after another, whose frames come back area by area --
+    leaves the row indices within a column unsorted, which scipy reports
+    as non-canonical and which breaks every consumer that binary-searches
+    a column. The columns are already grouped, so this is a sort *within*
+    columns over a bounded slice of the arrays at a time. The assembly
+    here and the streaming route's summed table
+    (``StreamingSpatialDataConverter._convert_to_csc_no_cache``) both sort
+    their memmaps with it.
+
+    Args:
+        indices: CSC row indices, one array-like (a memmap) of the
+            non-zero count.
+        data: CSC values, aligned with ``indices``.
+        indptr: Column pointers, ``n_cols + 1`` entries of any integer
+            dtype.
+        n_rows: Row count of the matrix; every row index is below it.
+        chunk_entries: Entries a chunk may hold. A column larger than
+            this is sorted on its own.
+    """
+    indptr = np.asarray(indptr, dtype=np.int64)
+    n_cols = int(indptr.size - 1)
+    logger.info(
+        "Rows arrived out of raster order; sorting %s columns in chunks",
+        f"{n_cols:,}",
+    )
+    start_col = 0
+    while start_col < n_cols:
+        # The largest column range whose entries fit the chunk budget,
+        # and at least one column even when that column alone exceeds it.
+        end_col = int(
+            np.searchsorted(indptr, indptr[start_col] + chunk_entries, side="right")
+        )
+        end_col = max(min(end_col - 1, n_cols), start_col + 1)
+        lo, hi = int(indptr[start_col]), int(indptr[end_col])
+        if hi > lo:
+            rows = np.asarray(indices[lo:hi]).astype(np.int64)
+            column = np.repeat(
+                np.arange(start_col, end_col, dtype=np.int64),
+                np.diff(indptr[start_col : end_col + 1]),
+            )
+            # One combined key, unique because a row occurs once per
+            # column, sorted stably: the columns are already in order, so
+            # the key is a sequence of nearly sorted runs that timsort
+            # merges in a fraction of a general sort's time (measured
+            # 0.5 s against 3.1 s for lexsort on 16M entries).
+            order = np.argsort(column * n_rows + rows, kind="stable")
+            indices[lo:hi] = rows[order]
+            data[lo:hi] = np.asarray(data[lo:hi])[order]
+        start_col = end_col
 
 
 def index_dtype(n_nonzeros: int, n_rows: int) -> Any:
@@ -275,44 +339,19 @@ class CscAssembly:
     def _sort_columns(self) -> None:
         """Put each column's entries in ascending row order, chunk by chunk.
 
-        Only needed when the source handed its rows out of order; the
-        columns are already grouped, so this is a sort *within* columns
-        over a bounded slice of the arrays at a time.
+        Only needed when the source handed its rows out of order; see
+        :func:`sort_csc_columns`. The chunk budget is read at call time
+        so a test can shrink it through the module constant.
         """
         assert self.indptr is not None and self._indices is not None
         assert self._data is not None
-        indptr = self.indptr.astype(np.int64, copy=False)
-        n_cols = int(indptr.size - 1)
-        logger.info(
-            "Rows arrived out of raster order; sorting %s columns in chunks",
-            f"{n_cols:,}",
+        sort_csc_columns(
+            self._indices,
+            self._data,
+            self.indptr,
+            self.n_rows,
+            chunk_entries=SORT_CHUNK_ENTRIES,
         )
-        start_col = 0
-        while start_col < n_cols:
-            # The largest column range whose entries fit the chunk budget,
-            # and at least one column even when that column alone exceeds it.
-            end_col = int(
-                np.searchsorted(
-                    indptr, indptr[start_col] + SORT_CHUNK_ENTRIES, side="right"
-                )
-            )
-            end_col = max(min(end_col - 1, n_cols), start_col + 1)
-            lo, hi = int(indptr[start_col]), int(indptr[end_col])
-            if hi > lo:
-                rows = np.asarray(self._indices[lo:hi]).astype(np.int64)
-                column = np.repeat(
-                    np.arange(start_col, end_col, dtype=np.int64),
-                    np.diff(indptr[start_col : end_col + 1]),
-                )
-                # One combined key, unique because a row occurs once per
-                # column, sorted stably: the columns are already in order,
-                # so the key is a sequence of nearly sorted runs that
-                # timsort merges in a fraction of a general sort's time
-                # (measured 0.5 s against 3.1 s for lexsort on 16M entries).
-                order = np.argsort(column * self.n_rows + rows, kind="stable")
-                self._indices[lo:hi] = rows[order]
-                self._data[lo:hi] = np.asarray(self._data[lo:hi])[order]
-            start_col = end_col
         self.rows_in_order = True
 
     def release(self) -> None:

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -31,6 +31,7 @@ from .base_spatialdata_converter import (
     BaseSpatialDataConverter,
     _suppress_upstream_warnings,
 )
+from .csc_assembly import sort_csc_columns
 
 if SPATIALDATA_AVAILABLE:
     import geopandas as gpd
@@ -47,70 +48,6 @@ logger = logging.getLogger(__name__)
 # axis; measured at 17.5 bytes per entry at peak against 88 for a one-shot
 # build, and 32 for an unchunked vectorised one.
 _INDEX_BUILD_CHUNK = 1_000_000
-
-# Entries loaded at once when the scattered columns have to be sorted (a
-# reader that hands its pixels over out of raster order). Bounds that pass
-# to a few hundred megabytes whatever the matrix size.
-_SORT_CHUNK_ENTRIES = 16_000_000
-
-
-def _sort_csc_columns(
-    indices: Any,
-    data: Any,
-    indptr: NDArray[np.int64],
-    n_rows: int,
-    chunk_entries: int = _SORT_CHUNK_ENTRIES,
-) -> None:
-    """Put each column's entries in ascending row order, in place, chunk by chunk.
-
-    The scatter writes a column's entries in the order the reader handed
-    its pixels over. A raster read makes that ascending and the matrix
-    canonical for free. Any other order -- a TDF acquisition of several
-    areas measured one after another, whose frames come back area by
-    area -- leaves the row indices within a column unsorted, which scipy
-    reports as non-canonical and which breaks every consumer that
-    binary-searches a column. The columns are already grouped, so this is
-    a sort *within* columns over a bounded slice of the arrays at a time.
-
-    Args:
-        indices: CSC row indices, one array-like (a memmap) of the
-            non-zero count.
-        data: CSC values, aligned with ``indices``.
-        indptr: Column pointers, ``n_cols + 1`` entries.
-        n_rows: Row count of the matrix; every row index is below it.
-        chunk_entries: Entries a chunk may hold. A column larger than
-            this is sorted on its own.
-    """
-    indptr = np.asarray(indptr, dtype=np.int64)
-    n_cols = int(indptr.size - 1)
-    logger.info(
-        "Rows arrived out of raster order; sorting %s columns in chunks",
-        f"{n_cols:,}",
-    )
-    start_col = 0
-    while start_col < n_cols:
-        # The largest column range whose entries fit the chunk budget,
-        # and at least one column even when that column alone exceeds it.
-        end_col = int(
-            np.searchsorted(indptr, indptr[start_col] + chunk_entries, side="right")
-        )
-        end_col = max(min(end_col - 1, n_cols), start_col + 1)
-        lo, hi = int(indptr[start_col]), int(indptr[end_col])
-        if hi > lo:
-            rows = np.asarray(indices[lo:hi]).astype(np.int64)
-            column = np.repeat(
-                np.arange(start_col, end_col, dtype=np.int64),
-                np.diff(indptr[start_col : end_col + 1]),
-            )
-            # One combined key, unique because a row occurs once per
-            # column, sorted stably: the columns are already in order, so
-            # the key is a sequence of nearly sorted runs that timsort
-            # merges in a fraction of a general sort's time (measured
-            # 0.5 s against 3.1 s for lexsort on 16M entries).
-            order = np.argsort(column * n_rows + rows, kind="stable")
-            indices[lo:hi] = rows[order]
-            data[lo:hi] = np.asarray(data[lo:hi])[order]
-        start_col = end_col
 
 
 class StreamingSpatialDataConverter(BaseSpatialDataConverter):
@@ -1166,8 +1103,8 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         3. Main pass: Process spectra again and scatter directly to CSC
            - If the reader handed its pixels over out of raster order,
              sort each column's rows afterwards, in place on the memmap
-             (see :func:`_sort_csc_columns`), so the stored matrix is
-             canonical either way
+             (``csc_assembly.sort_csc_columns``, shared with the sibling
+             tables), so the stored matrix is canonical either way
         4. Write CSC arrays to Zarr
 
         This works because nearest-neighbor resampling is deterministic -
@@ -1236,7 +1173,7 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                 mm_indices, mm_data, indptr, n_x, n_y, row_of_grid, pixel_count
             )
             if not rows_in_order:
-                _sort_csc_columns(mm_indices, mm_data, indptr, n_rows)
+                sort_csc_columns(mm_indices, mm_data, indptr, n_rows)
 
             # Write CSC arrays to Zarr
             logger.info("Writing CSC arrays to Zarr...")


### PR DESCRIPTION
## Summary

PR #203 (`CscAssembly._sort_columns`) and PR #204 (`_sort_csc_columns` in the streaming converter) each carried the same chunked in-place sort of a CSC matrix's columns: a stable argsort on `column * n_rows + row` over a bounded chunk of columns at a time. This makes it one function.

- `csc_assembly.sort_csc_columns(indices, data, indptr, n_rows, chunk_entries=SORT_CHUNK_ENTRIES)` is the single implementation, with the single constant `SORT_CHUNK_ENTRIES` (16M entries). `CscAssembly._sort_columns` calls it and the streaming route's `_convert_to_csc_no_cache` imports it. The body is PR #204's function verbatim; the log line "Rows arrived out of raster order; sorting N columns in chunks" is kept.
- `_sort_columns` passes the chunk budget explicitly at call time. `test_rows_out_of_order_are_sorted_into_the_same_matrix` shrinks the module constant to 97 by assignment, and a default argument would have bound the value at import and silently stopped that test from chunking. Checked: with the constant at 97 the sort makes 33 argsort calls of at most 97 entries, with the default it makes 1.
- Tests: the chunk-boundary test moved from `test_pcs_column_order.py` to `test_csc_assembly.py`, next to the function. `test_pcs_column_order.py` keeps the route-level tests and now patches `sort_csc_columns`.

No behaviour change: same algorithm, same constant, same log line, one code path instead of two.

## Verification

- `pytest tests/unit/converters/`: 618 passed
- `.github/scripts/complexity_monitor.py --threshold 15 --no-save`: 0 violations
- pre-commit on the four changed files: clean
- Before the merge of the two PRs, both bodies were run against scipy's `sort_indices` on 1814 edge cases (empty matrix, a column larger than the budget, chunk edges exactly on column ends, random shapes with int32/int64/uint32 index memmaps, sort keys beyond int32, the full count/scatter/matrix pipeline with empty columns kept and dropped). Both agreed with scipy and with each other on every case.
