### PR TITLE
fix(optical): stream optical TIFFs into the store instead of holding them whole

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,18 +135,23 @@ dependencies = [
     # resolves 2.12.x and the JSON-sync test pins the emission against it.
     "pydantic>=2.7, <3",              # tested 2.12.5
     # Imported directly, not merely re-exported through spatialdata: tifffile by
-    # converters/spatialdata/base_spatialdata_converter.py, xarray by that module
-    # and the 2D, 3D and streaming converters. Both arrive transitively today
+    # converters/spatialdata/optical_image.py, xarray by that module and the
+    # base, 2D, 3D and streaming converters. Both arrive transitively today
     # (spatialdata requires xarray >=2024.10.0 outright; tifffile comes in behind
     # scikit-image and dask-image), so this is the same undeclared-direct-import
     # defect as click above -- but a quieter one. Their imports sit inside the
     # SPATIALDATA_AVAILABLE try/except, so losing either degrades instead of
     # crashing: every converter is replaced by a dummy and the run reports
     # "SpatialData dependencies not available" rather than naming the real cause.
-    # Floors only, and deliberately so. They restate what the existing requirers
-    # already demand, which makes the direct dependency honest without asserting
-    # an upper bound nothing here has tested; the resolved set does not move.
-    "tifffile>=2022.8.12",
+    # Floors only, and deliberately so; no upper bound nothing here has tested.
+    # The tifffile floor is load-bearing: optical_image.py streams TIFF row bands
+    # through tifffile's zarr adapter (``TiffPage.aszarr()``), which speaks zarr
+    # format 3 only from 2026.5.2 on; an older tifffile hands zarr 3 a store it
+    # cannot open and every optical image would be dropped. tifffile's own
+    # metadata asks for zarr >= 3.2 there, but the adapter works on the 3.1.6
+    # this project pins (exercised by tests/unit/converters/
+    # test_optical_image_streaming.py and on real FlexImaging exports).
+    "tifffile>=2026.5.2",             # tested 2026.8.23
     "xarray>=2024.10.0",
 ]
 

--- a/tests/unit/converters/test_optical_image_streaming.py
+++ b/tests/unit/converters/test_optical_image_streaming.py
@@ -1,0 +1,422 @@
+"""The bounded optical-image path writes what the whole-page path wrote.
+
+Three contracts, each pinned against the library code it replaces rather
+than against a stored fixture:
+
+* :func:`block_mean` / :func:`trim_excess` reproduce xarray's
+  ``coarsen(boundary="trim", side="right").mean().astype(dtype)`` value for
+  value, odd sizes and all dtypes an optical TIFF can carry included;
+* :meth:`StreamedOpticalImage.placeholder` is structurally what
+  ``Image2DModel.parse(..., scale_factors=...)`` builds: same levels, shapes,
+  chunks, dtype, per-level transformations and coordinates;
+* declaring the placeholder through ``SpatialData.write`` and then streaming
+  the pixels leaves a store whose optical element -- metadata, chunk grid,
+  every pixel of every level -- equals the one the parse-and-write route
+  produces, and the store never sees the page whole.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import numpy as np
+import pytest
+import xarray as xr
+
+pytest.importorskip("spatialdata")
+tifffile = pytest.importorskip("tifffile")
+zarr = pytest.importorskip("zarr")
+
+from spatialdata import SpatialData  # noqa: E402
+from spatialdata.models import Image2DModel  # noqa: E402
+from spatialdata.transformations import Scale, get_transformation  # noqa: E402
+
+from thyra.converters.spatialdata.optical_image import (  # noqa: E402
+    OpticalTiffSource,
+    StreamedOpticalImage,
+    band_rows,
+    block_mean,
+    level_shapes,
+    trim_excess,
+)
+
+
+def _xarray_reference(block: np.ndarray, factor: int) -> np.ndarray:
+    """What multiscale_spatial_image computes for one pyramid step."""
+    image = xr.DataArray(block, dims=("c", "y", "x"))
+    return (
+        image.coarsen(dim={"y": factor, "x": factor}, boundary="trim", side="right")
+        .mean()
+        .astype(block.dtype)
+        .values
+    )
+
+
+def _stream_reference(block: np.ndarray, factor: int) -> np.ndarray:
+    """The same step the way stream_pixels computes it: trim, then block mean."""
+    ey = trim_excess(block.shape[1], factor)
+    ex = trim_excess(block.shape[2], factor)
+    return block_mean(block[:, ey:, ex:], (1, factor, factor))
+
+
+@pytest.mark.parametrize(
+    "dtype", [np.uint8, np.uint16, np.int16, np.uint32, np.float32, np.float64]
+)
+@pytest.mark.parametrize("shape", [(3, 8, 8), (1, 9, 7), (2, 15, 33), (3, 5, 6)])
+@pytest.mark.parametrize("factor", [2, 3])
+def test_block_mean_matches_xarray_coarsen(dtype, shape, factor):
+    rng = np.random.default_rng(int(np.prod(shape)) * factor)
+    if np.issubdtype(dtype, np.integer):
+        info = np.iinfo(dtype)
+        block = rng.integers(info.min, info.max, size=shape, dtype=dtype)
+    else:
+        block = rng.random(size=shape).astype(dtype) * 300 - 100
+    expected = _xarray_reference(block, factor)
+    actual = _stream_reference(block, factor)
+    assert actual.dtype == expected.dtype
+    np.testing.assert_array_equal(actual, expected)
+
+
+def test_trim_drops_the_leading_rows():
+    """side="right" keeps the LAST full windows; the excess comes off the front."""
+    block = np.arange(3 * 5 * 4, dtype=np.uint8).reshape(3, 5, 4)
+    reference = _xarray_reference(block, 2)
+    assert trim_excess(5, 2) == 1
+    assert trim_excess(4, 2) == 0
+    # Row 0 is dropped: the first output row averages rows 1 and 2.
+    np.testing.assert_array_equal(
+        reference[0, 0],
+        block[0, 1:3, :].reshape(2, 2, 2).mean(axis=(0, 2)).astype(np.uint8),
+    )
+    np.testing.assert_array_equal(_stream_reference(block, 2), reference)
+
+
+def test_block_mean_rejects_untrimmed_input():
+    with pytest.raises(ValueError, match="not a multiple"):
+        block_mean(np.zeros((1, 5, 4), dtype=np.uint8), (1, 2, 2))
+    with pytest.raises(ValueError, match="window factors"):
+        block_mean(np.zeros((1, 4, 4), dtype=np.uint8), (2, 2))
+
+
+def test_level_shapes_floor_like_coarsen():
+    assert level_shapes((3, 11748, 36736), [2, 2, 2], ("c", "y", "x")) == [
+        (3, 11748, 36736),
+        (3, 5874, 18368),
+        (3, 2937, 9184),
+        (3, 1468, 4592),
+    ]
+    assert level_shapes((1, 10, 10), [], ("c", "y", "x")) == [(1, 10, 10)]
+
+
+def test_band_rows_tile_the_chunk_rows():
+    # A whole chunk row fits: one band per chunk row.
+    assert band_rows(row_bytes=1000, chunk_rows=4096, budget=10_000_000) == 4096
+    # 110 KB rows (the 36736 x 3 uint8 brightfield): 2048 of them per 256 MiB.
+    assert (
+        band_rows(row_bytes=36736 * 3, chunk_rows=4096, budget=256 * 1024 * 1024)
+        == 2048
+    )
+    # Never a divisor that straddles: 4096 rows only split into powers of two.
+    assert band_rows(row_bytes=1 << 20, chunk_rows=4096, budget=3000 << 20) == 2048
+    assert band_rows(row_bytes=1 << 30, chunk_rows=4096, budget=1) == 1
+    with pytest.raises(ValueError):
+        band_rows(row_bytes=0, chunk_rows=4096)
+
+
+@pytest.fixture
+def rgb_tiff(tmp_path: Path) -> Path:
+    """An odd-sized RGB TIFF with strips of one row, like a FlexImaging export."""
+    rng = np.random.default_rng(7)
+    image = rng.integers(0, 256, size=(37, 53, 3), dtype=np.uint8)
+    # A fully black band, so an all-fill chunk exercises write_empty_chunks.
+    image[10:20, :, :] = 0
+    path = tmp_path / "brightfield_0000.tiff"
+    tifffile.imwrite(str(path), image, rowsperstrip=1, compression="lzw")
+    return path
+
+
+def _source_and_transform(path: Path):
+    source = OpticalTiffSource.probe(path)
+    assert source is not None
+    transform = Scale([2.0, 0.5], axes=("x", "y"))
+    return source, {"slide": transform, "global": transform}
+
+
+def test_probe_reads_only_the_header(rgb_tiff: Path):
+    source = OpticalTiffSource.probe(rgb_tiff)
+    assert source is not None
+    assert source.shape == (3, 37, 53)
+    assert source.dtype == np.uint8
+    assert source.streamable
+    assert source.page_axes == "YXS"
+    assert source.row_bytes == 53 * 3
+
+
+def test_bands_decode_row_ranges(rgb_tiff: Path):
+    source = OpticalTiffSource.probe(rgb_tiff)
+    whole = np.moveaxis(tifffile.imread(str(rgb_tiff)), -1, 0)
+    starts = []
+    for start, band in source.bands(rows=16):
+        starts.append(start)
+        assert band.shape[0] == 3
+        np.testing.assert_array_equal(band, whole[:, start : start + band.shape[1], :])
+    assert starts == [0, 16, 32]
+
+
+def test_placeholder_mirrors_image2dmodel_parse(rgb_tiff: Path):
+    source, transformations = _source_and_transform(rgb_tiff)
+    chunks = (1, 16, 16)
+    scale_factors = [2, 2]
+    streamed = StreamedOpticalImage(
+        source=source,
+        name="optical",
+        chunks=chunks,
+        scale_factors=scale_factors,
+        transformations=transformations,
+    )
+    placeholder = streamed.placeholder()
+
+    whole = np.moveaxis(tifffile.imread(str(rgb_tiff)), -1, 0)
+    reference = Image2DModel.parse(
+        xr.DataArray(
+            whole,
+            dims=("c", "y", "x"),
+            coords={"c": np.arange(3), "y": np.arange(37), "x": np.arange(53)},
+        ),
+        transformations=dict(transformations),
+        chunks=chunks,
+        scale_factors=scale_factors,
+    )
+
+    assert list(placeholder.children) == list(reference.children)
+    for level in reference.children:
+        ours = placeholder[level]["image"]
+        theirs = reference[level]["image"]
+        assert ours.dims == theirs.dims
+        assert ours.shape == theirs.shape
+        assert ours.dtype == theirs.dtype
+        assert ours.data.chunks == theirs.data.chunks
+        for axis in ("c", "y", "x"):
+            np.testing.assert_array_equal(
+                ours.coords[axis].values, theirs.coords[axis].values
+            )
+        for system in transformations:
+            assert get_transformation(ours, system) == get_transformation(
+                theirs, system
+            )
+
+
+def _read_element(store: Path, name: str):
+    group = zarr.open_group(str(store), mode="r", use_consolidated=False)[
+        f"images/{name}"
+    ]
+    attrs = group.attrs.asdict()
+    datasets = attrs["ome"]["multiscales"][0]["datasets"]
+    levels = {}
+    for dataset in datasets:
+        array = group[dataset["path"]]
+        levels[dataset["path"]] = (array.metadata.to_dict(), array[:])
+    files = sorted(
+        str(f.relative_to(store / "images" / name))
+        for f in (store / "images" / name).rglob("*")
+        if f.is_file()
+    )
+    return attrs, levels, files
+
+
+def test_declared_then_streamed_store_equals_parse_and_write(
+    rgb_tiff: Path, tmp_path: Path
+):
+    source, transformations = _source_and_transform(rgb_tiff)
+    chunks = (1, 16, 16)
+    scale_factors = [2, 2]
+    name = "optical"
+
+    # The route this module replaces: whole page -> parse -> write.
+    whole = np.moveaxis(tifffile.imread(str(rgb_tiff)), -1, 0)
+    reference = Image2DModel.parse(
+        xr.DataArray(
+            whole,
+            dims=("c", "y", "x"),
+            coords={"c": np.arange(3), "y": np.arange(37), "x": np.arange(53)},
+        ),
+        transformations=dict(transformations),
+        chunks=chunks,
+        scale_factors=scale_factors,
+    )
+    expected_store = tmp_path / "expected.zarr"
+    SpatialData(images={name: reference}).write(expected_store)
+
+    # Declare, then stream.
+    streamed = StreamedOpticalImage(
+        source=source,
+        name=name,
+        chunks=chunks,
+        scale_factors=scale_factors,
+        transformations=transformations,
+    )
+    actual_store = tmp_path / "actual.zarr"
+    SpatialData(images={name: streamed.placeholder()}).write(actual_store)
+    declared_files = [
+        f for f in (actual_store / "images" / name).rglob("*") if f.is_file()
+    ]
+    # Declaring stores metadata only: one zarr.json per level plus the group's.
+    assert all(f.name == "zarr.json" for f in declared_files)
+    assert len(declared_files) == len(scale_factors) + 2
+
+    streamed.stream_pixels(actual_store)
+
+    expected_attrs, expected_levels, expected_files = _read_element(
+        expected_store, name
+    )
+    actual_attrs, actual_levels, actual_files = _read_element(actual_store, name)
+    assert json.dumps(actual_attrs, sort_keys=True) == json.dumps(
+        expected_attrs, sort_keys=True
+    )
+    assert list(actual_levels) == list(expected_levels) == ["s0", "s1", "s2"]
+    for path in expected_levels:
+        expected_meta, expected_pixels = expected_levels[path]
+        actual_meta, actual_pixels = actual_levels[path]
+        assert json.dumps(actual_meta, sort_keys=True, default=str) == json.dumps(
+            expected_meta, sort_keys=True, default=str
+        )
+        np.testing.assert_array_equal(actual_pixels, expected_pixels)
+    # Same chunk files, so all-fill chunks are skipped the same way too.
+    assert actual_files == expected_files
+
+    # And the pixels are the TIFF's.
+    np.testing.assert_array_equal(actual_levels["s0"][1], whole)
+    # Reading back through spatialdata still sees a valid multiscale image.
+    sdata = SpatialData.read(str(actual_store))
+    assert list(sdata.images[name].children) == ["scale0", "scale1", "scale2"]
+    axes = ("x", "y")
+    np.testing.assert_array_equal(
+        get_transformation(sdata.images[name], "slide").to_affine_matrix(axes, axes),
+        transformations["slide"].to_affine_matrix(axes, axes),
+    )
+
+
+def test_streaming_a_small_band_budget_still_matches(
+    rgb_tiff: Path, tmp_path: Path, monkeypatch
+):
+    """Bands narrower than a chunk row (partial-chunk writes) change nothing."""
+    from thyra.converters.spatialdata import optical_image
+
+    monkeypatch.setattr(optical_image, "BAND_BUDGET_BYTES", 53 * 3 * 3)  # three rows
+    monkeypatch.setattr(optical_image, "REDUCE_STRIP_ROWS", 2)
+    source, transformations = _source_and_transform(rgb_tiff)
+    streamed = StreamedOpticalImage(
+        source=source,
+        name="optical",
+        chunks=(1, 16, 16),
+        scale_factors=[2, 2],
+        transformations=transformations,
+    )
+    store = tmp_path / "narrow.zarr"
+    SpatialData(images={"optical": streamed.placeholder()}).write(store)
+    streamed.stream_pixels(store)
+
+    whole = np.moveaxis(tifffile.imread(str(rgb_tiff)), -1, 0)
+    _, levels, _ = _read_element(store, "optical")
+    np.testing.assert_array_equal(levels["s0"][1], whole)
+    np.testing.assert_array_equal(levels["s1"][1], _stream_reference(whole, 2))
+    np.testing.assert_array_equal(
+        levels["s2"][1], _stream_reference(_stream_reference(whole, 2), 2)
+    )
+
+
+def test_stream_pixels_refuses_a_store_without_the_element(
+    rgb_tiff: Path, tmp_path: Path
+):
+    source, transformations = _source_and_transform(rgb_tiff)
+    streamed = StreamedOpticalImage(
+        source=source,
+        name="optical",
+        chunks=(1, 16, 16),
+        scale_factors=[2],
+        transformations=transformations,
+    )
+    store = tmp_path / "wrong.zarr"
+    # A different pyramid was declared under that name.
+    other = StreamedOpticalImage(
+        source=source,
+        name="optical",
+        chunks=(1, 16, 16),
+        scale_factors=[2, 2],
+        transformations=transformations,
+    )
+    SpatialData(images={"optical": other.placeholder()}).write(store)
+    with pytest.raises(RuntimeError, match="pyramid levels"):
+        streamed.stream_pixels(store)
+    shutil.rmtree(store)
+    with pytest.raises((KeyError, FileNotFoundError)):
+        streamed.stream_pixels(store)
+
+
+def test_grayscale_and_non_streamable_layouts(tmp_path: Path):
+    rng = np.random.default_rng(3)
+    gray = rng.integers(0, 65535, size=(21, 30), dtype=np.uint16)
+    gray_path = tmp_path / "gray.tif"
+    tifffile.imwrite(str(gray_path), gray)
+    source = OpticalTiffSource.probe(gray_path)
+    assert source.shape == (1, 21, 30)
+    assert source.dtype == np.uint16
+    bands = list(source.bands(rows=8))
+    assert [start for start, _ in bands] == [0, 8, 16]
+    np.testing.assert_array_equal(
+        np.concatenate([b for _, b in bands], axis=1), gray[np.newaxis]
+    )
+
+    # Planar (separate samples) pages cannot be row-streamed; they decode whole,
+    # reshaped the way the converter always reshaped a 3-d page.
+    planar = rng.integers(0, 256, size=(3, 11, 13), dtype=np.uint8)
+    planar_path = tmp_path / "planar.tif"
+    tifffile.imwrite(
+        str(planar_path), planar, photometric="rgb", planarconfig="separate"
+    )
+    source = OpticalTiffSource.probe(planar_path)
+    assert not source.streamable
+    bands = list(source.bands(rows=4))
+    assert len(bands) == 1 and bands[0][0] == 0
+    np.testing.assert_array_equal(bands[0][1], np.moveaxis(planar, -1, 0))
+
+
+@pytest.mark.parametrize("route", ["2d", "streaming"])
+def test_converters_stream_the_pixels_after_the_write(
+    rgb_tiff: Path, tmp_path: Path, route
+):
+    """Both write paths declare the placeholder, then fill it: the store has the pixels."""
+    from tests.fixtures.mock_msi_generator import MockMSIConfig, MockMSIReader
+    from thyra.converters.spatialdata.spatialdata_2d_converter import (
+        SpatialData2DConverter,
+    )
+    from thyra.converters.spatialdata.streaming_converter import (
+        StreamingSpatialDataConverter,
+    )
+
+    reader = MockMSIReader(
+        MockMSIConfig(n_x=4, n_y=3, n_mz_bins=32, peaks_per_spectrum=(2, 4)),
+        optical_image_paths=[rgb_tiff],
+    )
+    output_path = tmp_path / f"{route}.zarr"
+    if route == "2d":
+        converter = SpatialData2DConverter(
+            reader, output_path, dataset_id="ds", pixel_size_um=10.0
+        )
+    else:
+        converter = StreamingSpatialDataConverter(
+            reader, output_path, dataset_id="ds", pixel_size_um=10.0, use_csc=True
+        )
+    assert converter.convert() is True
+    # Nothing is left waiting: every declared image was streamed.
+    assert converter._pending_optical_images == []
+
+    whole = np.moveaxis(tifffile.imread(str(rgb_tiff)), -1, 0)
+    _, levels, _ = _read_element(output_path, "ds_optical_highres")
+    # 37 x 53 is far below the 1000 px coarsest-level floor: a single level.
+    assert list(levels) == ["s0"]
+    np.testing.assert_array_equal(levels["s0"][1], whole)
+    sdata = SpatialData.read(str(output_path))
+    np.testing.assert_array_equal(sdata.images["ds_optical_highres"].values, whole)

--- a/tests/unit/converters/test_optical_image_streaming.py
+++ b/tests/unit/converters/test_optical_image_streaming.py
@@ -7,17 +7,21 @@ than against a stored fixture:
   ``coarsen(boundary="trim", side="right").mean().astype(dtype)`` value for
   value, odd sizes and all dtypes an optical TIFF can carry included;
 * :meth:`StreamedOpticalImage.placeholder` is structurally what
-  ``Image2DModel.parse(..., scale_factors=...)`` builds: same levels, shapes,
-  chunks, dtype, per-level transformations and coordinates;
+  ``Image2DModel.parse`` builds, with and without ``scale_factors``: same
+  levels, shapes, chunks, dtype, per-level transformations and coordinates;
 * declaring the placeholder through ``SpatialData.write`` and then streaming
   the pixels leaves a store whose optical element -- metadata, chunk grid,
   every pixel of every level -- equals the one the parse-and-write route
   produces, and the store never sees the page whole.
+
+Plus the tolerance the old route had: a TIFF whose pixels cannot be read
+is dropped with a warning, not fatal, on both converter routes.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 import shutil
 from pathlib import Path
 
@@ -33,6 +37,7 @@ from spatialdata import SpatialData  # noqa: E402
 from spatialdata.models import Image2DModel  # noqa: E402
 from spatialdata.transformations import Scale, get_transformation  # noqa: E402
 
+from thyra.converters.spatialdata import optical_image  # noqa: E402
 from thyra.converters.spatialdata.optical_image import (  # noqa: E402
     OpticalTiffSource,
     StreamedOpticalImage,
@@ -41,6 +46,10 @@ from thyra.converters.spatialdata.optical_image import (  # noqa: E402
     level_shapes,
     trim_excess,
 )
+
+CHUNKS = (1, 16, 16)
+TRANSFORM = Scale([2.0, 0.5], axes=("x", "y"))
+TRANSFORMATIONS = {"slide": TRANSFORM, "global": TRANSFORM}
 
 
 def _xarray_reference(block: np.ndarray, factor: int) -> np.ndarray:
@@ -58,11 +67,46 @@ def _stream_reference(block: np.ndarray, factor: int) -> np.ndarray:
     """The same step the way stream_pixels computes it: trim, then block mean."""
     ey = trim_excess(block.shape[1], factor)
     ex = trim_excess(block.shape[2], factor)
-    return block_mean(block[:, ey:, ex:], (1, factor, factor))
+    return block_mean(block[:, ey:, ex:], factor)
+
+
+def _parse_reference(whole: np.ndarray, scale_factors):
+    """The route this module replaces: whole page -> Image2DModel.parse."""
+    kwargs = {"transformations": dict(TRANSFORMATIONS), "chunks": CHUNKS}
+    if scale_factors:
+        kwargs["scale_factors"] = scale_factors
+    return Image2DModel.parse(
+        xr.DataArray(
+            whole,
+            dims=("c", "y", "x"),
+            coords={
+                "c": np.arange(whole.shape[0]),
+                "y": np.arange(whole.shape[1]),
+                "x": np.arange(whole.shape[2]),
+            },
+        ),
+        **kwargs,
+    )
+
+
+def _streamed(source: OpticalTiffSource, scale_factors, name="optical"):
+    return StreamedOpticalImage(
+        source=source,
+        name=name,
+        chunks=CHUNKS,
+        scale_factors=scale_factors,
+        transformations=dict(TRANSFORMATIONS),
+    )
+
+
+def _cyx(path: Path) -> np.ndarray:
+    decoded = tifffile.imread(str(path))
+    return decoded[np.newaxis] if decoded.ndim == 2 else np.moveaxis(decoded, -1, 0)
 
 
 @pytest.mark.parametrize(
-    "dtype", [np.uint8, np.uint16, np.int16, np.uint32, np.float32, np.float64]
+    "dtype",
+    [np.uint8, np.uint16, np.int16, np.uint32, np.int32, np.float32, np.float64],
 )
 @pytest.mark.parametrize("shape", [(3, 8, 8), (1, 9, 7), (2, 15, 33), (3, 5, 6)])
 @pytest.mark.parametrize("factor", [2, 3])
@@ -77,6 +121,28 @@ def test_block_mean_matches_xarray_coarsen(dtype, shape, factor):
     actual = _stream_reference(block, factor)
     assert actual.dtype == expected.dtype
     np.testing.assert_array_equal(actual, expected)
+
+
+def test_block_mean_extremes_and_nans():
+    # Saturated unsigned windows: the exact accumulator must not overflow.
+    full = np.full((2, 6, 4), 255, dtype=np.uint8)
+    np.testing.assert_array_equal(
+        _stream_reference(full, 2), _xarray_reference(full, 2)
+    )
+    full32 = np.full((1, 4, 6), np.iinfo(np.uint32).max, dtype=np.uint32)
+    np.testing.assert_array_equal(
+        _stream_reference(full32, 3), _xarray_reference(full32, 3)
+    )
+    # NaNs are skipped the way xarray's nanmean skips them.
+    floats = np.arange(2 * 4 * 4, dtype=np.float32).reshape(2, 4, 4)
+    floats[0, 0, 0] = np.nan
+    floats[1, 2:4, 2:4] = np.nan
+    expected = _xarray_reference(floats, 2)
+    actual = _stream_reference(floats, 2)
+    np.testing.assert_array_equal(np.isnan(actual), np.isnan(expected))
+    np.testing.assert_array_equal(
+        actual[~np.isnan(actual)], expected[~np.isnan(expected)]
+    )
 
 
 def test_trim_drops_the_leading_rows():
@@ -95,34 +161,38 @@ def test_trim_drops_the_leading_rows():
 
 def test_block_mean_rejects_untrimmed_input():
     with pytest.raises(ValueError, match="not a multiple"):
-        block_mean(np.zeros((1, 5, 4), dtype=np.uint8), (1, 2, 2))
-    with pytest.raises(ValueError, match="window factors"):
-        block_mean(np.zeros((1, 4, 4), dtype=np.uint8), (2, 2))
+        block_mean(np.zeros((1, 5, 4), dtype=np.uint8), 2)
+    with pytest.raises(ValueError, match="\\(c, y, x\\)"):
+        block_mean(np.zeros((4, 4), dtype=np.uint8), 2)
 
 
 def test_level_shapes_floor_like_coarsen():
-    assert level_shapes((3, 11748, 36736), [2, 2, 2], ("c", "y", "x")) == [
+    assert level_shapes((3, 11748, 36736), [2, 2, 2]) == [
         (3, 11748, 36736),
         (3, 5874, 18368),
         (3, 2937, 9184),
         (3, 1468, 4592),
     ]
-    assert level_shapes((1, 10, 10), [], ("c", "y", "x")) == [(1, 10, 10)]
+    assert level_shapes((1, 10, 10), []) == [(1, 10, 10)]
 
 
-def test_band_rows_tile_the_chunk_rows():
-    # A whole chunk row fits: one band per chunk row.
-    assert band_rows(row_bytes=1000, chunk_rows=4096, budget=10_000_000) == 4096
-    # 110 KB rows (the 36736 x 3 uint8 brightfield): 2048 of them per 256 MiB.
-    assert (
-        band_rows(row_bytes=36736 * 3, chunk_rows=4096, budget=256 * 1024 * 1024)
-        == 2048
-    )
-    # Never a divisor that straddles: 4096 rows only split into powers of two.
-    assert band_rows(row_bytes=1 << 20, chunk_rows=4096, budget=3000 << 20) == 2048
-    assert band_rows(row_bytes=1 << 30, chunk_rows=4096, budget=1) == 1
+def test_band_rows_are_whole_strips_that_tile_the_chunk_rows():
+    row = 36736 * 3  # the 110 KB rows of the real brightfield
+    # A whole chunk row fits the budget: one band per chunk row.
+    assert band_rows(1000, 4096, budget=10_000_000) == 4096
+    assert band_rows(row, 4096, strip_rows=1, budget=512 << 20) == 4096
+    # Half a chunk row fits: the largest divisor, still a whole number of strips.
+    assert band_rows(row, 4096, strip_rows=1, budget=256 << 20) == 2048
+    assert band_rows(row, 4096, strip_rows=8, budget=256 << 20) == 2048
+    # Strips that do not divide the chunk: whole strips within the budget.
+    assert band_rows(row, 4096, strip_rows=1000, budget=256 << 20) == 2000
+    # A single-strip page (rowsperstrip == height): one band, the whole page.
+    assert band_rows(row, 4096, strip_rows=11748, budget=256 << 20) == 11748
+    # Never less than one strip, even when a strip is over budget.
+    assert band_rows(1 << 30, 4096, strip_rows=64, budget=1) == 64
+    assert band_rows(1 << 30, 4096, strip_rows=1, budget=1) == 1
     with pytest.raises(ValueError):
-        band_rows(row_bytes=0, chunk_rows=4096)
+        band_rows(0, 4096)
 
 
 @pytest.fixture
@@ -137,26 +207,18 @@ def rgb_tiff(tmp_path: Path) -> Path:
     return path
 
 
-def _source_and_transform(path: Path):
-    source = OpticalTiffSource.probe(path)
-    assert source is not None
-    transform = Scale([2.0, 0.5], axes=("x", "y"))
-    return source, {"slide": transform, "global": transform}
-
-
 def test_probe_reads_only_the_header(rgb_tiff: Path):
     source = OpticalTiffSource.probe(rgb_tiff)
-    assert source is not None
     assert source.shape == (3, 37, 53)
     assert source.dtype == np.uint8
-    assert source.streamable
     assert source.page_axes == "YXS"
+    assert source.strip_rows == 1
     assert source.row_bytes == 53 * 3
 
 
 def test_bands_decode_row_ranges(rgb_tiff: Path):
     source = OpticalTiffSource.probe(rgb_tiff)
-    whole = np.moveaxis(tifffile.imread(str(rgb_tiff)), -1, 0)
+    whole = _cyx(rgb_tiff)
     starts = []
     for start, band in source.bands(rows=16):
         starts.append(start)
@@ -165,35 +227,128 @@ def test_bands_decode_row_ranges(rgb_tiff: Path):
     assert starts == [0, 16, 32]
 
 
-def test_placeholder_mirrors_image2dmodel_parse(rgb_tiff: Path):
-    source, transformations = _source_and_transform(rgb_tiff)
-    chunks = (1, 16, 16)
-    scale_factors = [2, 2]
-    streamed = StreamedOpticalImage(
-        source=source,
-        name="optical",
-        chunks=chunks,
-        scale_factors=scale_factors,
-        transformations=transformations,
-    )
-    placeholder = streamed.placeholder()
+def test_probe_reports_strip_and_tile_heights(tmp_path: Path):
+    rng = np.random.default_rng(1)
+    image = rng.integers(0, 256, size=(70, 90, 3), dtype=np.uint8)
+    default = tmp_path / "default.tif"
+    tifffile.imwrite(str(default), image)  # tifffile's default: one strip
+    assert OpticalTiffSource.probe(default).strip_rows == 70
+    strips = tmp_path / "strips.tif"
+    tifffile.imwrite(str(strips), image, rowsperstrip=8)
+    assert OpticalTiffSource.probe(strips).strip_rows == 8
+    tiles = tmp_path / "tiles.tif"
+    tifffile.imwrite(str(tiles), image, tile=(16, 16))
+    assert OpticalTiffSource.probe(tiles).strip_rows == 16
 
-    whole = np.moveaxis(tifffile.imread(str(rgb_tiff)), -1, 0)
-    reference = Image2DModel.parse(
-        xr.DataArray(
-            whole,
-            dims=("c", "y", "x"),
-            coords={"c": np.arange(3), "y": np.arange(37), "x": np.arange(53)},
-        ),
-        transformations=dict(transformations),
-        chunks=chunks,
-        scale_factors=scale_factors,
+
+def test_single_strip_page_is_decoded_once_whole(tmp_path: Path, monkeypatch):
+    """A page stored as one strip cannot be read in pieces: one band, one decode."""
+    rng = np.random.default_rng(2)
+    image = rng.integers(0, 256, size=(64, 40, 3), dtype=np.uint8)
+    path = tmp_path / "single_strip.tif"
+    tifffile.imwrite(str(path), image)
+    source = OpticalTiffSource.probe(path)
+    assert source.strip_rows == 64
+    rows = band_rows(source.row_bytes, 16, source.strip_rows, budget=40 * 3 * 4)
+    assert rows == 64
+    calls = []
+    original = tifffile.TiffPage.asarray
+
+    def counting_asarray(self, *args, **kwargs):
+        calls.append(1)
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(tifffile.TiffPage, "asarray", counting_asarray)
+    bands = list(source.bands(rows))
+    assert [start for start, _ in bands] == [0]
+    np.testing.assert_array_equal(bands[0][1], np.moveaxis(image, -1, 0))
+    assert len(calls) == 1
+
+
+def test_probe_rejects_what_the_decoder_would_have(tmp_path: Path, monkeypatch):
+    rng = np.random.default_rng(3)
+    volume = rng.integers(0, 256, size=(4, 16, 16), dtype=np.uint8)
+    path = tmp_path / "volume.tif"
+    # One ZYX page (ImageDepth), the kind of 3-d page that is not an image.
+    tifffile.imwrite(str(path), volume, photometric="minisblack", volumetric=True)
+    with pytest.raises(ValueError, match="layout"):
+        OpticalTiffSource.probe(path)
+
+    # tifffile reports a (SampleFormat, BitsPerSample) pair it cannot map as
+    # dtype None; np.dtype(None) would silently be float64.
+    class _UntypedPage:
+        shape = (16, 16, 3)
+        dtype = None
+        axes = "YXS"
+        chunks = (1, 16, 3)
+
+    class _UntypedTiff:
+        pages = [_UntypedPage()]
+
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+    monkeypatch.setattr(optical_image.tifffile, "TiffFile", _UntypedTiff)
+    with pytest.raises(ValueError, match="sample format"):
+        OpticalTiffSource.probe(path)
+
+
+def test_grayscale_and_planar_layouts(tmp_path: Path):
+    rng = np.random.default_rng(3)
+    gray = rng.integers(0, 65535, size=(21, 30), dtype=np.uint16)
+    gray_path = tmp_path / "gray.tif"
+    tifffile.imwrite(str(gray_path), gray, rowsperstrip=4)
+    source = OpticalTiffSource.probe(gray_path)
+    assert source.shape == (1, 21, 30)
+    assert source.dtype == np.uint16
+    bands = list(source.bands(rows=8))
+    assert [start for start, _ in bands] == [0, 8, 16]
+    np.testing.assert_array_equal(
+        np.concatenate([b for _, b in bands], axis=1), gray[np.newaxis]
     )
 
-    assert list(placeholder.children) == list(reference.children)
-    for level in reference.children:
-        ours = placeholder[level]["image"]
-        theirs = reference[level]["image"]
+    # One plane per sample: already (c, y, x), and streamed by rows too.
+    planar = rng.integers(0, 256, size=(3, 40, 13), dtype=np.uint8)
+    planar_path = tmp_path / "planar.tif"
+    tifffile.imwrite(
+        str(planar_path),
+        planar,
+        photometric="rgb",
+        planarconfig="separate",
+        rowsperstrip=8,
+    )
+    source = OpticalTiffSource.probe(planar_path)
+    assert source.page_axes == "SYX"
+    assert source.shape == (3, 40, 13)
+    assert source.strip_rows == 8
+    bands = list(source.bands(rows=16))
+    assert [start for start, _ in bands] == [0, 16, 32]
+    np.testing.assert_array_equal(np.concatenate([b for _, b in bands], axis=1), planar)
+
+
+@pytest.mark.parametrize("scale_factors", [[2, 2], []])
+def test_placeholder_mirrors_image2dmodel_parse(rgb_tiff: Path, scale_factors):
+    placeholder = _streamed(
+        OpticalTiffSource.probe(rgb_tiff), scale_factors
+    ).placeholder()
+    reference = _parse_reference(_cyx(rgb_tiff), scale_factors)
+    assert type(placeholder) is type(reference)
+
+    if scale_factors:
+        assert list(placeholder.children) == list(reference.children)
+        pairs = [
+            (placeholder[level]["image"], reference[level]["image"])
+            for level in reference.children
+        ]
+    else:
+        pairs = [(placeholder, reference)]
+    for ours, theirs in pairs:
         assert ours.dims == theirs.dims
         assert ours.shape == theirs.shape
         assert ours.dtype == theirs.dtype
@@ -202,7 +357,7 @@ def test_placeholder_mirrors_image2dmodel_parse(rgb_tiff: Path):
             np.testing.assert_array_equal(
                 ours.coords[axis].values, theirs.coords[axis].values
             )
-        for system in transformations:
+        for system in TRANSFORMATIONS:
             assert get_transformation(ours, system) == get_transformation(
                 theirs, system
             )
@@ -226,37 +381,18 @@ def _read_element(store: Path, name: str):
     return attrs, levels, files
 
 
+@pytest.mark.parametrize("scale_factors", [[2, 2], []])
 def test_declared_then_streamed_store_equals_parse_and_write(
-    rgb_tiff: Path, tmp_path: Path
+    rgb_tiff: Path, tmp_path: Path, scale_factors
 ):
-    source, transformations = _source_and_transform(rgb_tiff)
-    chunks = (1, 16, 16)
-    scale_factors = [2, 2]
     name = "optical"
-
-    # The route this module replaces: whole page -> parse -> write.
-    whole = np.moveaxis(tifffile.imread(str(rgb_tiff)), -1, 0)
-    reference = Image2DModel.parse(
-        xr.DataArray(
-            whole,
-            dims=("c", "y", "x"),
-            coords={"c": np.arange(3), "y": np.arange(37), "x": np.arange(53)},
-        ),
-        transformations=dict(transformations),
-        chunks=chunks,
-        scale_factors=scale_factors,
-    )
+    whole = _cyx(rgb_tiff)
     expected_store = tmp_path / "expected.zarr"
-    SpatialData(images={name: reference}).write(expected_store)
-
-    # Declare, then stream.
-    streamed = StreamedOpticalImage(
-        source=source,
-        name=name,
-        chunks=chunks,
-        scale_factors=scale_factors,
-        transformations=transformations,
+    SpatialData(images={name: _parse_reference(whole, scale_factors)}).write(
+        expected_store
     )
+
+    streamed = _streamed(OpticalTiffSource.probe(rgb_tiff), scale_factors, name)
     actual_store = tmp_path / "actual.zarr"
     SpatialData(images={name: streamed.placeholder()}).write(actual_store)
     declared_files = [
@@ -275,7 +411,8 @@ def test_declared_then_streamed_store_equals_parse_and_write(
     assert json.dumps(actual_attrs, sort_keys=True) == json.dumps(
         expected_attrs, sort_keys=True
     )
-    assert list(actual_levels) == list(expected_levels) == ["s0", "s1", "s2"]
+    assert list(actual_levels) == list(expected_levels)
+    assert list(actual_levels) == [f"s{i}" for i in range(len(scale_factors) + 1)]
     for path in expected_levels:
         expected_meta, expected_pixels = expected_levels[path]
         actual_meta, actual_pixels = actual_levels[path]
@@ -288,13 +425,17 @@ def test_declared_then_streamed_store_equals_parse_and_write(
 
     # And the pixels are the TIFF's.
     np.testing.assert_array_equal(actual_levels["s0"][1], whole)
-    # Reading back through spatialdata still sees a valid multiscale image.
+    # Reading back through spatialdata still sees a valid image.
     sdata = SpatialData.read(str(actual_store))
-    assert list(sdata.images[name].children) == ["scale0", "scale1", "scale2"]
+    element = sdata.images[name]
+    if scale_factors:
+        assert list(element.children) == ["scale0", "scale1", "scale2"]
+    else:
+        assert isinstance(element, xr.DataArray)
     axes = ("x", "y")
     np.testing.assert_array_equal(
-        get_transformation(sdata.images[name], "slide").to_affine_matrix(axes, axes),
-        transformations["slide"].to_affine_matrix(axes, axes),
+        get_transformation(element, "slide").to_affine_matrix(axes, axes),
+        TRANSFORM.to_affine_matrix(axes, axes),
     )
 
 
@@ -302,23 +443,25 @@ def test_streaming_a_small_band_budget_still_matches(
     rgb_tiff: Path, tmp_path: Path, monkeypatch
 ):
     """Bands narrower than a chunk row (partial-chunk writes) change nothing."""
-    from thyra.converters.spatialdata import optical_image
-
     monkeypatch.setattr(optical_image, "BAND_BUDGET_BYTES", 53 * 3 * 3)  # three rows
     monkeypatch.setattr(optical_image, "REDUCE_STRIP_ROWS", 2)
-    source, transformations = _source_and_transform(rgb_tiff)
-    streamed = StreamedOpticalImage(
-        source=source,
-        name="optical",
-        chunks=(1, 16, 16),
-        scale_factors=[2, 2],
-        transformations=transformations,
-    )
+    source = OpticalTiffSource.probe(rgb_tiff)
+    assert band_rows(source.row_bytes, 16, source.strip_rows, budget=53 * 3 * 3) == 2
+    streamed = _streamed(source, [2, 2])
     store = tmp_path / "narrow.zarr"
     SpatialData(images={"optical": streamed.placeholder()}).write(store)
-    streamed.stream_pixels(store)
+    bands_seen = []
+    original = OpticalTiffSource.bands
 
-    whole = np.moveaxis(tifffile.imread(str(rgb_tiff)), -1, 0)
+    def counting_bands(self, rows):
+        bands_seen.append(rows)
+        return original(self, rows)
+
+    monkeypatch.setattr(OpticalTiffSource, "bands", counting_bands)
+    streamed.stream_pixels(store)
+    assert bands_seen == [2]
+
+    whole = _cyx(rgb_tiff)
     _, levels, _ = _read_element(store, "optical")
     np.testing.assert_array_equal(levels["s0"][1], whole)
     np.testing.assert_array_equal(levels["s1"][1], _stream_reference(whole, 2))
@@ -330,24 +473,13 @@ def test_streaming_a_small_band_budget_still_matches(
 def test_stream_pixels_refuses_a_store_without_the_element(
     rgb_tiff: Path, tmp_path: Path
 ):
-    source, transformations = _source_and_transform(rgb_tiff)
-    streamed = StreamedOpticalImage(
-        source=source,
-        name="optical",
-        chunks=(1, 16, 16),
-        scale_factors=[2],
-        transformations=transformations,
-    )
+    source = OpticalTiffSource.probe(rgb_tiff)
+    streamed = _streamed(source, [2])
     store = tmp_path / "wrong.zarr"
     # A different pyramid was declared under that name.
-    other = StreamedOpticalImage(
-        source=source,
-        name="optical",
-        chunks=(1, 16, 16),
-        scale_factors=[2, 2],
-        transformations=transformations,
+    SpatialData(images={"optical": _streamed(source, [2, 2]).placeholder()}).write(
+        store
     )
-    SpatialData(images={"optical": other.placeholder()}).write(store)
     with pytest.raises(RuntimeError, match="pyramid levels"):
         streamed.stream_pixels(store)
     shutil.rmtree(store)
@@ -355,40 +487,22 @@ def test_stream_pixels_refuses_a_store_without_the_element(
         streamed.stream_pixels(store)
 
 
-def test_grayscale_and_non_streamable_layouts(tmp_path: Path):
-    rng = np.random.default_rng(3)
-    gray = rng.integers(0, 65535, size=(21, 30), dtype=np.uint16)
-    gray_path = tmp_path / "gray.tif"
-    tifffile.imwrite(str(gray_path), gray)
-    source = OpticalTiffSource.probe(gray_path)
-    assert source.shape == (1, 21, 30)
-    assert source.dtype == np.uint16
-    bands = list(source.bands(rows=8))
-    assert [start for start, _ in bands] == [0, 8, 16]
-    np.testing.assert_array_equal(
-        np.concatenate([b for _, b in bands], axis=1), gray[np.newaxis]
-    )
-
-    # Planar (separate samples) pages cannot be row-streamed; they decode whole,
-    # reshaped the way the converter always reshaped a 3-d page.
-    planar = rng.integers(0, 256, size=(3, 11, 13), dtype=np.uint8)
-    planar_path = tmp_path / "planar.tif"
-    tifffile.imwrite(
-        str(planar_path), planar, photometric="rgb", planarconfig="separate"
-    )
-    source = OpticalTiffSource.probe(planar_path)
-    assert not source.streamable
-    bands = list(source.bands(rows=4))
-    assert len(bands) == 1 and bands[0][0] == 0
-    np.testing.assert_array_equal(bands[0][1], np.moveaxis(planar, -1, 0))
+def test_discard_removes_the_declared_element(rgb_tiff: Path, tmp_path: Path):
+    streamed = _streamed(OpticalTiffSource.probe(rgb_tiff), [2])
+    store = tmp_path / "declared.zarr"
+    SpatialData(images={"optical": streamed.placeholder()}).write(store)
+    assert (store / "images" / "optical").exists()
+    streamed.discard(store)
+    assert not (store / "images" / "optical").exists()
+    streamed.discard(store)  # idempotent
+    zarr.consolidate_metadata(str(store))
+    assert list(SpatialData.read(str(store)).images) == []
 
 
-@pytest.mark.parametrize("route", ["2d", "streaming"])
-def test_converters_stream_the_pixels_after_the_write(
-    rgb_tiff: Path, tmp_path: Path, route
-):
-    """Both write paths declare the placeholder, then fill it: the store has the pixels."""
-    from tests.fixtures.mock_msi_generator import MockMSIConfig, MockMSIReader
+# ---- the converter routes ----------------------------------------------
+
+
+def _convert(route: str, reader, output_path: Path):
     from thyra.converters.spatialdata.spatialdata_2d_converter import (
         SpatialData2DConverter,
     )
@@ -396,11 +510,6 @@ def test_converters_stream_the_pixels_after_the_write(
         StreamingSpatialDataConverter,
     )
 
-    reader = MockMSIReader(
-        MockMSIConfig(n_x=4, n_y=3, n_mz_bins=32, peaks_per_spectrum=(2, 4)),
-        optical_image_paths=[rgb_tiff],
-    )
-    output_path = tmp_path / f"{route}.zarr"
     if route == "2d":
         converter = SpatialData2DConverter(
             reader, output_path, dataset_id="ds", pixel_size_um=10.0
@@ -409,14 +518,89 @@ def test_converters_stream_the_pixels_after_the_write(
         converter = StreamingSpatialDataConverter(
             reader, output_path, dataset_id="ds", pixel_size_um=10.0, use_csc=True
         )
-    assert converter.convert() is True
-    # Nothing is left waiting: every declared image was streamed.
-    assert converter._pending_optical_images == []
+    return converter, converter.convert()
 
-    whole = np.moveaxis(tifffile.imread(str(rgb_tiff)), -1, 0)
+
+def _mock_reader(*optical_paths: Path):
+    from tests.fixtures.mock_msi_generator import MockMSIConfig, MockMSIReader
+
+    return MockMSIReader(
+        MockMSIConfig(n_x=4, n_y=3, n_mz_bins=32, peaks_per_spectrum=(2, 4)),
+        optical_image_paths=list(optical_paths),
+    )
+
+
+@pytest.mark.parametrize("route", ["2d", "streaming"])
+def test_converters_stream_the_pixels_after_the_write(
+    rgb_tiff: Path, tmp_path: Path, route
+):
+    """Both write paths declare the placeholder, then fill it: the store has the pixels."""
+    output_path = tmp_path / f"{route}.zarr"
+    converter, success = _convert(route, _mock_reader(rgb_tiff), output_path)
+    assert success is True
+    # Nothing is left waiting: every declared image was streamed.
+    assert converter._pending_optical_images == {}
+
+    whole = _cyx(rgb_tiff)
     _, levels, _ = _read_element(output_path, "ds_optical_highres")
     # 37 x 53 is far below the 1000 px coarsest-level floor: a single level.
     assert list(levels) == ["s0"]
     np.testing.assert_array_equal(levels["s0"][1], whole)
     sdata = SpatialData.read(str(output_path))
     np.testing.assert_array_equal(sdata.images["ds_optical_highres"].values, whole)
+
+
+@pytest.fixture
+def truncated_tiff(tmp_path: Path) -> Path:
+    """Header intact, strips cut: probe succeeds, decoding fails."""
+    rng = np.random.default_rng(11)
+    image = rng.integers(0, 256, size=(40, 30, 3), dtype=np.uint8)
+    path = tmp_path / "truncated_0000.tiff"
+    tifffile.imwrite(str(path), image, rowsperstrip=1, compression="lzw")
+    data = path.read_bytes()
+    path.write_bytes(data[: len(data) // 2])
+    source = OpticalTiffSource.probe(path)
+    assert source.shape == (3, 40, 30)
+    return path
+
+
+@pytest.mark.parametrize("route", ["2d", "streaming"])
+def test_unreadable_pixels_drop_the_image_not_the_conversion(
+    truncated_tiff: Path, tmp_path: Path, route, caplog
+):
+    """A TIFF that cannot be decoded is skipped with a warning, as it always was."""
+    output_path = tmp_path / f"{route}.zarr"
+    with caplog.at_level(logging.WARNING):
+        converter, success = _convert(route, _mock_reader(truncated_tiff), output_path)
+    assert success is True
+    assert converter._pending_optical_images == {}
+    assert any(
+        "Failed to load optical image truncated_0000.tiff" in record.message
+        for record in caplog.records
+    )
+    sdata = SpatialData.read(str(output_path))
+    assert [k for k in sdata.images if "optical" in k] == []
+    assert not (output_path / "images" / "ds_optical_highres").exists()
+    # The rest of the store is intact and consolidated.
+    assert "ds_z0_tic" in sdata.images
+    assert (output_path / "zarr.json").exists()
+
+
+def test_same_name_keeps_the_last_file(tmp_path: Path, caplog):
+    """Two TIFFs mapping to one element name: last wins, like the dict always did."""
+    rng = np.random.default_rng(5)
+    first = tmp_path / "a_0000.tif"
+    second = tmp_path / "b_0000.tif"
+    tifffile.imwrite(str(first), rng.integers(0, 256, size=(20, 24, 3), dtype=np.uint8))
+    last = rng.integers(0, 256, size=(18, 22, 3), dtype=np.uint8)
+    tifffile.imwrite(str(second), last)
+    output_path = tmp_path / "out.zarr"
+    with caplog.at_level(logging.WARNING):
+        converter, success = _convert(
+            "streaming", _mock_reader(first, second), output_path
+        )
+    assert success is True
+    assert converter._pending_optical_images == {}
+    assert any("is replaced by b_0000.tif" in r.message for r in caplog.records)
+    _, levels, _ = _read_element(output_path, "ds_optical_highres")
+    np.testing.assert_array_equal(levels["s0"][1], np.moveaxis(last, -1, 0))

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -683,7 +683,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         # Optical images declared to SpatialData as placeholders whose pixels
         # still have to be streamed into the store once it is written. See
         # optical_image.py and _stream_pending_optical_pixels().
-        self._pending_optical_images: List["StreamedOpticalImage"] = []
+        self._pending_optical_images: Dict[str, "StreamedOpticalImage"] = {}
 
         # Metadata caches (populated lazily during conversion)
         self._essential_metadata_cached: Optional[EssentialMetadata] = None
@@ -3048,10 +3048,10 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         # and _stream_pending_optical_pixels() fills it in bands once the
         # store exists. See optical_image.py for why (the whole-page route
         # cost ~5x the decoded image in transient memory).
+        # probe raises for a layout or sample format it cannot read; the
+        # per-image guard in _add_optical_images turns that into the same
+        # "skip with a warning" the whole-page decode used to give.
         source = OpticalTiffSource.probe(tiff_path)
-        if source is None:
-            logger.warning(f"Unexpected image dimensions for {tiff_path.name}")
-            return
         n_channels, y_size, x_size = source.shape
 
         # Determine transform.  Two cases:
@@ -3067,13 +3067,13 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         #    This way the optical image lands alongside the MSI in
         #    the same um frame and downstream registration steps
         #    map both together.
+        um_mode = (
+            not self._apply_optical_alignment and self._tic_to_image_matrix is not None
+        )
         is_primary = self._is_primary_optical(tiff_path)
         if is_primary:
             self._primary_optical_dims = (x_size, y_size)
-            if (
-                not self._apply_optical_alignment
-                and self._tic_to_image_matrix is not None
-            ):
+            if um_mode:
                 transform = self._build_optical_to_um_transform()
                 logger.info(
                     f"  Primary image -> um via inverse alignment: {x_size}x{y_size}"
@@ -3085,10 +3085,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             # Non-primary: first scale to match primary, then if
             # we're in um-mode, chain through the same um affine.
             base = self._compute_optical_scale_transform(x_size, y_size)
-            if (
-                not self._apply_optical_alignment
-                and self._tic_to_image_matrix is not None
-            ):
+            if um_mode:
                 transform = Sequence([base, self._build_optical_to_um_transform()])
             else:
                 transform = base
@@ -3129,8 +3126,17 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 "original_path": str(tiff_path),
             },
         )
+        # Keyed by element name, as the images dict is: a second file that
+        # maps to the same name replaces the first, the way the dict
+        # assignment always did, only now with a warning.
+        earlier = self._pending_optical_images.get(image_name)
+        if earlier is not None:
+            logger.warning(
+                f"Optical image '{image_name}' from {earlier.source.path.name} "
+                f"is replaced by {tiff_path.name}, which maps to the same name"
+            )
         data_structures["images"][image_name] = streamed.placeholder()
-        self._pending_optical_images.append(streamed)
+        self._pending_optical_images[image_name] = streamed
 
         pyramid_desc = (
             f", {len(scale_factors)} pyramid level{'s' if len(scale_factors) != 1 else ''}"
@@ -3143,20 +3149,38 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             "; pixels stream in once the store is written"
         )
 
-    def _stream_pending_optical_pixels(self) -> None:
+    def _stream_pending_optical_pixels(self) -> int:
         """Fill every optical image declared so far with its pixels.
 
         Call once the SpatialData write that carried the placeholders has
         returned and before metadata is consolidated. Each image streams
         from its TIFF in bands and builds its pyramid level by level on
-        disk, so memory stays bounded by one band, not by the image. A
-        failure propagates: an image with metadata and no pixels is a
-        corrupt store, never a successful conversion.
+        disk, so memory stays bounded by one band, not by the image.
+
+        A TIFF whose pixels cannot be read is dropped from the store with a
+        warning and the conversion goes on without it -- the tolerance the
+        whole-page decode had, when the same failure happened before
+        anything was written. Only a failure to drop the element propagates,
+        because an image with metadata and no pixels is a corrupt store.
+
+        Returns:
+            The number of images whose pixels are now in the store.
         """
-        pending, self._pending_optical_images = self._pending_optical_images, []
-        for image in pending:
+        pending, self._pending_optical_images = self._pending_optical_images, {}
+        streamed = 0
+        for image in pending.values():
             logger.info(f"Streaming optical image pixels: '{image.name}'")
-            image.stream_pixels(self.output_path)
+            try:
+                image.stream_pixels(self.output_path)
+            except Exception as e:  # mirrors the per-image guard in _add_optical_images
+                logger.warning(
+                    f"Failed to load optical image {image.source.path.name}: {e}; "
+                    f"dropping '{image.name}' from the store"
+                )
+                image.discard(self.output_path)
+                continue
+            streamed += 1
+        return streamed
 
     def _generate_optical_image_name(self, tiff_path: Path) -> str:
         """Generate a clean name for an optical image layer.

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -196,14 +196,14 @@ SPATIALDATA_AVAILABLE = False
 _import_error_msg = None
 try:
     import geopandas as gpd
-    import tifffile
-    import xarray as xr
     import zarr
     from anndata import AnnData
     from shapely.geometry import box
     from spatialdata import SpatialData
     from spatialdata.models import Image2DModel, ShapesModel, TableModel
     from spatialdata.transformations import Affine, Identity, Scale, Sequence
+
+    from .optical_image import OpticalTiffSource, StreamedOpticalImage
 
     SPATIALDATA_AVAILABLE = True
 except (ImportError, NotImplementedError) as e:
@@ -222,6 +222,8 @@ except (ImportError, NotImplementedError) as e:
     Scale = None
     box = None
     gpd = None
+    OpticalTiffSource = None  # type: ignore[misc]
+    StreamedOpticalImage = None  # type: ignore[misc]
 
 
 def _calc_optical_scale_factors(
@@ -678,6 +680,10 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         # Primary optical image filename from .mis <ImageFile> and its dimensions
         self._primary_optical_filename: Optional[str] = None
         self._primary_optical_dims: Optional[Tuple[int, int]] = None  # (width, height)
+        # Optical images declared to SpatialData as placeholders whose pixels
+        # still have to be streamed into the store once it is written. See
+        # optical_image.py and _stream_pending_optical_pixels().
+        self._pending_optical_images: List["StreamedOpticalImage"] = []
 
         # Metadata caches (populated lazily during conversion)
         self._essential_metadata_cached: Optional[EssentialMetadata] = None
@@ -3036,132 +3042,121 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
 
         logger.info(f"Loading optical image: {tiff_path.name} as '{image_name}'")
 
-        # Read TIFF using tifffile (handles large files efficiently)
-        with tifffile.TiffFile(tiff_path) as tif:
-            # Read the first page/frame
-            img_data = tif.pages[0].asarray()
+        # Only the page header is read here. The pixels never enter this
+        # process whole: the element is declared to SpatialData as a lazy
+        # placeholder with the final shape, dtype, chunking and pyramid,
+        # and _stream_pending_optical_pixels() fills it in bands once the
+        # store exists. See optical_image.py for why (the whole-page route
+        # cost ~5x the decoded image in transient memory).
+        source = OpticalTiffSource.probe(tiff_path)
+        if source is None:
+            logger.warning(f"Unexpected image dimensions for {tiff_path.name}")
+            return
+        n_channels, y_size, x_size = source.shape
 
-            # Get image dimensions
-            if img_data.ndim == 2:
-                # Grayscale: (y, x) -> (c, y, x)
-                img_data = img_data[np.newaxis, :, :]
-                n_channels = 1
-            elif img_data.ndim == 3:
-                # RGB/RGBA: (y, x, c) -> (c, y, x)
-                img_data = np.moveaxis(img_data, -1, 0)
-                n_channels = img_data.shape[0]
-            else:
-                logger.warning(
-                    f"Unexpected image dimensions {img_data.ndim} for {tiff_path.name}"
+        # Determine transform.  Two cases:
+        #
+        # 1. apply_optical_alignment=True (default): "global" is
+        #    optical-image pixel space.  Primary image is Identity;
+        #    non-primary images Scale to match primary dims.
+        #
+        # 2. apply_optical_alignment=False (e.g. Ousia wizard):
+        #    "global" is MSI micrometer space.  Map the primary
+        #    image's pixel coordinates into MSI um using the inverse
+        #    of the tic-to-image affine, then scale by pixel_size_um.
+        #    This way the optical image lands alongside the MSI in
+        #    the same um frame and downstream registration steps
+        #    map both together.
+        is_primary = self._is_primary_optical(tiff_path)
+        if is_primary:
+            self._primary_optical_dims = (x_size, y_size)
+            if (
+                not self._apply_optical_alignment
+                and self._tic_to_image_matrix is not None
+            ):
+                transform = self._build_optical_to_um_transform()
+                logger.info(
+                    f"  Primary image -> um via inverse alignment: {x_size}x{y_size}"
                 )
-                return
-
-            y_size, x_size = img_data.shape[1], img_data.shape[2]
-
-            # Create xarray DataArray
-            optical_image = xr.DataArray(
-                img_data,
-                dims=("c", "y", "x"),
-                coords={
-                    "c": np.arange(n_channels),
-                    "y": np.arange(y_size),
-                    "x": np.arange(x_size),
-                },
-                attrs={
-                    "source_file": tiff_path.name,
-                    "original_path": str(tiff_path),
-                },
-            )
-
-            # Determine transform.  Two cases:
-            #
-            # 1. apply_optical_alignment=True (default): "global" is
-            #    optical-image pixel space.  Primary image is Identity;
-            #    non-primary images Scale to match primary dims.
-            #
-            # 2. apply_optical_alignment=False (e.g. Ousia wizard):
-            #    "global" is MSI micrometer space.  Map the primary
-            #    image's pixel coordinates into MSI um using the inverse
-            #    of the tic-to-image affine, then scale by pixel_size_um.
-            #    This way the optical image lands alongside the MSI in
-            #    the same um frame and downstream registration steps
-            #    map both together.
-            is_primary = self._is_primary_optical(tiff_path)
-            if is_primary:
-                self._primary_optical_dims = (x_size, y_size)
-                if (
-                    not self._apply_optical_alignment
-                    and self._tic_to_image_matrix is not None
-                ):
-                    transform = self._build_optical_to_um_transform()
-                    logger.info(
-                        f"  Primary image -> um via inverse alignment: "
-                        f"{x_size}x{y_size}"
-                    )
-                else:
-                    transform = Identity()
-                    logger.info(f"  Primary alignment image: {x_size}x{y_size}")
-            elif self._primary_optical_dims is not None:
-                # Non-primary: first scale to match primary, then if
-                # we're in um-mode, chain through the same um affine.
-                base = self._compute_optical_scale_transform(x_size, y_size)
-                if (
-                    not self._apply_optical_alignment
-                    and self._tic_to_image_matrix is not None
-                ):
-                    transform = Sequence([base, self._build_optical_to_um_transform()])
-                else:
-                    transform = base
             else:
                 transform = Identity()
+                logger.info(f"  Primary alignment image: {x_size}x{y_size}")
+        elif self._primary_optical_dims is not None:
+            # Non-primary: first scale to match primary, then if
+            # we're in um-mode, chain through the same um affine.
+            base = self._compute_optical_scale_transform(x_size, y_size)
+            if (
+                not self._apply_optical_alignment
+                and self._tic_to_image_matrix is not None
+            ):
+                transform = Sequence([base, self._build_optical_to_um_transform()])
+            else:
+                transform = base
+        else:
+            transform = Identity()
 
-            # Multi-scale pyramid + chunked layout.
-            #
-            # Without scale_factors, Image2DModel.parse writes a
-            # single-scale image and any downstream viewer has to read
-            # full-resolution tiles at every zoom level.  For a typical
-            # FlexImaging brightfield (10k x 10k+ pixels) that is the
-            # difference between an instant first paint and a multi-
-            # second stall every time the user pans or zooms.
-            #
-            # We mirror what spatialdata-io's xenium reader does for
-            # its morphology images: scale_factors=[2, 2, 2, 2] gives
-            # the viewer five pyramid levels.  Here we adapt the level
-            # count to the image's smallest spatial dimension so tiny
-            # images don't waste levels and huge ones get enough to
-            # keep the coarsest level fast (< ~1000 px short side).
-            #
-            # chunks=(1, 4096, 4096) stores each channel as 4k x 4k
-            # blocks so a viewer's 512 x 512 tile read decompresses
-            # at most one chunk per request.
-            smallest = min(y_size, x_size)
-            scale_factors = _calc_optical_scale_factors(smallest)
-            parse_kwargs: Dict[str, Any] = {
-                "transformations": {
-                    self.dataset_id: transform,
-                    "global": transform,
-                },
-                "chunks": image_chunks(
-                    2
-                ),  # (1, 4096, 4096); sharding seam, see _chunking
-            }
-            if scale_factors:
-                parse_kwargs["scale_factors"] = scale_factors
+        # Multi-scale pyramid + chunked layout.
+        #
+        # Without scale_factors a single-scale image is written and any
+        # downstream viewer has to read full-resolution tiles at every
+        # zoom level.  For a typical FlexImaging brightfield (10k x 10k+
+        # pixels) that is the difference between an instant first paint
+        # and a multi-second stall every time the user pans or zooms.
+        #
+        # We mirror what spatialdata-io's xenium reader does for its
+        # morphology images: scale_factors=[2, 2, 2, 2] gives the viewer
+        # five pyramid levels.  Here we adapt the level count to the
+        # image's smallest spatial dimension so tiny images don't waste
+        # levels and huge ones get enough to keep the coarsest level
+        # fast (< ~1000 px short side).
+        #
+        # chunks=(1, 4096, 4096) stores each channel as 4k x 4k blocks
+        # so a viewer's 512 x 512 tile read decompresses at most one
+        # chunk per request.
+        smallest = min(y_size, x_size)
+        scale_factors = _calc_optical_scale_factors(smallest)
+        streamed = StreamedOpticalImage(
+            source=source,
+            name=image_name,
+            chunks=image_chunks(2),  # (1, 4096, 4096); sharding seam, see _chunking
+            scale_factors=scale_factors,
+            transformations={
+                self.dataset_id: transform,
+                "global": transform,
+            },
+            attrs={
+                "source_file": tiff_path.name,
+                "original_path": str(tiff_path),
+            },
+        )
+        data_structures["images"][image_name] = streamed.placeholder()
+        self._pending_optical_images.append(streamed)
 
-            data_structures["images"][image_name] = Image2DModel.parse(
-                optical_image,
-                **parse_kwargs,
-            )
+        pyramid_desc = (
+            f", {len(scale_factors)} pyramid level{'s' if len(scale_factors) != 1 else ''}"
+            if scale_factors
+            else " (no pyramid; image small enough)"
+        )
+        logger.info(
+            f"Added optical image '{image_name}': {x_size}x{y_size} "
+            f"({n_channels} channel{'s' if n_channels > 1 else ''}){pyramid_desc}"
+            "; pixels stream in once the store is written"
+        )
 
-            pyramid_desc = (
-                f", {len(scale_factors)} pyramid level{'s' if len(scale_factors) != 1 else ''}"
-                if scale_factors
-                else " (no pyramid; image small enough)"
-            )
-            logger.info(
-                f"Added optical image '{image_name}': {x_size}x{y_size} "
-                f"({n_channels} channel{'s' if n_channels > 1 else ''}){pyramid_desc}"
-            )
+    def _stream_pending_optical_pixels(self) -> None:
+        """Fill every optical image declared so far with its pixels.
+
+        Call once the SpatialData write that carried the placeholders has
+        returned and before metadata is consolidated. Each image streams
+        from its TIFF in bands and builds its pyramid level by level on
+        disk, so memory stays bounded by one band, not by the image. A
+        failure propagates: an image with metadata and no pixels is a
+        corrupt store, never a successful conversion.
+        """
+        pending, self._pending_optical_images = self._pending_optical_images, []
+        for image in pending:
+            logger.info(f"Streaming optical image pixels: '{image.name}'")
+            image.stream_pixels(self.output_path)
 
     def _generate_optical_image_name(self, tiff_path: Path) -> str:
         """Generate a clean name for an optical image layer.
@@ -3220,6 +3215,9 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             # file per KB -- and the write dominates conversion wall-clock.
             with _suppress_upstream_warnings(), table_write_config():
                 sdata.write(str(self.output_path))
+                # The optical images above are placeholders; their pixels
+                # stream into the store now that it exists.
+                self._stream_pending_optical_pixels()
                 zarr.consolidate_metadata(str(self.output_path))
             logger.info(f"Successfully saved SpatialData to {self.output_path}")
             return True

--- a/thyra/converters/spatialdata/optical_image.py
+++ b/thyra/converters/spatialdata/optical_image.py
@@ -7,9 +7,11 @@ same road as any other raster: decode the whole page into numpy, hand it to
 compute the pyramid. Measured on a 1.29 GB decode that road costs ~6.6 GB
 over the conversion's baseline, for three reasons, none of them the image:
 
-* dask's expression-based ``from_array`` copies every numpy array it is
-  given (``x.copy()`` in ``dask.array._array_expr._collection.from_array``),
-  so the decoded page is in memory twice before anything is written;
+* dask's ``from_array`` copies every numpy array it is given (``x.copy()``
+  in both ``dask.array.core.from_array`` and its expression-based twin, so
+  no dask configuration avoids it), and ``Image2DModel.parse`` calls it for
+  numpy input: the decoded page is in memory twice before anything is
+  written;
 * ``multiscale_spatial_image`` builds each pyramid level as
   ``coarsen(...).mean().astype(dtype)`` -- the mean promotes every 4096 x 4096
   block to float64 (128 MB per 16 MB of uint8) and the threaded scheduler
@@ -17,29 +19,37 @@ over the conversion's baseline, for three reasons, none of them the image:
 * all levels are computed in a single ``dask.compute``, so the scheduler is
   free to hold as many of those intermediates as it has threads.
 
-This module keeps the store byte-for-byte what that road produced while
-bounding memory by one *band* of the source, not by the image:
+This module keeps the store what that road produced while bounding memory
+by one *band* of the source, not by the image:
 
-1. **Declare, then stream.** The converter hands ``SpatialData`` a
-   :meth:`StreamedOpticalImage.placeholder` -- a DataTree with the right
-   shapes, dtype, chunks and transformations per level whose pixels are
-   lazy zeros.
+1. **Declare, then stream.** The converter hands ``SpatialData``
+   :meth:`StreamedOpticalImage.placeholder` -- the element with its final
+   shapes, dtype, chunks and transformations, whose pixels are lazy zeros.
    spatialdata and ome-zarr create the arrays and write every piece of
    metadata exactly as before; zarr skips the all-zero chunks (its
-   ``write_empty_chunks`` default), so declaring costs nothing on disk.
+   ``write_empty_chunks`` default), so declaring stores no chunk.
 2. **Level 0 from the TIFF in bands.** :meth:`StreamedOpticalImage.stream_pixels`
-   opens the page through tifffile's zarr adapter, which decodes only the
-   strips a row range needs, and writes the bands into the level-0 array
-   under :data:`BAND_BUDGET_BYTES`.
-3. **Each pyramid level from the one below, on disk.** Every level-*k* chunk
-   is the exact block mean of its level-*k-1* footprint, read back from the
-   store and reduced in strips (:func:`block_mean`), so a chunk's working set
-   is tens of MB whatever the image size.
+   reads row bands through tifffile's zarr adapter, which decodes only the
+   strips (or tile rows) a band needs, and writes them into the level-0
+   array under :data:`BAND_BUDGET_BYTES`. Bands are whole strips: a page
+   stored as one strip cannot be read in pieces, so it is decoded once,
+   whole, as before.
+3. **Each pyramid level from the one below, on disk.** Every level-*k* write
+   unit is assembled one level-*k-1* chunk at a time, each reduced with the
+   exact :func:`block_mean`, so a worker holds one source chunk, one
+   accumulator and the chunk it is building whatever the image size.
 
 The pixel values are those ``xarray``'s ``coarsen`` produces: same
 ``boundary="trim", side="right"`` rule (an odd-sized axis drops its FIRST
 row or column), same float64 mean, same truncating cast back to the source
 dtype. :func:`block_mean` is unit-tested against xarray for exactly that.
+
+**Failure policy.** A TIFF that cannot be decoded used to be skipped with a
+warning before anything was written; now the header is read up front and
+the pixels only after the store exists, so
+:meth:`BaseSpatialDataConverter._stream_pending_optical_pixels` keeps that
+contract by dropping the declared element from the store and warning. A
+store never keeps an image whose pixels were not written.
 """
 
 from __future__ import annotations
@@ -50,7 +60,7 @@ import os
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Iterator, List, Sequence, Tuple, Union
 
 import dask.array as da
 import numpy as np
@@ -63,55 +73,74 @@ from spatialdata.transformations import set_transformation
 logger = logging.getLogger(__name__)
 
 #: Decoded bytes one band of the source TIFF may occupy while level 0 is
-#: streamed in. Bands tile the level-0 chunk rows (never straddle them), so
-#: a narrow budget only means more partial-chunk writes, never a wrong one.
-BAND_BUDGET_BYTES = 256 * 1024 * 1024
+#: streamed in. Measured on a 36736 px wide RGB brightfield: a whole
+#: 4096-row chunk row (451 MB) fits, so every level-0 chunk is encoded once;
+#: a 256 MiB budget split it in two and cost a read-modify-write per chunk
+#: (+0.7 s per chunk row) for a stage peak only 29 MB lower.
+BAND_BUDGET_BYTES = 512 * 1024 * 1024
 
-#: Output rows reduced at a time when a pyramid chunk is assembled from the
-#: level below. Bounds the float64 intermediate of the block mean.
+#: Output rows reduced at a time inside one source chunk. Bounds the
+#: accumulator of the block mean to (rows x chunk width) values.
 REDUCE_STRIP_ROWS = 512
 
-#: Pyramid chunks reduced concurrently. Each holds its level-below footprint
-#: (four source chunks), the chunk being assembled and one strip's float64
-#: mean, so this is the multiplier on that working set.
+#: Pyramid write units reduced concurrently. Each worker holds one source
+#: chunk, one strip accumulator and the unit it is assembling.
 REDUCE_WORKERS = 4
 
-Axes = Tuple[str, ...]
-Shape = Tuple[int, ...]
+#: The layouts of a TIFF page this module reads: samples interleaved per
+#: pixel (what FlexImaging exports and practically every RGB TIFF use),
+#: a single sample, or one plane per sample.
+PAGE_LAYOUTS = ("YXS", "YX", "SYX")
+
+Shape = Tuple[int, int, int]
 
 
-def block_mean(block: np.ndarray, factors: Sequence[int]) -> np.ndarray:
-    """Mean over non-overlapping windows, cast back to ``block``'s dtype.
+def block_mean(block: np.ndarray, factor: int) -> np.ndarray:
+    """Mean over ``factor`` x ``factor`` windows of a ``(c, y, x)`` block.
 
     Reproduces ``xarray``'s ``coarsen(window).mean().astype(block.dtype)``
-    value for value: integer input is averaged in float64 (numpy's own
-    ``mean`` accumulator for integers, the dtype dask picks for the same
-    reduction), floating input in its own precision with NaNs skipped as
-    xarray's ``nanmean`` does, and the cast truncates the way
-    ``ndarray.astype`` does.
+    value for value. Unsigned integers are summed exactly and floor-divided,
+    which equals the truncated float64 mean for values that are never
+    negative; signed integers take numpy's float64 mean (the accumulator
+    dask picks for the same reduction); floating input keeps its own
+    precision and skips NaNs the way xarray's ``nanmean`` does when any are
+    present. The cast truncates the way ``ndarray.astype`` does.
 
     Args:
-        block: Array whose every axis is a multiple of its window. Trim
-            before calling; see :func:`trim_excess`.
-        factors: Window per axis. ``1`` leaves an axis alone.
+        block: ``(c, y, x)`` array whose ``y`` and ``x`` are multiples of
+            ``factor``. Trim before calling; see :func:`trim_excess`.
+        factor: Window edge along ``y`` and ``x``.
 
     Returns:
-        Array of shape ``block.shape // factors`` and ``block.dtype``.
+        Array of shape ``(c, y // factor, x // factor)`` and ``block.dtype``.
     """
-    if len(factors) != block.ndim:
-        raise ValueError(f"{len(factors)} window factors for a {block.ndim}-d block")
-    shape: List[int] = []
-    reduce_axes: List[int] = []
-    for axis, (size, factor) in enumerate(zip(block.shape, factors)):
-        if factor < 1 or size % factor:
-            raise ValueError(
-                f"axis {axis} of size {size} is not a multiple of window {factor}"
-            )
-        shape.extend((size // factor, factor))
-        reduce_axes.append(2 * axis + 1)
-    windows = block.reshape(shape)
-    mean_of = np.nanmean if block.dtype.kind in "fc" else np.mean
-    return mean_of(windows, axis=tuple(reduce_axes)).astype(block.dtype)
+    if block.ndim != 3:
+        raise ValueError(f"block_mean expects a (c, y, x) block, got {block.ndim}-d")
+    if factor < 1:
+        raise ValueError(f"window factor must be positive, got {factor}")
+    channels, rows, cols = block.shape
+    if rows % factor or cols % factor:
+        raise ValueError(
+            f"block of shape {block.shape} is not a multiple of window {factor}"
+        )
+    if block.dtype.kind in "ub":
+        # Exact integer path: the float64 sum of these values is exact and
+        # /n truncates to the floor, so floor(sum / n) is the same number.
+        n = factor * factor
+        acc_dtype = (
+            np.uint32 if int(np.iinfo(block.dtype).max) * n < 2**32 else np.uint64
+        )
+        if block.dtype.kind == "b":
+            acc_dtype = np.uint32
+        acc = np.zeros((channels, rows // factor, cols // factor), dtype=acc_dtype)
+        for dy in range(factor):
+            for dx in range(factor):
+                acc += block[:, dy::factor, dx::factor]
+        return (acc // n).astype(block.dtype)
+    windows = block.reshape(channels, rows // factor, factor, cols // factor, factor)
+    if block.dtype.kind in "fc" and np.isnan(windows).any():
+        return np.nanmean(windows, axis=(2, 4)).astype(block.dtype)
+    return np.mean(windows, axis=(2, 4)).astype(block.dtype)
 
 
 def trim_excess(size: int, factor: int) -> int:
@@ -124,94 +153,125 @@ def trim_excess(size: int, factor: int) -> int:
     return size - (size // factor) * factor
 
 
-def level_shapes(shape: Shape, scale_factors: Sequence[int], axes: Axes) -> List[Shape]:
-    """Shape of every pyramid level, level 0 first.
+def level_shapes(shape: Shape, scale_factors: Sequence[int]) -> List[Shape]:
+    """``(c, y, x)`` of every pyramid level, level 0 first.
 
-    Each factor halves (or whatever the factor is) the spatial axes of the
-    level before it, flooring the way ``coarsen(boundary="trim")`` does. The
-    channel axis is never reduced.
+    Each factor divides the spatial axes of the level before it, flooring
+    the way ``coarsen(boundary="trim")`` does. The channel axis is never
+    reduced.
     """
-    shapes = [tuple(shape)]
+    shapes = [(int(shape[0]), int(shape[1]), int(shape[2]))]
     for factor in scale_factors:
-        previous = shapes[-1]
-        shapes.append(
-            tuple(
-                n // factor if ax in ("x", "y", "z") else n
-                for n, ax in zip(previous, axes)
-            )
-        )
+        c, y, x = shapes[-1]
+        shapes.append((c, y // factor, x // factor))
     return shapes
 
 
-def band_rows(row_bytes: int, chunk_rows: int, budget: int = BAND_BUDGET_BYTES) -> int:
-    """Rows per band so a decoded band fits ``budget`` and tiles the chunk rows.
+def band_rows(
+    row_bytes: int,
+    chunk_rows: int,
+    strip_rows: int = 1,
+    budget: int = BAND_BUDGET_BYTES,
+) -> int:
+    """Rows per band: whole strips, within ``budget``, tiling the chunk rows.
 
-    Returns ``chunk_rows`` whenever a whole chunk row of the source fits;
-    otherwise the largest divisor of ``chunk_rows`` that does, so bands never
-    straddle a chunk boundary and every chunk is completed by a contiguous
-    run of bands.
+    A strip (or tile row) is the smallest unit the TIFF decoder produces, so
+    a band is always a whole number of them and never shorter than one --
+    a single-strip page yields one band, the whole page, decoded once.
+    Within that, the largest divisor of ``chunk_rows`` that fits is
+    preferred so bands complete whole level-0 chunks instead of straddling
+    them; when the strip height does not divide the chunk height no such
+    divisor exists and the budget alone decides, which only means the
+    chunks are completed by more than one band.
     """
-    if row_bytes <= 0 or chunk_rows <= 0:
-        raise ValueError("row_bytes and chunk_rows must be positive")
-    rows = max(1, budget // row_bytes)
-    if rows >= chunk_rows:
+    if row_bytes <= 0 or chunk_rows <= 0 or strip_rows <= 0:
+        raise ValueError("row_bytes, chunk_rows and strip_rows must be positive")
+    rows = max(strip_rows, (budget // row_bytes) // strip_rows * strip_rows)
+    if rows >= chunk_rows and chunk_rows % strip_rows == 0:
         return chunk_rows
-    for candidate in range(rows, 0, -1):
-        if chunk_rows % candidate == 0:
+    for candidate in range(min(rows, chunk_rows), 0, -1):
+        if chunk_rows % candidate == 0 and candidate % strip_rows == 0:
             return candidate
-    return 1
+    return rows
 
 
-def _chunk_slices(array: zarr.Array) -> Iterator[Tuple[slice, ...]]:
-    """Every chunk of ``array`` as a tuple of slices, C order."""
-    ranges = [range(0, size, chunk) for size, chunk in zip(array.shape, array.chunks)]
+def _write_unit(array: zarr.Array) -> Tuple[int, ...]:
+    """The block one write of ``array`` should cover: its shard, else its chunk.
+
+    ``zarr.Array.chunks`` is the inner chunk once an array is sharded, and
+    concurrent writes inside one shard clobber each other, so the streaming
+    and the reducer key on the shard whenever there is one.
+    """
+    return tuple(int(n) for n in (array.shards or array.chunks))
+
+
+def _write_regions(array: zarr.Array) -> Iterator[Tuple[slice, slice, slice]]:
+    """Every write unit of a ``(c, y, x)`` array as slices, C order."""
+    unit = _write_unit(array)
+    ranges = [range(0, size, step) for size, step in zip(array.shape, unit)]
     for starts in itertools.product(*ranges):
-        yield tuple(
-            slice(start, min(start + chunk, size))
-            for start, chunk, size in zip(starts, array.chunks, array.shape)
+        c, y, x = (
+            slice(start, min(start + step, size))
+            for start, step, size in zip(starts, unit, array.shape)
         )
+        yield c, y, x
 
 
 @dataclass(frozen=True)
 class OpticalTiffSource:
     """What the first page of an optical TIFF looks like, without decoding it.
 
-    ``shape`` is always ``(c, y, x)``. ``streamable`` is True when the page
-    is stored ``YX`` or ``YXS`` (samples interleaved per pixel, the layout
-    every FlexImaging export and practically every RGB TIFF uses), which is
-    what lets a row range be decoded on its own. Any other layout is
-    decoded whole, exactly as before, and reshaped the same way.
+    ``shape`` is always ``(c, y, x)``. ``page_axes`` is one of
+    :data:`PAGE_LAYOUTS` and says how a decoded array maps onto that;
+    ``strip_rows`` is the height of the page's strips or tiles, the smallest
+    row range the decoder can produce on its own.
     """
 
     path: Path
     shape: Shape
     dtype: np.dtype
-    streamable: bool
     page_axes: str
+    strip_rows: int
 
     @classmethod
-    def probe(cls, path: Union[str, Path]) -> Optional["OpticalTiffSource"]:
-        """Read the page header. ``None`` when the page is not 2-D or 3-D."""
+    def probe(cls, path: Union[str, Path]) -> "OpticalTiffSource":
+        """Read the page header.
+
+        Raises:
+            ValueError: for a page layout other than :data:`PAGE_LAYOUTS`
+                or a sample format tifffile cannot map to a dtype -- the
+                cases the whole-page decode used to reject, at the same
+                point, before anything is written.
+        """
         path = Path(path)
         with tifffile.TiffFile(path) as tif:
             page = tif.pages[0]
             page_shape = tuple(int(n) for n in page.shape)
-            dtype = np.dtype(page.dtype)
+            dtype = page.dtype
             axes = str(page.axes)
-        if len(page_shape) == 2:
+            chunks = tuple(int(n) for n in page.chunks)
+        if dtype is None:
+            raise ValueError(f"{path.name}: sample format not supported by tifffile")
+        if axes == "YX":
             shape: Shape = (1, page_shape[0], page_shape[1])
-        elif len(page_shape) == 3:
-            # Trailing axis is the channel axis, as the moveaxis(-1, 0) the
-            # converter always applied assumed.
+            strip_rows = chunks[0]
+        elif axes == "YXS":
             shape = (page_shape[2], page_shape[0], page_shape[1])
+            strip_rows = chunks[0]
+        elif axes == "SYX":
+            shape = (page_shape[0], page_shape[1], page_shape[2])
+            # tifffile reports planar strips as (rows, width).
+            strip_rows = chunks[-2]
         else:
-            return None
+            raise ValueError(
+                f"{path.name}: unsupported TIFF page layout {axes} {page_shape}"
+            )
         return cls(
             path=path,
             shape=shape,
-            dtype=dtype,
-            streamable=axes in ("YX", "YXS"),
+            dtype=np.dtype(dtype),
             page_axes=axes,
+            strip_rows=max(1, min(strip_rows, shape[1])),
         )
 
     @property
@@ -222,26 +282,31 @@ class OpticalTiffSource:
     def bands(self, rows: int) -> Iterator[Tuple[int, np.ndarray]]:
         """Yield ``(first_row, band)`` with ``band`` shaped ``(c, rows, x)``.
 
-        Streams row ranges through tifffile's zarr adapter when the layout
-        allows it, so only the strips of a band are ever decoded; otherwise
-        decodes the page once and yields it as a single band.
+        Row ranges are decoded through tifffile's zarr adapter, so only the
+        strips of a band are ever decoded. When ``rows`` covers the page the
+        page is decoded once, whole, with tifffile's own parallel decoder.
         """
+        n_rows = self.shape[1]
         with tifffile.TiffFile(self.path) as tif:
             page = tif.pages[0]
-            if not self.streamable:
+            if rows >= n_rows:
                 yield 0, self._to_cyx(page.asarray())
                 return
             source = zarr.open_array(store=page.aszarr(), mode="r")
-            n_rows = self.shape[1]
             for start in range(0, n_rows, rows):
                 stop = min(start + rows, n_rows)
-                yield start, self._to_cyx(source[start:stop])
+                if self.page_axes == "SYX":
+                    decoded = source[:, start:stop]
+                else:
+                    decoded = source[start:stop]
+                yield start, self._to_cyx(decoded)
 
-    @staticmethod
-    def _to_cyx(decoded: np.ndarray) -> np.ndarray:
-        if decoded.ndim == 2:
+    def _to_cyx(self, decoded: np.ndarray) -> np.ndarray:
+        if self.page_axes == "YX":
             return decoded[np.newaxis, :, :]
-        return np.moveaxis(decoded, -1, 0)
+        if self.page_axes == "YXS":
+            return np.moveaxis(decoded, -1, 0)
+        return decoded
 
 
 @dataclass
@@ -251,54 +316,60 @@ class StreamedOpticalImage:
     Build it, put :meth:`placeholder` in the images the SpatialData write
     carries, and call :meth:`stream_pixels` on the store once that write
     has returned. Between the two the element on disk has all its metadata
-    and no pixels.
+    and no pixels; :meth:`discard` removes it again if the pixels cannot
+    be streamed.
     """
 
     source: OpticalTiffSource
     name: str
-    chunks: Shape
+    chunks: Tuple[int, ...]
     scale_factors: Sequence[int]
     transformations: Dict[str, Any]
-    axes: Axes = ("c", "y", "x")
     attrs: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        # The band and chunk arithmetic below indexes rows as axis 1 and
-        # columns as axis 2; that is the (c, y, x) layout and nothing else.
-        if tuple(self.axes) != ("c", "y", "x"):
-            raise ValueError(f"optical images are (c, y, x), got axes {self.axes}")
-        if len(self.chunks) != len(self.axes):
-            raise ValueError(f"chunks {self.chunks} do not match axes {self.axes}")
+        if len(self.chunks) != 3:
+            raise ValueError(f"chunks must be (c, y, x), got {self.chunks}")
         self.scale_factors = [int(f) for f in self.scale_factors]
 
     @property
     def level_shapes(self) -> List[Shape]:
-        """Shape of every pyramid level of this image, level 0 first."""
-        return level_shapes(self.source.shape, self.scale_factors, self.axes)
+        """``(c, y, x)`` of every pyramid level of this image, level 0 first."""
+        return level_shapes(self.source.shape, self.scale_factors)
 
-    def placeholder(self) -> xr.DataTree:
-        """The multiscale element as ``Image2DModel.parse`` would shape it.
+    def placeholder(self) -> Union[xr.DataArray, xr.DataTree]:
+        """The element as ``Image2DModel.parse`` would build it, pixels lazy zeros.
 
-        Every level is lazy zeros with the store's chunking, so the write
-        creates the arrays and metadata and stores no chunk. Structure,
-        per-level transformations and coordinates mirror what ``parse``
-        builds for ``scale_factors`` so the in-memory element is a valid
-        spatialdata image as well.
+        With scale factors this is the multiscale DataTree ``parse`` builds
+        for ``scale_factors``: same levels, chunks, per-level transformations
+        and coordinates. Without, it is the single-scale DataArray ``parse``
+        returns, so the store gets the single-scale writer it always had.
+        Either way the write creates the arrays and metadata and stores no
+        chunk.
         """
+        dims = ("c", "y", "x")
+        if not self.scale_factors:
+            image = Image2DModel.parse(
+                da.zeros(
+                    self.source.shape, chunks=self.chunks, dtype=self.source.dtype
+                ),
+                dims=dims,
+                transformations=dict(self.transformations),
+                chunks=self.chunks,
+            )
+            image.attrs.update(self.attrs)
+            return image
         base = self.level_shapes[0]
         levels: Dict[str, xr.Dataset] = {}
         for index, shape in enumerate(self.level_shapes):
             coords: Dict[str, Any] = {"c": np.arange(shape[0])}
-            for axis, size in zip(self.axes, shape):
-                if axis == "c":
-                    continue
-                full = base[self.axes.index(axis)]
+            for axis, full, size in zip(dims[1:], base[1:], shape[1:]):
                 # Pixel centres in level-0 units; spatialdata's own
                 # compute_coordinates for a DataTree, verbatim.
                 coords[axis] = np.linspace(0, full, size + 1)[:-1] + full / size / 2
             image = xr.DataArray(
                 da.zeros(shape, chunks=self.chunks, dtype=self.source.dtype),
-                dims=self.axes,
+                dims=dims,
                 coords=coords,
                 attrs=dict(self.attrs),
             )
@@ -313,7 +384,7 @@ class StreamedOpticalImage:
 
         Requires the store to hold the element :meth:`placeholder` declared.
         Level 0 comes from the TIFF in bands; each further level from the
-        level below, chunk by chunk.
+        level below, one write unit at a time.
         """
         arrays = self._open_level_arrays(store_path)
         self._stream_level0(arrays[0])
@@ -325,18 +396,23 @@ class StreamedOpticalImage:
             f"{'s' if len(self.scale_factors) != 1 else ''}"
         )
 
+    def discard(self, store_path: Union[str, Path]) -> None:
+        """Remove the declared element from ``store_path``, if it is there."""
+        root = zarr.open_group(str(store_path), mode="r+", use_consolidated=False)
+        images = root["images"]
+        if self.name in images:
+            del images[self.name]
+
     def _open_level_arrays(self, store_path: Union[str, Path]) -> List[zarr.Array]:
         root = zarr.open_group(str(store_path), mode="r+", use_consolidated=False)
         element = root[f"images/{self.name}"]
-        attrs = element.attrs.asdict()
-        multiscales = attrs.get("ome", {}).get("multiscales") or attrs.get(
-            "multiscales"
-        )
-        if not multiscales:
+        try:
+            datasets = element.attrs["ome"]["multiscales"][0]["datasets"]
+        except (KeyError, IndexError, TypeError) as exc:
             raise RuntimeError(
                 f"images/{self.name} in {store_path} carries no multiscales metadata"
-            )
-        paths = [dataset["path"] for dataset in multiscales[0]["datasets"]]
+            ) from exc
+        paths = [dataset["path"] for dataset in datasets]
         expected = self.level_shapes
         if len(paths) != len(expected):
             raise RuntimeError(
@@ -355,8 +431,15 @@ class StreamedOpticalImage:
         return arrays
 
     def _stream_level0(self, target: zarr.Array) -> None:
-        chunk_rows = int(target.chunks[1])
-        rows = band_rows(self.source.row_bytes, chunk_rows)
+        chunk_rows = _write_unit(target)[1]
+        # The budget is looked up here, not bound as a default, so a test
+        # (or a caller) can narrow it.
+        rows = band_rows(
+            self.source.row_bytes,
+            chunk_rows,
+            self.source.strip_rows,
+            budget=BAND_BUDGET_BYTES,
+        )
         n_bands = -(-self.source.shape[1] // rows)
         logger.debug(
             f"  level 0 of '{self.name}': {n_bands} band(s) of {rows} rows "
@@ -364,33 +447,59 @@ class StreamedOpticalImage:
         )
         for start, band in self.source.bands(rows):
             target[:, start : start + band.shape[1], :] = band
+            # The next band is decoded before this name is rebound; drop
+            # it now so only one band is ever alive.
             del band
 
     def _reduce_level(
         self, source: zarr.Array, target: zarr.Array, factor: int
     ) -> None:
-        factors = tuple(factor if ax in ("x", "y", "z") else 1 for ax in self.axes)
-        excess = tuple(trim_excess(size, f) for size, f in zip(source.shape, factors))
-        chunks = list(_chunk_slices(target))
-        workers = max(1, min(REDUCE_WORKERS, os.cpu_count() or 1, len(chunks)))
+        """Write every unit of ``target`` from its footprint in ``source``.
 
-        def reduce_chunk(out_sel: Tuple[slice, ...]) -> None:
-            in_sel = tuple(
-                slice(e + s.start * f, e + s.stop * f)
-                for s, e, f in zip(out_sel, excess, factors)
+        A unit's footprint is walked one source write unit at a time (an
+        odd trim shifts the walk by the excess, so the last step of a row or
+        column may touch a second source chunk), and each piece is reduced
+        in strips of :data:`REDUCE_STRIP_ROWS` output rows.
+        """
+        excess_y = trim_excess(source.shape[1], factor)
+        excess_x = trim_excess(source.shape[2], factor)
+        _, src_rows, src_cols = _write_unit(source)
+        out_rows_per_read = max(1, src_rows // factor)
+        out_cols_per_read = max(1, src_cols // factor)
+        regions = list(_write_regions(target))
+        workers = max(1, min(REDUCE_WORKERS, os.cpu_count() or 1, len(regions)))
+
+        def reduce_region(region: Tuple[slice, slice, slice]) -> None:
+            c_sel, y_sel, x_sel = region
+            unit = np.empty(
+                (
+                    c_sel.stop - c_sel.start,
+                    y_sel.stop - y_sel.start,
+                    x_sel.stop - x_sel.start,
+                ),
+                dtype=target.dtype,
             )
-            footprint = source[in_sel]
-            chunk = np.empty(
-                tuple(s.stop - s.start for s in out_sel), dtype=target.dtype
-            )
-            n_rows = chunk.shape[1]
-            for row in range(0, n_rows, REDUCE_STRIP_ROWS):
-                stop = min(row + REDUCE_STRIP_ROWS, n_rows)
-                strip = footprint[:, row * factors[1] : stop * factors[1], :]
-                chunk[:, row:stop, :] = block_mean(strip, factors)
-            del footprint
-            target[out_sel] = chunk
+            for y0 in range(0, unit.shape[1], out_rows_per_read):
+                y1 = min(y0 + out_rows_per_read, unit.shape[1])
+                for x0 in range(0, unit.shape[2], out_cols_per_read):
+                    x1 = min(x0 + out_cols_per_read, unit.shape[2])
+                    piece = source[
+                        c_sel,
+                        excess_y
+                        + (y_sel.start + y0) * factor : excess_y
+                        + (y_sel.start + y1) * factor,
+                        excess_x
+                        + (x_sel.start + x0) * factor : excess_x
+                        + (x_sel.start + x1) * factor,
+                    ]
+                    for r0 in range(0, y1 - y0, REDUCE_STRIP_ROWS):
+                        r1 = min(r0 + REDUCE_STRIP_ROWS, y1 - y0)
+                        unit[:, y0 + r0 : y0 + r1, x0:x1] = block_mean(
+                            piece[:, r0 * factor : r1 * factor, :], factor
+                        )
+                    del piece
+            target[region] = unit
 
         with ThreadPoolExecutor(max_workers=workers) as pool:
-            # list() so a failing chunk raises here, not silently.
-            list(pool.map(reduce_chunk, chunks))
+            # list() so a failing unit raises here, not silently.
+            list(pool.map(reduce_region, regions))

--- a/thyra/converters/spatialdata/optical_image.py
+++ b/thyra/converters/spatialdata/optical_image.py
@@ -1,0 +1,396 @@
+"""Bounded-memory loading of optical TIFFs into a SpatialData store.
+
+The optical images Thyra bundles with a conversion (FlexImaging brightfield,
+typically a 10k x 40k RGB TIFF that decodes to 1-2 GB) used to travel the
+same road as any other raster: decode the whole page into numpy, hand it to
+``Image2DModel.parse`` with ``scale_factors``, and let ``SpatialData.write``
+compute the pyramid. Measured on a 1.29 GB decode that road costs ~6.6 GB
+over the conversion's baseline, for three reasons, none of them the image:
+
+* dask's expression-based ``from_array`` copies every numpy array it is
+  given (``x.copy()`` in ``dask.array._array_expr._collection.from_array``),
+  so the decoded page is in memory twice before anything is written;
+* ``multiscale_spatial_image`` builds each pyramid level as
+  ``coarsen(...).mean().astype(dtype)`` -- the mean promotes every 4096 x 4096
+  block to float64 (128 MB per 16 MB of uint8) and the threaded scheduler
+  runs one such block per core;
+* all levels are computed in a single ``dask.compute``, so the scheduler is
+  free to hold as many of those intermediates as it has threads.
+
+This module keeps the store byte-for-byte what that road produced while
+bounding memory by one *band* of the source, not by the image:
+
+1. **Declare, then stream.** The converter hands ``SpatialData`` a
+   :meth:`StreamedOpticalImage.placeholder` -- a DataTree with the right
+   shapes, dtype, chunks and transformations per level whose pixels are
+   lazy zeros.
+   spatialdata and ome-zarr create the arrays and write every piece of
+   metadata exactly as before; zarr skips the all-zero chunks (its
+   ``write_empty_chunks`` default), so declaring costs nothing on disk.
+2. **Level 0 from the TIFF in bands.** :meth:`StreamedOpticalImage.stream_pixels`
+   opens the page through tifffile's zarr adapter, which decodes only the
+   strips a row range needs, and writes the bands into the level-0 array
+   under :data:`BAND_BUDGET_BYTES`.
+3. **Each pyramid level from the one below, on disk.** Every level-*k* chunk
+   is the exact block mean of its level-*k-1* footprint, read back from the
+   store and reduced in strips (:func:`block_mean`), so a chunk's working set
+   is tens of MB whatever the image size.
+
+The pixel values are those ``xarray``'s ``coarsen`` produces: same
+``boundary="trim", side="right"`` rule (an odd-sized axis drops its FIRST
+row or column), same float64 mean, same truncating cast back to the source
+dtype. :func:`block_mean` is unit-tested against xarray for exactly that.
+"""
+
+from __future__ import annotations
+
+import itertools
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Union
+
+import dask.array as da
+import numpy as np
+import tifffile
+import xarray as xr
+import zarr
+from spatialdata.models import Image2DModel
+from spatialdata.transformations import set_transformation
+
+logger = logging.getLogger(__name__)
+
+#: Decoded bytes one band of the source TIFF may occupy while level 0 is
+#: streamed in. Bands tile the level-0 chunk rows (never straddle them), so
+#: a narrow budget only means more partial-chunk writes, never a wrong one.
+BAND_BUDGET_BYTES = 256 * 1024 * 1024
+
+#: Output rows reduced at a time when a pyramid chunk is assembled from the
+#: level below. Bounds the float64 intermediate of the block mean.
+REDUCE_STRIP_ROWS = 512
+
+#: Pyramid chunks reduced concurrently. Each holds its level-below footprint
+#: (four source chunks), the chunk being assembled and one strip's float64
+#: mean, so this is the multiplier on that working set.
+REDUCE_WORKERS = 4
+
+Axes = Tuple[str, ...]
+Shape = Tuple[int, ...]
+
+
+def block_mean(block: np.ndarray, factors: Sequence[int]) -> np.ndarray:
+    """Mean over non-overlapping windows, cast back to ``block``'s dtype.
+
+    Reproduces ``xarray``'s ``coarsen(window).mean().astype(block.dtype)``
+    value for value: integer input is averaged in float64 (numpy's own
+    ``mean`` accumulator for integers, the dtype dask picks for the same
+    reduction), floating input in its own precision with NaNs skipped as
+    xarray's ``nanmean`` does, and the cast truncates the way
+    ``ndarray.astype`` does.
+
+    Args:
+        block: Array whose every axis is a multiple of its window. Trim
+            before calling; see :func:`trim_excess`.
+        factors: Window per axis. ``1`` leaves an axis alone.
+
+    Returns:
+        Array of shape ``block.shape // factors`` and ``block.dtype``.
+    """
+    if len(factors) != block.ndim:
+        raise ValueError(f"{len(factors)} window factors for a {block.ndim}-d block")
+    shape: List[int] = []
+    reduce_axes: List[int] = []
+    for axis, (size, factor) in enumerate(zip(block.shape, factors)):
+        if factor < 1 or size % factor:
+            raise ValueError(
+                f"axis {axis} of size {size} is not a multiple of window {factor}"
+            )
+        shape.extend((size // factor, factor))
+        reduce_axes.append(2 * axis + 1)
+    windows = block.reshape(shape)
+    mean_of = np.nanmean if block.dtype.kind in "fc" else np.mean
+    return mean_of(windows, axis=tuple(reduce_axes)).astype(block.dtype)
+
+
+def trim_excess(size: int, factor: int) -> int:
+    """Leading rows/columns xarray's ``coarsen`` drops for ``boundary="trim"``.
+
+    With ``side="right"`` the excess comes off the FRONT of the axis, so the
+    last window always ends on the last element. This is the rule
+    ``multiscale_spatial_image`` uses for every pyramid level.
+    """
+    return size - (size // factor) * factor
+
+
+def level_shapes(shape: Shape, scale_factors: Sequence[int], axes: Axes) -> List[Shape]:
+    """Shape of every pyramid level, level 0 first.
+
+    Each factor halves (or whatever the factor is) the spatial axes of the
+    level before it, flooring the way ``coarsen(boundary="trim")`` does. The
+    channel axis is never reduced.
+    """
+    shapes = [tuple(shape)]
+    for factor in scale_factors:
+        previous = shapes[-1]
+        shapes.append(
+            tuple(
+                n // factor if ax in ("x", "y", "z") else n
+                for n, ax in zip(previous, axes)
+            )
+        )
+    return shapes
+
+
+def band_rows(row_bytes: int, chunk_rows: int, budget: int = BAND_BUDGET_BYTES) -> int:
+    """Rows per band so a decoded band fits ``budget`` and tiles the chunk rows.
+
+    Returns ``chunk_rows`` whenever a whole chunk row of the source fits;
+    otherwise the largest divisor of ``chunk_rows`` that does, so bands never
+    straddle a chunk boundary and every chunk is completed by a contiguous
+    run of bands.
+    """
+    if row_bytes <= 0 or chunk_rows <= 0:
+        raise ValueError("row_bytes and chunk_rows must be positive")
+    rows = max(1, budget // row_bytes)
+    if rows >= chunk_rows:
+        return chunk_rows
+    for candidate in range(rows, 0, -1):
+        if chunk_rows % candidate == 0:
+            return candidate
+    return 1
+
+
+def _chunk_slices(array: zarr.Array) -> Iterator[Tuple[slice, ...]]:
+    """Every chunk of ``array`` as a tuple of slices, C order."""
+    ranges = [range(0, size, chunk) for size, chunk in zip(array.shape, array.chunks)]
+    for starts in itertools.product(*ranges):
+        yield tuple(
+            slice(start, min(start + chunk, size))
+            for start, chunk, size in zip(starts, array.chunks, array.shape)
+        )
+
+
+@dataclass(frozen=True)
+class OpticalTiffSource:
+    """What the first page of an optical TIFF looks like, without decoding it.
+
+    ``shape`` is always ``(c, y, x)``. ``streamable`` is True when the page
+    is stored ``YX`` or ``YXS`` (samples interleaved per pixel, the layout
+    every FlexImaging export and practically every RGB TIFF uses), which is
+    what lets a row range be decoded on its own. Any other layout is
+    decoded whole, exactly as before, and reshaped the same way.
+    """
+
+    path: Path
+    shape: Shape
+    dtype: np.dtype
+    streamable: bool
+    page_axes: str
+
+    @classmethod
+    def probe(cls, path: Union[str, Path]) -> Optional["OpticalTiffSource"]:
+        """Read the page header. ``None`` when the page is not 2-D or 3-D."""
+        path = Path(path)
+        with tifffile.TiffFile(path) as tif:
+            page = tif.pages[0]
+            page_shape = tuple(int(n) for n in page.shape)
+            dtype = np.dtype(page.dtype)
+            axes = str(page.axes)
+        if len(page_shape) == 2:
+            shape: Shape = (1, page_shape[0], page_shape[1])
+        elif len(page_shape) == 3:
+            # Trailing axis is the channel axis, as the moveaxis(-1, 0) the
+            # converter always applied assumed.
+            shape = (page_shape[2], page_shape[0], page_shape[1])
+        else:
+            return None
+        return cls(
+            path=path,
+            shape=shape,
+            dtype=dtype,
+            streamable=axes in ("YX", "YXS"),
+            page_axes=axes,
+        )
+
+    @property
+    def row_bytes(self) -> int:
+        """Decoded bytes of one full-width row across all channels."""
+        return int(self.shape[0]) * int(self.shape[2]) * int(self.dtype.itemsize)
+
+    def bands(self, rows: int) -> Iterator[Tuple[int, np.ndarray]]:
+        """Yield ``(first_row, band)`` with ``band`` shaped ``(c, rows, x)``.
+
+        Streams row ranges through tifffile's zarr adapter when the layout
+        allows it, so only the strips of a band are ever decoded; otherwise
+        decodes the page once and yields it as a single band.
+        """
+        with tifffile.TiffFile(self.path) as tif:
+            page = tif.pages[0]
+            if not self.streamable:
+                yield 0, self._to_cyx(page.asarray())
+                return
+            source = zarr.open_array(store=page.aszarr(), mode="r")
+            n_rows = self.shape[1]
+            for start in range(0, n_rows, rows):
+                stop = min(start + rows, n_rows)
+                yield start, self._to_cyx(source[start:stop])
+
+    @staticmethod
+    def _to_cyx(decoded: np.ndarray) -> np.ndarray:
+        if decoded.ndim == 2:
+            return decoded[np.newaxis, :, :]
+        return np.moveaxis(decoded, -1, 0)
+
+
+@dataclass
+class StreamedOpticalImage:
+    """One optical image: declared to SpatialData up front, pixels streamed after.
+
+    Build it, put :meth:`placeholder` in the images the SpatialData write
+    carries, and call :meth:`stream_pixels` on the store once that write
+    has returned. Between the two the element on disk has all its metadata
+    and no pixels.
+    """
+
+    source: OpticalTiffSource
+    name: str
+    chunks: Shape
+    scale_factors: Sequence[int]
+    transformations: Dict[str, Any]
+    axes: Axes = ("c", "y", "x")
+    attrs: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        # The band and chunk arithmetic below indexes rows as axis 1 and
+        # columns as axis 2; that is the (c, y, x) layout and nothing else.
+        if tuple(self.axes) != ("c", "y", "x"):
+            raise ValueError(f"optical images are (c, y, x), got axes {self.axes}")
+        if len(self.chunks) != len(self.axes):
+            raise ValueError(f"chunks {self.chunks} do not match axes {self.axes}")
+        self.scale_factors = [int(f) for f in self.scale_factors]
+
+    @property
+    def level_shapes(self) -> List[Shape]:
+        """Shape of every pyramid level of this image, level 0 first."""
+        return level_shapes(self.source.shape, self.scale_factors, self.axes)
+
+    def placeholder(self) -> xr.DataTree:
+        """The multiscale element as ``Image2DModel.parse`` would shape it.
+
+        Every level is lazy zeros with the store's chunking, so the write
+        creates the arrays and metadata and stores no chunk. Structure,
+        per-level transformations and coordinates mirror what ``parse``
+        builds for ``scale_factors`` so the in-memory element is a valid
+        spatialdata image as well.
+        """
+        base = self.level_shapes[0]
+        levels: Dict[str, xr.Dataset] = {}
+        for index, shape in enumerate(self.level_shapes):
+            coords: Dict[str, Any] = {"c": np.arange(shape[0])}
+            for axis, size in zip(self.axes, shape):
+                if axis == "c":
+                    continue
+                full = base[self.axes.index(axis)]
+                # Pixel centres in level-0 units; spatialdata's own
+                # compute_coordinates for a DataTree, verbatim.
+                coords[axis] = np.linspace(0, full, size + 1)[:-1] + full / size / 2
+            image = xr.DataArray(
+                da.zeros(shape, chunks=self.chunks, dtype=self.source.dtype),
+                dims=self.axes,
+                coords=coords,
+                attrs=dict(self.attrs),
+            )
+            levels[f"scale{index}"] = xr.Dataset({"image": image})
+        tree = xr.DataTree.from_dict(levels)
+        set_transformation(tree, dict(self.transformations), set_all=True)
+        Image2DModel.validate(tree)
+        return tree
+
+    def stream_pixels(self, store_path: Union[str, Path]) -> None:
+        """Fill the element's arrays in ``store_path`` with the real pixels.
+
+        Requires the store to hold the element :meth:`placeholder` declared.
+        Level 0 comes from the TIFF in bands; each further level from the
+        level below, chunk by chunk.
+        """
+        arrays = self._open_level_arrays(store_path)
+        self._stream_level0(arrays[0])
+        for index, factor in enumerate(self.scale_factors, start=1):
+            self._reduce_level(arrays[index - 1], arrays[index], factor)
+        logger.info(
+            f"Streamed optical image '{self.name}': level 0 plus "
+            f"{len(self.scale_factors)} pyramid level"
+            f"{'s' if len(self.scale_factors) != 1 else ''}"
+        )
+
+    def _open_level_arrays(self, store_path: Union[str, Path]) -> List[zarr.Array]:
+        root = zarr.open_group(str(store_path), mode="r+", use_consolidated=False)
+        element = root[f"images/{self.name}"]
+        attrs = element.attrs.asdict()
+        multiscales = attrs.get("ome", {}).get("multiscales") or attrs.get(
+            "multiscales"
+        )
+        if not multiscales:
+            raise RuntimeError(
+                f"images/{self.name} in {store_path} carries no multiscales metadata"
+            )
+        paths = [dataset["path"] for dataset in multiscales[0]["datasets"]]
+        expected = self.level_shapes
+        if len(paths) != len(expected):
+            raise RuntimeError(
+                f"images/{self.name} has {len(paths)} pyramid levels on disk, "
+                f"expected {len(expected)}"
+            )
+        arrays: List[zarr.Array] = []
+        for path, shape in zip(paths, expected):
+            array = element[path]
+            if not isinstance(array, zarr.Array) or tuple(array.shape) != tuple(shape):
+                raise RuntimeError(
+                    f"images/{self.name}/{path} is {getattr(array, 'shape', None)}, "
+                    f"expected {shape}"
+                )
+            arrays.append(array)
+        return arrays
+
+    def _stream_level0(self, target: zarr.Array) -> None:
+        chunk_rows = int(target.chunks[1])
+        rows = band_rows(self.source.row_bytes, chunk_rows)
+        n_bands = -(-self.source.shape[1] // rows)
+        logger.debug(
+            f"  level 0 of '{self.name}': {n_bands} band(s) of {rows} rows "
+            f"({rows * self.source.row_bytes / 1e6:.0f} MB decoded each)"
+        )
+        for start, band in self.source.bands(rows):
+            target[:, start : start + band.shape[1], :] = band
+            del band
+
+    def _reduce_level(
+        self, source: zarr.Array, target: zarr.Array, factor: int
+    ) -> None:
+        factors = tuple(factor if ax in ("x", "y", "z") else 1 for ax in self.axes)
+        excess = tuple(trim_excess(size, f) for size, f in zip(source.shape, factors))
+        chunks = list(_chunk_slices(target))
+        workers = max(1, min(REDUCE_WORKERS, os.cpu_count() or 1, len(chunks)))
+
+        def reduce_chunk(out_sel: Tuple[slice, ...]) -> None:
+            in_sel = tuple(
+                slice(e + s.start * f, e + s.stop * f)
+                for s, e, f in zip(out_sel, excess, factors)
+            )
+            footprint = source[in_sel]
+            chunk = np.empty(
+                tuple(s.stop - s.start for s in out_sel), dtype=target.dtype
+            )
+            n_rows = chunk.shape[1]
+            for row in range(0, n_rows, REDUCE_STRIP_ROWS):
+                stop = min(row + REDUCE_STRIP_ROWS, n_rows)
+                strip = footprint[:, row * factors[1] : stop * factors[1], :]
+                chunk[:, row:stop, :] = block_mean(strip, factors)
+            del footprint
+            target[out_sel] = chunk
+
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            # list() so a failing chunk raises here, not silently.
+            list(pool.map(reduce_chunk, chunks))

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -1972,6 +1972,11 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
             with table_write_config():
                 sdata.write_element(element_names, overwrite=True)
 
+        # The optical images were declared as placeholders; their pixels
+        # stream into the store now that the elements exist. Also outside
+        # any try/except: a metadata-only image group is a corrupt store.
+        self._stream_pending_optical_pixels()
+
         n_optical = len(data_structures["images"]) - 1
         logger.info(
             f"  Wrote TIC image '{tic_name}' ({x_size}x{y_size}), "

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -1973,11 +1973,12 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                 sdata.write_element(element_names, overwrite=True)
 
         # The optical images were declared as placeholders; their pixels
-        # stream into the store now that the elements exist. Also outside
-        # any try/except: a metadata-only image group is a corrupt store.
-        self._stream_pending_optical_pixels()
+        # stream into the store now that the elements exist. An unreadable
+        # TIFF is dropped from the store with a warning in there; anything
+        # else propagates, since a half-written image group is a corrupt
+        # store.
+        n_optical = self._stream_pending_optical_pixels()
 
-        n_optical = len(data_structures["images"]) - 1
         logger.info(
             f"  Wrote TIC image '{tic_name}' ({x_size}x{y_size}), "
             f"{kept_grid.size:,} pixel shapes, and {n_optical} optical image(s)"

--- a/uv.lock
+++ b/uv.lock
@@ -2651,7 +2651,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3901,7 +3901,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.7.0" },
     { name = "shapely", specifier = ">=2.0.0" },
     { name = "spatialdata", specifier = ">=0.8.0,<0.9" },
-    { name = "tifffile", specifier = ">=2022.8.12" },
+    { name = "tifffile", specifier = ">=2026.5.2" },
     { name = "tqdm", specifier = ">=4.50.0" },
     { name = "xarray", specifier = ">=2024.10.0" },
     { name = "zarr", specifier = ">=3.1.6,<3.2" },


### PR DESCRIPTION
## Problem

Loading the optical image at the end of a streaming conversion spiked memory far beyond the rest of the run. On `05_maldi2_shortramp_26k_px` (26,087 pixels) with the 313 MB LZW brightfield `CM2 and CJ4 LV_0000.tiff` (11748 x 36736 x 3 uint8, 1.29 GB decoded), private bytes went from 1.9 GB to 6.8 GB (RSS 8.4 GB) within the optical step and fell back afterwards. The spectral tables were unaffected.

## Root cause (measured with psutil around each step)

| step | private bytes |
|---|---|
| tifffile decode | +1.29 GB image, +0.56 GB transient |
| `Image2DModel.parse` | +1.31 GB, persistent |
| pyramid write | +4.0 GB, transient |

- dask's `from_array` copies every numpy array it is given (both the classic and the expression-based implementation), and `parse` calls it for numpy input, so the page was in memory twice.
- `multiscale_spatial_image` builds each pyramid level as `coarsen().mean().astype()`, promoting every 4096 x 4096 uint8 block to float64 (128 MB), and spatialdata computes all levels in one `dask.compute`, so the threaded scheduler ran 32 such blocks at once.

## Fix

New module `thyra/converters/spatialdata/optical_image.py`:

1. **Declare, then stream.** The converter reads only the TIFF header and hands SpatialData a placeholder element with the final shapes, dtype, chunks and transformations whose pixels are lazy zeros. spatialdata and ome-zarr create the arrays and every piece of metadata exactly as before; zarr stores no chunk (`write_empty_chunks` default).
2. **Level 0 in bands.** After the write, `_stream_pending_optical_pixels()` fills level 0 from tifffile's zarr adapter in whole-strip row bands under a 512 MiB budget.
3. **Each pyramid level from the level below, on disk**, one source chunk at a time, with an exact block mean that reproduces xarray's `coarsen(boundary="trim", side="right").mean().astype()` value for value.

Both write paths call the fill: `_save_output` (2D/3D) and the streaming writer after `write_element`. A TIFF whose pixels cannot be read is dropped from the store with the same warning the whole-page route gave, and the conversion goes on.

## Verification

Same dataset, full conversion under a process-tree memory watch:

| | before | after |
|---|---|---|
| optical step, private bytes | 1.91 -> 6.79 GB | 1.94 -> 2.74 GB |
| optical step, RSS peak | 8.43 GB | 4.55 GB |
| optical step, wall time (3 TIFFs) | ~13 s | ~22 s |

Every image element of the store (three optical images, TIC) is identical to the previous code's output: group attributes and transforms, per-level array metadata, chunk-file sets, every pixel of every level.

Tests: `tests/unit/converters/test_optical_image_streaming.py` pins the block mean against xarray for seven dtypes and odd sizes, the placeholder against `Image2DModel.parse` with and without scale factors, a declared-then-streamed store against a parse-and-write store, and exercises both converter routes including a truncated TIFF, a name collision, single-strip and planar pages. Full suite 2236 passed including the integration set; complexity monitor at threshold 15 clean; pre-commit clean.

## Review pass

The second commit addresses a ten-angle review of the first: an undecodable TIFF aborted the conversion after the table write (now dropped with a warning), single-strip pages were decoded whole once per band (bands are now whole strips), `np.dtype(None)` declared float64 (rejected at probe), two files mapping to one name both streamed (last wins), no-pyramid images changed one on-disk metadata string (single-scale DataArray restored), planar pages were mangled (handled), and the tifffile floor was raised to 2026.5.2 for the zarr-3 adapter. `uv lock` also normalised one unrelated `ptyprocess` marker.

**Declined alternative, for the record.** A lazy dask band reader into `Image2DModel.parse` with a capped dask worker count would need far less code. Measured on a 384 MB test image it peaks at +1.1 GB with four workers (about 2 GB at this dataset's 450 MB bands) against +0.55 GB for this design, and it loses the skip-with-warning tolerance for unreadable TIFFs. Kept the tighter bound.
