### PR TITLE
feat(waters): MRT runs default to the profile trace on a digitiser-matched axis, plus the two-term TOF width law

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -173,15 +173,14 @@ thyra tims_data.d output.zarr --mobility-grid --mobility-bins 512     --mobility
 
 These options control how spectra are mapped onto a common mass axis. In most
 cases the defaults work well -- Thyra auto-detects the instrument type and
-chooses an appropriate method and bin count.
+chooses an appropriate method, axis law and bin width. **Start with no flags**;
+the table after this one says when each option is actually needed.
 
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--resample-method METHOD` | `auto` | `auto`, `nearest_neighbor`, or `tic_preserving` |
 | `--mass-axis-type TYPE` | `auto` | `auto`, `constant`, `linear_tof`, `reflector_tof`, `tof`, `orbitrap`, `fticr` |
-| `--tof-a FLOAT` | auto | `A` of the `tof` width law `sqrt(A m + B m^2)` mDa, in mDa<sup>2</sup>/Da; with `--tof-b`. Omitted, the detected instrument's pair applies (MRT centroid, timsTOF) |
-| `--tof-b FLOAT` | auto | `B` of the `tof` width law, dimensionless |
-| `--bins-per-fwhm FLOAT` | 3 | `tof` only: bins per peak width; mutually exclusive with `--resample-width-at-mz` |
+| `--tof-law A B` | auto | Coefficients of the `tof` width law `sqrt(A m + B m^2)` mDa (`A` in mDa<sup>2</sup>/Da, `B` dimensionless). Only for an instrument Thyra has no pair for; an MRT centroid run or a timsTOF supplies its own |
 | `--resample-bins INTEGER` | auto | Number of bins (mutually exclusive with `--resample-width-at-mz`) |
 | `--resample-min-mz FLOAT` | auto | Minimum m/z value |
 | `--resample-max-mz FLOAT` | auto | Maximum m/z value |
@@ -189,18 +188,41 @@ chooses an appropriate method and bin count.
 | `--resample-reference-mz FLOAT` | `1000.0` | Reference m/z for width specification |
 | `--resample-gap-tolerance FLOAT` | none | `tic_preserving` only: discard target bins farther than this many Da from any measured m/z, instead of interpolating across the gap |
 
+### Which of these you actually need
+
+Every instrument Thyra recognises gets a measured default: the method, the
+axis law and the bin width all come from the detector that matched the file
+(see [Resampling](resampling.md#which-detector-wins)). The flags exist for the
+cases the defaults cannot know about.
+
+| You want to | Use | Leave alone |
+|---|---|---|
+| Convert a file from a recognised instrument | nothing | everything here |
+| A finer or coarser axis than the default | `--resample-width-at-mz` (with `--resample-reference-mz`) | `--mass-axis-type`: the law stays the instrument's, only the width moves |
+| A fixed number of bins instead of a width | `--resample-bins` | |
+| A narrower mass window | `--resample-min-mz` / `--resample-max-mz` | |
+| An axis law for an instrument Thyra could not identify | `--mass-axis-type` | Note that a manual axis type also resets the width to the axis type's own default (5 mDa at m/z 1000; 17 mDa at 300 for `linear_tof`), since a width tuned for one law is not a default for another |
+| The measured `tof` law on a timsTOF, or on a new TOF you have fitted | `--mass-axis-type tof`, plus `--tof-law A B` only when Thyra has no pair for the instrument | |
+| Force interpolation on data Thyra would bin | `--resample-method tic_preserving`, and `--resample-gap-tolerance` if the m/z arrays are sparse | |
+| The raw m/z values, no common axis | `--no-resample` | |
+
+The bin width of a `tof` axis is set the same way as any other: the width at
+the reference m/z. Thyra derives the bins per peak width from it (3 by
+default), so there is no separate flag for that quantity.
+
 !!! info "Choosing a resampling method"
     - **`nearest_neighbor`** -- Each target bin takes the nearest original m/z
       value. Correct for **centroid** data, where peaks are discrete masses.
     - **`tic_preserving`** -- Linear interpolation, rescaled so the total ion
       current is unchanged. Correct for **profile** data on a target axis
-      whose bin widths scale the same way the source points are spaced --
-      pair it only with `constant` unless you know otherwise.
-    - **`auto`** -- Picks `tic_preserving` only for Bruker flexImaging /
-      Rapiflex data, whose source grid is uniform in m/z, and
-      `nearest_neighbor` for everything else -- including profile data from
-      an instrument Thyra cannot identify, because the interpolating method
-      is only exact when the two axis laws match. See
+      whose bin widths scale the same way the source points are spaced.
+    - **`auto`** -- Picks `tic_preserving` only where the source grid's law
+      is known and the target axis follows it: Bruker flexImaging / Rapiflex
+      data (uniform in m/z, onto `constant`) and the Waters profile trace
+      (uniform in flight time, onto `linear_tof`). Everything else gets
+      `nearest_neighbor` -- including profile data from an instrument Thyra
+      cannot identify, because the interpolating method is only exact when
+      the two axis laws match. See
       [Resampling](resampling.md#which-detector-wins) for the full decision
       table.
 
@@ -210,6 +232,7 @@ chooses an appropriate method and bin count.
     - **`constant`** -- Uniform bin width (Da). Suitable for MALDI-TOF in linear mode.
     - **`linear_tof`** -- Width scales as sqrt(m/z). Matches TOF resolution.
     - **`reflector_tof`** -- Width scales linearly with m/z (constant relative resolution). Matches reflector TOF.
+    - **`tof`** -- Width follows a measured peak-width law `sqrt(A m + B m^2)`, of which the two above are the limits. See [the two-term TOF law](resampling.md#the-two-term-tof-law).
     - **`orbitrap`** -- Width scales as m/z^(3/2). Matches Orbitrap resolution.
     - **`fticr`** -- Width scales as m/z^2. Matches FTICR resolution.
     - **`auto`** -- Detected from instrument metadata.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -178,7 +178,10 @@ chooses an appropriate method and bin count.
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--resample-method METHOD` | `auto` | `auto`, `nearest_neighbor`, or `tic_preserving` |
-| `--mass-axis-type TYPE` | `auto` | `auto`, `constant`, `linear_tof`, `reflector_tof`, `orbitrap`, `fticr` |
+| `--mass-axis-type TYPE` | `auto` | `auto`, `constant`, `linear_tof`, `reflector_tof`, `tof`, `orbitrap`, `fticr` |
+| `--tof-a FLOAT` | auto | `A` of the `tof` width law `sqrt(A m + B m^2)` mDa, in mDa<sup>2</sup>/Da; with `--tof-b`. Omitted, the detected instrument's pair applies (MRT centroid, timsTOF) |
+| `--tof-b FLOAT` | auto | `B` of the `tof` width law, dimensionless |
+| `--bins-per-fwhm FLOAT` | 3 | `tof` only: bins per peak width; mutually exclusive with `--resample-width-at-mz` |
 | `--resample-bins INTEGER` | auto | Number of bins (mutually exclusive with `--resample-width-at-mz`) |
 | `--resample-min-mz FLOAT` | auto | Minimum m/z value |
 | `--resample-max-mz FLOAT` | auto | Maximum m/z value |
@@ -359,14 +362,19 @@ This option only applies when converting Waters `.raw` directories.
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--waters-spectrum {centroid,profile}` | `centroid` | What MassLynx hands back for one pixel: the vendor peak picker, or the sampled trace behind it |
+| `--waters-spectrum {centroid,profile}` | `profile` on a SELECT SERIES MRT, `centroid` on every other Waters instrument | What MassLynx hands back for one pixel: the vendor peak picker, or the sampled trace behind it |
 
 ### Examples
 
 ```bash
-# Keep near-isobars the vendor centroider merges
-thyra data.raw output.zarr --waters-spectrum profile \
-    --resample-width-at-mz 0.001 --resample-reference-mz 1000
+# An MRT run: the profile trace on a linear_tof axis at 1.3 mDa, no flags needed
+thyra mrt_run.raw output.zarr
+
+# The same run through the vendor peak picker instead (reflector_tof, 2 mDa)
+thyra mrt_run.raw output.zarr --waters-spectrum centroid
+
+# A Synapt run's profile trace; the bin width follows its own digitiser
+thyra synapt_run.raw output.zarr --waters-spectrum profile
 ```
 
 !!! note "When the profile is worth its size"
@@ -376,9 +384,11 @@ thyra data.raw output.zarr --waters-spectrum profile \
     m/z 760 and 830 -- including the <sup>13</sup>C<sub>2</sub> isotopologue of
     PC 34:1 [M+K]<sup>+</sup> against PC 34:0 [M+K]<sup>+</sup> -- came back as
     one centroid in 96-100% of the pixels that resolved them, 4-8 ppm from
-    either true mass. `--waters-spectrum profile` keeps them apart, for about
-    3.5 times the stored non-zeros and 2.3 times the store. It is not slower:
-    MassLynx centroids on demand, so a profile read skips that work.
+    either true mass. The profile keeps them apart, for about 3 times the
+    store, and is not slower: MassLynx centroids on demand, so a profile read
+    skips that work. On a Synapt G2-Si the centroider was found to merge
+    nothing the profile resolves, which is why only the MRT defaults to it;
+    see [Supported Formats](supported-formats.md#waters-masslynx).
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -14,8 +14,8 @@ thyra [OPTIONS] INPUT OUTPUT
 !!! tip "Grouped help"
     `thyra --help` lists every option under a category heading -- Conversion,
     Logging, Resampling (advanced), Performance, imzML-specific,
-    Bruker-specific, Other, and a General section holding `--version` and
-    `--help` -- in the same order as the sections on this page.
+    Bruker-specific, Waters-specific, Other, and a General section holding
+    `--version` and `--help` -- in the same order as the sections on this page.
 
 ---
 
@@ -350,6 +350,35 @@ thyra tims_data.d output.zarr --tdf-spectrum scan_sum
     **before** writing to zarr. This reduces file size but is irreversible.
     Use with care -- inspect the data with `-v DEBUG` first to choose an
     appropriate threshold.
+
+---
+
+## Waters-Specific
+
+This option only applies when converting Waters `.raw` directories.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--waters-spectrum {centroid,profile}` | `centroid` | What MassLynx hands back for one pixel: the vendor peak picker, or the sampled trace behind it |
+
+### Examples
+
+```bash
+# Keep near-isobars the vendor centroider merges
+thyra data.raw output.zarr --waters-spectrum profile \
+    --resample-width-at-mz 0.001 --resample-reference-mz 1000
+```
+
+!!! note "When the profile is worth its size"
+    MassLynx centroiding reports a single peak wherever the sampled trace has
+    two maxima a few mDa apart, and puts it partway between them. On a
+    SELECT SERIES MRT brain section, four separate 8-9 mDa doublets between
+    m/z 760 and 830 -- including the <sup>13</sup>C<sub>2</sub> isotopologue of
+    PC 34:1 [M+K]<sup>+</sup> against PC 34:0 [M+K]<sup>+</sup> -- came back as
+    one centroid in 96-100% of the pixels that resolved them, 4-8 ppm from
+    either true mass. `--waters-spectrum profile` keeps them apart, for about
+    3.5 times the stored non-zeros and 2.3 times the store. It is not slower:
+    MassLynx centroids on demand, so a profile read skips that work.
 
 ---
 

--- a/docs/resampling.md
+++ b/docs/resampling.md
@@ -341,19 +341,26 @@ The cumulative bin count has a closed form, `(2/sqrt(B)) asinh(sqrt(B m / A))`,
 so the axis is a uniform grid in that variable and the count is exact.
 
 ```bash
-# An MRT centroid conversion: this is the default, spelled out
-thyra mrt_run.raw out.zarr --waters-spectrum centroid \
-    --mass-axis-type tof --tof-a 0.0185 --tof-b 9.1e-6 --bins-per-fwhm 3
+# An MRT centroid conversion: this is the default, no flags needed
+thyra mrt_run.raw out.zarr --waters-spectrum centroid
 
 # A timsTOF opting in to its measured pair (the default stays reflector_tof)
 thyra run.d out.zarr --mass-axis-type tof
+
+# A TOF instrument Thyra has no pair for, fitted from its own peaks
+thyra run.imzML out.zarr --mass-axis-type tof --tof-law 0.0185 9.1e-6
+
+# Finer bins: the width at the reference m/z sets k, as on any other axis
+thyra run.d out.zarr --mass-axis-type tof \
+    --resample-width-at-mz 0.005 --resample-reference-mz 1000
 ```
 
-`--mass-axis-type tof` without `--tof-a`/`--tof-b` takes the pair the detected
-instrument declares (MRT centroid, timsTOF) and is an error elsewhere.
-`--resample-width-at-mz` at `--resample-reference-mz` is accepted in place of
-`--bins-per-fwhm`: `k` is derived so that the bin at the reference m/z has
-that width, so the two parameterisations are interchangeable.
+`--mass-axis-type tof` takes the pair the detected instrument declares (MRT
+centroid, timsTOF); `--tof-law A B` supplies one for an instrument that has
+none, and it is an error to have neither. There is no separate flag for the
+bins per peak width: `--resample-width-at-mz` at `--resample-reference-mz`
+fixes it, since `k` is whatever puts a bin of that width at the reference m/z.
+The Python API's `ResamplingConfig` also accepts `bins_per_fwhm` directly.
 
 **Centroid axes follow peak width; profile axes follow the sample grid.** The
 law describes how wide a peak is, which is what the bins of a *centroid* list

--- a/docs/resampling.md
+++ b/docs/resampling.md
@@ -107,7 +107,9 @@ catch-all default. This table is the actual observed behaviour of that chain:
 | solariX `.d` (native, peaks.sqlite) | FT-ICR | `nearest_neighbor` | `fticr` |
 | imzML declaring an Orbitrap analyzer or model | Orbitrap | `nearest_neighbor` | `orbitrap` |
 | PHI SmartSoft-TOF `.raw` | PHI SmartSoft-TOF (ToF-SIMS) | `nearest_neighbor` | `linear_tof` |
-| Waters MassLynx `.raw`, any representation | Waters MassLynx | `nearest_neighbor` | `reflector_tof` |
+| Waters MassLynx `.raw`, profile trace (the SELECT SERIES MRT default) | Waters MassLynx (profile trace) | `tic_preserving` | `linear_tof` |
+| Waters MassLynx `.raw`, SELECT SERIES MRT vendor centroid | Waters SELECT SERIES MRT (vendor centroid) | `nearest_neighbor` | `tof` |
+| Waters MassLynx `.raw`, vendor centroid or undeclared, other instruments | Waters MassLynx | `nearest_neighbor` | `reflector_tof` |
 | unknown vendor, profile (any density) | Unknown (default) | `nearest_neighbor` | `constant` |
 | unknown, centroid | ImzML Centroid | `nearest_neighbor` | `reflector_tof` |
 | no usable metadata | Unknown (default) | `nearest_neighbor` | `constant` |
@@ -128,9 +130,13 @@ catch-all default. This table is the actual observed behaviour of that chain:
 !!! info "`tic_preserving` is gated on the source and target axis laws matching"
     A detector may only ask for `tic_preserving` if it knows the spacing law
     of the grid the spectra *arrive* on, and that law is the one it is asking
-    the target axis to use. Only the Rapiflex route qualifies:
-    `RapiflexReader` lays every spectrum out with `np.linspace`, so the source
-    is uniform in m/z, and the axis it requests is `constant` -- the same law.
+    the target axis to use. Two routes qualify. `RapiflexReader` lays every
+    spectrum out with `np.linspace`, so the source is uniform in m/z, and the
+    axis it requests is `constant` -- the same law. The Waters profile trace
+    is the digitiser's own record, sampled at a fixed clock rate and so
+    spaced as `sqrt(m/z)` (measured `(m/z)^0.494` on a SELECT SERIES MRT and
+    `(m/z)^0.498` on a Synapt G2-Si), and the axis it requests is
+    `linear_tof` -- again the same law.
 
     Anything else is refused and gets `nearest_neighbor` instead, with a log
     line saying so. This is the rule SCiLS Lab applies: TIC-preserving
@@ -183,10 +189,11 @@ catch-all default. This table is the actual observed behaviour of that chain:
     `fticr`.
 
     Auto-selection cannot produce these pairings. `tic_preserving` is only
-    ever chosen alongside `constant`, and only on a source grid that is
-    itself uniform in m/z, which is what makes it exact; the detector chain
-    enforces that. You have to ask for the combination with two explicit
-    flags, and Thyra takes you at your word.
+    ever chosen alongside an axis whose law the source grid itself follows --
+    `constant` for the Rapiflex, `linear_tof` for the Waters profile trace --
+    which is what makes it exact; the detector chain enforces that. You have
+    to ask for a mismatched combination with two explicit flags, and Thyra
+    takes you at your word.
 
     If you want a non-uniform axis, use `nearest_neighbor`, which moves each
     peak into a single bin and is unaffected by bin width.
@@ -286,6 +293,7 @@ power instead of over-sampling the low end and under-sampling the high end.
 | `constant` | Constant (equidistant) | constant Da | Equidistant bins |
 | `linear_tof` | **Axial TOF** | `sqrt(m/z)` | Linear TOF: flight time `t ∝ sqrt(m/z)`, so equal time bins give `sqrt(m/z)` mass bins |
 | `reflector_tof` | **Orthogonal TOF** | `m/z` | Constant *relative* resolution `R = m/Δm`; bins are uniform in `ln(m/z)` |
+| `tof` | -- | `sqrt(A m + B m^2)` | A measured TOF peak width; `linear_tof` and `reflector_tof` are its two limits. See [The two-term TOF law](#the-two-term-tof-law) |
 | `orbitrap` | Orbitrap | `m/z^1.5` | Orbitrap frequency `f ∝ 1/sqrt(m/z)`, so equal frequency bins give `m/z^1.5` mass bins |
 | `fticr` | **MRMS** (Fourier-transform) | `m/z^2` | Cyclotron frequency `f ∝ 1/(m/z)`, so equal frequency bins give `m/z^2` mass bins |
 
@@ -299,6 +307,63 @@ FT-ICR type is now called MRMS. The laws are unchanged; only the labels moved.
 resolution means constant relative mass accuracy across the whole range, which
 is what most MS workflows assume.
 
+### The two-term TOF law
+
+A time-of-flight peak's width in flight time has a constant part (detector
+and digitiser response, pusher timing) and a part proportional to the flight
+time (energy spread, turnaround time), added in quadrature. In m/z:
+
+```
+FWHM(m) = sqrt(A * m + B * m^2)        m in Da, FWHM in mDa
+```
+
+`A` is in mDa<sup>2</sup>/Da and `B` is dimensionless. `linear_tof` is the
+`B = 0` limit (width grows as `sqrt(m)`), `reflector_tof` the `A = 0` limit
+(width grows as `m`, constant ppm, with `1/sqrt(B)` the resolving power). Real
+instruments sit between, and where they sit is measurable from a few hundred
+isolated peaks by least squares on `FWHM^2 = A m + B m^2`:
+
+| Instrument | `A` | `B` | `1/sqrt(B)` | Fitted from |
+|---|---|---|---|---|
+| SELECT SERIES MRT | 0.0185 | 9.1e-6 | 331,000 | 229 peaks, m/z 300-1000 (R<sup>2</sup> 0.36 on FWHM<sup>2</sup>: the peaks scatter, the trend does not) |
+| timsTOF fleX | 0.0877 | 8.74e-4 | 34,000 | 180 peaks, m/z 300-1000 (R<sup>2</sup> 0.89) |
+
+The MRT pair reproduces the measured 2.97 / 3.79 / 4.54 mDa at m/z 400 / 600 /
+800; a log-log fit of the same peaks gives an exponent of 0.67, between the
+0.5 and 1.0 the two single-term laws allow, which is why neither of them fits
+an MRT centroid list exactly. The timsTOF pair is within 10% of the
+`reflector_tof` shape over m/z 400-1000 (7% at 400, 3% at 600; the constant
+term shows below that and the gap reaches 10% at m/z 300), so nothing changes
+for timsTOF by default and the pair is opt-in.
+
+The axis lays bins at `FWHM(m) / k` for `k` bins per peak width (default 3).
+The cumulative bin count has a closed form, `(2/sqrt(B)) asinh(sqrt(B m / A))`,
+so the axis is a uniform grid in that variable and the count is exact.
+
+```bash
+# An MRT centroid conversion: this is the default, spelled out
+thyra mrt_run.raw out.zarr --waters-spectrum centroid \
+    --mass-axis-type tof --tof-a 0.0185 --tof-b 9.1e-6 --bins-per-fwhm 3
+
+# A timsTOF opting in to its measured pair (the default stays reflector_tof)
+thyra run.d out.zarr --mass-axis-type tof
+```
+
+`--mass-axis-type tof` without `--tof-a`/`--tof-b` takes the pair the detected
+instrument declares (MRT centroid, timsTOF) and is an error elsewhere.
+`--resample-width-at-mz` at `--resample-reference-mz` is accepted in place of
+`--bins-per-fwhm`: `k` is derived so that the bin at the reference m/z has
+that width, so the two parameterisations are interchangeable.
+
+**Centroid axes follow peak width; profile axes follow the sample grid.** The
+law describes how wide a peak is, which is what the bins of a *centroid* list
+should track. A *profile* trace is a set of samples on the digitiser's own
+grid, and its bins should track that grid instead -- the Waters profile
+default uses `linear_tof` because that is how its samples are spaced (see
+[Supported Formats](supported-formats.md#waters-masslynx)), not because of how
+wide its peaks are. The two-term law is never applied to profile data, nor to
+FT-ICR or Orbitrap data, whose widths are not time-of-flight quantities.
+
 ---
 
 ## Bin count
@@ -307,12 +372,27 @@ You can set the bin count directly, or specify a target bin **width at a
 reference m/z** and let Thyra derive the count from the axis physics. The two
 are mutually exclusive.
 
-When you specify neither, these defaults apply:
+When you specify neither, the detected instrument may declare a width; failing
+that, the axis type's default applies:
 
-| Axis type | Default width | At reference m/z |
+| Source | Default width | At reference m/z |
 |---|---|---|
-| `linear_tof` | 17 mDa | 300 |
-| everything else | 5 mDa | 1000 |
+| Waters SELECT SERIES MRT vendor centroid | `tof` law at 3 bins per FWHM (1.75 mDa) | 1000 |
+| Waters vendor centroid, other instruments | 2 mDa | 1000 |
+| Waters SELECT SERIES MRT profile trace | 1.3 mDa | 1000 |
+| Waters profile trace, other instruments | 1.14 x the run's predicted sample spacing | 1000 |
+| any other source, `linear_tof` | 17 mDa | 300 |
+| any other source, everything else | 5 mDa | 1000 |
+
+The Waters figures are measured, not conventional. 2 mDa is the coarsest
+centroid setting that clears two bins per measured peak width at m/z 800 on an
+MRT (2.8 bins per FWHM of 4.48 mDa; the earlier 5 mDa gave 1.1). 1.3 mDa is
+about 1.14 times the MRT digitiser's sample spacing at m/z 1000, pinned rather
+than derived so every MRT run with the same mass range shares one axis; see
+[Supported Formats](supported-formats.md#waters-masslynx). An instrument's
+width applies only on the fully automatic path -- set `--mass-axis-type` and
+the width defaults revert to the axis type's, since a width tuned for one law
+is not a sensible default for another.
 
 The 17 mDa / m/z 300 pairing for `linear_tof` was chosen to be close to the
 axis SCiLS Lab produces for FlexImaging data. Treat it as a working default
@@ -359,14 +439,20 @@ non-zero count does not depend on the bin width at all and only the index
 arrays lengthen: the tutorial store comes out at roughly 31 MB, and going from
 4,000 bins to 190,000 costs about +0.8% on disk.
 
-!!! warning "That only holds for `nearest_neighbor`"
-    `tic_preserving` interpolates, so it populates essentially every bin. The
-    matrix comes out 99.998% dense and the store becomes
-    `n_pixels x target_bins x ~7.5 bytes` -- independent of how sparse the
-    source was. Measured on this same 4,000-point source: at 190,000 bins it
-    costs 1.44 MB per pixel, so 400 pixels take 574 MB against 6.93 MB at
+!!! warning "That only holds for `nearest_neighbor`, and for zero-suppressed profiles"
+    `tic_preserving` interpolates, so on a continuous profile it populates
+    essentially every bin. The matrix comes out 99.998% dense and the store
+    becomes `n_pixels x target_bins x ~7.5 bytes` -- independent of how sparse
+    the source was. Measured on this same 4,000-point source: at 190,000 bins
+    it costs 1.44 MB per pixel, so 400 pixels take 574 MB against 6.93 MB at
     4,000 bins, an 82.9x blowup, and the 1,728-pixel tutorial dataset would
     take roughly 2.5 GB.
+
+    The exception is a source that stores explicit zeros around its peaks and
+    nothing in between, like the Waters profile trace. Interpolation between
+    two zeros is zero, so only the bins under the stored clusters are
+    populated -- and only those are evaluated, which is what keeps the MRT
+    default's conversion time in line with nearest-neighbour binning.
 
     On that path the default bin count is a decision rather than a detail.
 

--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -210,6 +210,72 @@ reconstructed from the laser X/Y position recorded on each scan, and only MS
 functions are converted -- lockmass, MRM and ion-mobility functions are
 classified and skipped.
 
+### Which representation is read
+
+MassLynx can hand back either of two things for a profile-acquired pixel: the
+**vendor centroid** list, computed on demand by its peak picker, or the
+**profile trace** behind it -- the digitiser's samples, zero-suppressed to the
+clusters around each peak. Thyra reads `_extern.inf` and `_header.txt` to
+decide which one is the default, and logs the field it decided on:
+
+| Instrument | Identified by | Default | Method | Axis | Default width |
+|---|---|---|---|---|---|
+| SELECT SERIES MRT | `OpticMode = MRT`, or `$$ Instrument: MRT#`, or `Resolution` above 100,000 | **profile trace** | `tic_preserving` | `linear_tof` | 1.3 mDa at m/z 1000 |
+| SELECT SERIES MRT, `--waters-spectrum centroid` | as above | vendor centroid | `nearest_neighbor` | `tof` (measured width law, see [Resampling](resampling.md#the-two-term-tof-law)) | 3 bins per peak width |
+| every other Waters instrument | none of the above | vendor centroid | `nearest_neighbor` | `reflector_tof` | 2 mDa at m/z 1000 |
+
+`--waters-spectrum centroid|profile` overrides the default in either
+direction. A run that is not an MRT but is asked for its profile gets the
+profile treatment with a bin width taken from its own digitiser: 1.14 times
+the sample spacing predicted from `Lteff`, `Veff` and the ADC clock in
+`_extern.inf` (15.8 mDa on a Synapt G2-Si), so the store is not oversampled.
+
+**Why the MRT defaults to the profile.** Its multi-reflecting flight path
+gives a measured resolving power of 130,000 at m/z 300 rising to 190,000 at
+m/z 1000 (median 168,000), and at that resolution the vendor peak picker, not
+the analyser, is what limits the data. On a 13,398-pixel MALDI brain section,
+four separate 8-9 mDa doublets between m/z 760 and 830 -- including the
+<sup>13</sup>C<sub>2</sub> isotopologue of PC 34:1 [M+K]<sup>+</sup> at
+800.5477 against PC 34:0 [M+K]<sup>+</sup> at 800.5566 -- were resolved as two
+maxima in the profile in 19,227 pixels between them. The vendor returned
+**exactly one** centroid in 96-100% of those pixels, never two, landing 4-8 ppm
+from either true mass. No centroid-side setting recovers that: a finer axis
+just places the merged centroid more precisely.
+
+**Why the others do not.** The same test on a Synapt G2-Si MALDI imaging run
+(7,007 pixels, resolving power about 26,000) found the vendor centroider
+merging **none** of the pairs its profile resolves: it reported three or more
+peaks in 99.4-99.7% of the pixels where the profile showed two. At that
+resolving power the analyser is the limit and the peak picker keeps everything
+the trace has, so the profile would cost 2-3x the store for nothing. Both
+instruments sample the trace on the same `sqrt(m/z)` grid (measured
+`(m/z)^0.494` on the MRT, `(m/z)^0.498` on the Synapt), which is why the
+profile route uses `linear_tof` whichever instrument it is asked for on.
+
+**What the profile default costs.** On the reference run (13,398 pixels) the
+store is 289 MB against 52 MB for the centroid default, and it converts in
+15 s against 96 s, because MassLynx centroids on demand and a profile read
+skips that work. Two things make the profile store that size: it holds 4.5x
+the non-zeros (31.3M against 6.9M), and interpolated values are not the
+integer ADC counts the raw samples are, so they compress about half as well
+-- nearest-neighbour binning of the same trace onto the same axis gives
+138 MB. The profile is stored on a fixed, generated
+axis at about 1.14 times the digitiser's own sample spacing (1.3 mDa at m/z
+1000 against 1.14 mDa per sample), so every MRT run with the same acquisition
+mass range lands on the same bins -- the axis is built over the acquisition
+setting, not the span of stored values, exactly as the timsTOF route does.
+The accepted loss is one bin of smoothing: intensity is interpolated between
+samples, so a peak apex in the stored mean spectrum sits within about 2 ppm of
+the raw apex before any peak picking, and a centroider run on the stored
+profile recovers it. The raw digitiser grid itself is still available with
+`--no-resample`, where binning is the identity and the apex error is zero,
+at the cost of an axis that differs from run to run.
+
+`uns["essential_metadata"]["spectrum_type"]` records what was stored
+(`profile spectrum` or `centroid spectrum`), `format_specific.spectrum_source`
+says which MassLynx representation it came from, and `format_specific.is_mrt`
+with `instrument_decided_by` record the instrument decision.
+
 ## PHI SmartSoft-TOF (ToF-SIMS)
 
 A single `.raw` **file** from PHI (Physical Electronics) nanoTOF instruments.

--- a/tests/unit/converters/test_detected_reference_width.py
+++ b/tests/unit/converters/test_detected_reference_width.py
@@ -1,0 +1,81 @@
+"""A detector's bin width reaches the axis, behind the caller's own setting.
+
+``_reference_params`` is the one place the width and reference m/z are
+decided, for both the bin count and the axis generator. Precedence is the
+caller's ``--resample-width-at-mz``, then the width the detected instrument
+declared (Waters: 2 mDa for the vendor centroid, 1.3 mDa for the MRT
+profile), then the per-axis-type default that applied before any detector
+could speak.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from thyra.converters.spatialdata.base_spatialdata_converter import (
+    BaseSpatialDataConverter,
+    _reference_params,
+)
+from thyra.resampling.types import AxisType
+
+
+def _stub(width=None, ref=1000.0, detected=None):
+    return SimpleNamespace(
+        _width_at_mz=width, _reference_mz=ref, _detected_reference_width=detected
+    )
+
+
+class TestPrecedence:
+    def test_explicit_width_wins(self):
+        assert _reference_params(
+            _stub(0.01, 500.0, (0.002, 1000.0)), "reflector_tof"
+        ) == (
+            0.01,
+            500.0,
+        )
+
+    def test_detected_width_beats_the_axis_default(self):
+        assert _reference_params(_stub(detected=(0.0013, 1000.0)), "linear_tof") == (
+            0.0013,
+            1000.0,
+        )
+
+    @pytest.mark.parametrize(
+        "axis_name, expected",
+        [
+            ("linear_tof", (0.017, 300.0)),
+            ("reflector_tof", (0.005, 1000.0)),
+            ("constant", (0.005, 1000.0)),
+            ("fticr", (0.005, 1000.0)),
+        ],
+    )
+    def test_axis_defaults_when_nothing_was_declared(self, axis_name, expected):
+        assert _reference_params(_stub(), axis_name) == expected
+
+    def test_a_stub_without_the_attribute_still_works(self):
+        """Older test stubs carry only the two explicit attributes."""
+        stub = SimpleNamespace(_width_at_mz=None, _reference_mz=1000.0)
+        assert _reference_params(stub, "reflector_tof") == (0.005, 1000.0)
+
+
+class TestBothConsumersAgree:
+    def test_bin_count_and_generator_read_the_same_width(self):
+        stub = _stub(detected=(0.002, 1000.0))
+        assert BaseSpatialDataConverter._get_reference_params(
+            stub, AxisType.REFLECTOR_TOF
+        ) == (0.002, 1000.0)
+        bins = BaseSpatialDataConverter._calculate_bins_from_width(
+            stub, 100.0, 1000.0, AxisType.REFLECTOR_TOF
+        )
+        # ln(10) * 1000 / 0.002
+        assert bins == pytest.approx(1_151_292, rel=1e-3)
+
+    def test_mrt_profile_axis_size_on_the_reference_run(self):
+        """1.3 mDa at m/z 1000 over 100-1000 on linear_tof: ~1.05M bins."""
+        stub = _stub(detected=(0.0013, 1000.0))
+        bins = BaseSpatialDataConverter._calculate_bins_from_width(
+            stub, 100.0, 1000.0, AxisType.LINEAR_TOF
+        )
+        assert bins == pytest.approx(1_051_941, rel=1e-3)

--- a/tests/unit/converters/test_resampling_config_normalization.py
+++ b/tests/unit/converters/test_resampling_config_normalization.py
@@ -41,6 +41,7 @@ class TestRecognisedValues:
             ("constant", AxisType.CONSTANT),
             ("linear_tof", AxisType.LINEAR_TOF),
             ("reflector_tof", AxisType.REFLECTOR_TOF),
+            ("tof", AxisType.TOF),
             ("orbitrap", AxisType.ORBITRAP),
             ("fticr", AxisType.FTICR),
         ],
@@ -106,7 +107,7 @@ class TestUnrecognisedValues:
             "fticr ",
             "FTICR",
             "ft-icr",
-            "tof",
+            "TOF",
             "unknown",  # enum member exists but has no axis generator
             "typo",
         ],

--- a/tests/unit/converters/test_tic_preserving_sparse.py
+++ b/tests/unit/converters/test_tic_preserving_sparse.py
@@ -1,0 +1,212 @@
+"""The sparse form of ``tic_preserving`` is the dense form, bin for bin.
+
+``_tic_preserving_resample`` used to interpolate onto every bin of the axis
+and hand a dense array downstream, where it was scanned for non-zeros. On a
+zero-suppressed profile source -- a Waters MRT pixel stores ~15,000 samples
+in clusters around its peaks and the default axis has 1.05M bins -- that
+cost 570 s for a conversion nearest-neighbour binning finished in 16 s. The
+sparse form evaluates only the axis points the interpolant can be non-zero
+at. These tests pin that it is the same operator: same values, same TIC,
+same handling of gaps, cropping, unsorted input and degenerate spectra.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from thyra.converters.spatialdata.base_spatialdata_converter import (
+    BaseSpatialDataConverter,
+    _tic_preserving_sparse,
+    _tic_support_bins,
+)
+
+
+def _sqrt_axis(lo, hi, width_at_1000):
+    """A linear_tof axis: uniform in sqrt(m/z), like the digitiser grid."""
+    k = width_at_1000 / np.sqrt(1000.0)
+    n = int((2.0 / k) * (np.sqrt(hi) - np.sqrt(lo)))
+    edges = np.linspace(np.sqrt(lo), np.sqrt(hi), n + 1) ** 2
+    return (edges[:-1] + edges[1:]) / 2
+
+
+def _zero_suppressed_profile(seed=0, n_peaks=40, spacing_at_1000=1.14e-3):
+    """Clusters of samples on a sqrt-spaced grid, an explicit zero at each edge.
+
+    This is the shape MassLynx returns for a profile pixel: only samples
+    around peaks are stored, the sample positions lie on one global grid,
+    and every cluster starts and ends with a stored zero.
+    """
+    rng = np.random.default_rng(seed)
+    grid = _sqrt_axis(300.0, 1000.0, spacing_at_1000)
+    centres = np.sort(rng.uniform(320.0, 980.0, n_peaks))
+    mzs, its = [], []
+    for c in centres:
+        sigma = 1.9e-3 * np.sqrt(c / 1000.0)  # ~4 samples per FWHM
+        i = np.searchsorted(grid, c)
+        lo, hi = max(i - 12, 0), min(i + 13, grid.size)
+        m = grid[lo:hi]
+        y = rng.uniform(50, 5000) * np.exp(-((m - c) ** 2) / (2 * sigma**2))
+        y[y < 20.0] = 0.0
+        if y[0] != 0.0 or y[-1] != 0.0:
+            continue
+        # Trim to one zero on either side, as MassLynx stores it.
+        nz = np.flatnonzero(y)
+        m, y = m[nz[0] - 1 : nz[-1] + 2], y[nz[0] - 1 : nz[-1] + 2]
+        if mzs and m[0] <= mzs[-1][-1]:
+            continue
+        mzs.append(m)
+        its.append(y)
+    return np.concatenate(mzs), np.concatenate(its)
+
+
+AXIS = _sqrt_axis(300.0, 1000.0, 1.3e-3)
+
+
+def _dense(axis, mzs, its, tol=None):
+    stub = SimpleNamespace(_common_mass_axis=axis, _gap_tolerance_da=tol)
+    return BaseSpatialDataConverter._tic_preserving_resample(stub, mzs, its)
+
+
+def _sparse(axis, mzs, its, tol=None):
+    stub = SimpleNamespace(_common_mass_axis=axis, _gap_tolerance_da=tol)
+    return BaseSpatialDataConverter._tic_preserving_resample_sparse(stub, mzs, its)
+
+
+def _scatter(axis, idx, vals):
+    out = np.zeros(axis.size)
+    out[idx] = vals
+    return out
+
+
+class TestSupportBins:
+    def test_open_at_the_zero_neighbours_closed_at_the_ends(self):
+        axis = np.arange(0.0, 10.5, 0.5)
+        mzs = np.array([1.0, 2.0, 3.0, 4.0, 6.0, 7.0, 8.0, 9.0])
+        its = np.array([5.0, 3.0, 0.0, 0.0, 0.0, 2.0, 0.0, 4.0])
+        idx = _tic_support_bins(axis, mzs, its)
+        # First run [1, 2] starts at the spectrum's own first sample, so
+        # axis == 1.0 is included; it ends before the zero at 3.0.
+        # Run [7] sits between zeros at 6.0 and 8.0, open at both.
+        # Run [9] ends at the spectrum's last sample: axis == 9.0 included.
+        expected = np.flatnonzero(
+            ((axis >= 1.0) & (axis < 3.0))
+            | ((axis > 6.0) & (axis < 8.0))
+            | ((axis > 8.0) & (axis <= 9.0))
+        )
+        np.testing.assert_array_equal(idx, expected)
+
+    def test_no_zeros_means_the_whole_span(self):
+        axis = np.linspace(0.0, 10.0, 41)
+        mzs = np.array([2.0, 3.0, 5.0])
+        idx = _tic_support_bins(axis, mzs, np.array([1.0, 1.0, 1.0]))
+        np.testing.assert_array_equal(
+            idx, np.flatnonzero((axis >= 2.0) & (axis <= 5.0))
+        )
+
+    def test_all_zero_is_empty(self):
+        idx = _tic_support_bins(np.linspace(0, 1, 5), np.array([0.2, 0.4]), np.zeros(2))
+        assert idx.size == 0
+
+    def test_indices_are_sorted_and_unique(self):
+        mzs, its = _zero_suppressed_profile()
+        idx = _tic_support_bins(AXIS, mzs, its)
+        assert np.all(np.diff(idx) > 0)
+
+
+class TestAgreesWithTheDenseForm:
+    @pytest.mark.parametrize("seed", [0, 1, 2])
+    def test_zero_suppressed_profile(self, seed):
+        mzs, its = _zero_suppressed_profile(seed)
+        dense = _dense(AXIS, mzs, its)
+        idx, vals = _sparse(AXIS, mzs, its)
+        np.testing.assert_allclose(_scatter(AXIS, idx, vals), dense, rtol=1e-12, atol=0)
+        assert np.all(vals != 0)
+        assert vals.sum() == pytest.approx(its.sum(), rel=1e-12)
+
+    def test_only_a_small_fraction_of_the_axis_is_touched(self):
+        """The point of the exercise: work proportional to the samples."""
+        mzs, its = _zero_suppressed_profile()
+        idx, _ = _sparse(AXIS, mzs, its)
+        assert idx.size < 2 * np.count_nonzero(its)
+        assert idx.size < 0.05 * AXIS.size
+
+    def test_centroid_like_input_without_zeros(self):
+        rng = np.random.default_rng(3)
+        mzs = np.sort(rng.uniform(300.0, 1000.0, 150))
+        its = rng.uniform(10.0, 1000.0, 150)
+        dense = _dense(AXIS, mzs, its)
+        idx, vals = _sparse(AXIS, mzs, its)
+        np.testing.assert_allclose(_scatter(AXIS, idx, vals), dense, rtol=1e-12, atol=0)
+
+    def test_unsorted_input(self):
+        mzs, its = _zero_suppressed_profile(4)
+        order = np.random.default_rng(4).permutation(mzs.size)
+        dense = _dense(AXIS, mzs, its)
+        idx, vals = _sparse(AXIS, mzs[order], its[order])
+        np.testing.assert_allclose(_scatter(AXIS, idx, vals), dense, rtol=1e-12, atol=0)
+
+    def test_gap_tolerance_is_applied_the_same_way(self):
+        rng = np.random.default_rng(5)
+        mzs = np.sort(rng.uniform(300.0, 1000.0, 60))
+        its = rng.uniform(10.0, 1000.0, 60)
+        dense = _dense(AXIS, mzs, its, tol=0.05)
+        idx, vals = _sparse(AXIS, mzs, its, tol=0.05)
+        np.testing.assert_allclose(_scatter(AXIS, idx, vals), dense, rtol=1e-12, atol=0)
+        assert vals.sum() == pytest.approx(its.sum(), rel=1e-12)
+
+    def test_cropped_axis_keeps_the_same_share(self):
+        mzs, its = _zero_suppressed_profile(6)
+        axis = _sqrt_axis(500.0, 800.0, 1.3e-3)
+        dense = _dense(axis, mzs, its)
+        idx, vals = _sparse(axis, mzs, its)
+        np.testing.assert_allclose(_scatter(axis, idx, vals), dense, rtol=1e-12, atol=0)
+        assert 0 < vals.sum() < its.sum()
+
+    def test_single_point(self):
+        idx, vals = _sparse(AXIS, np.array([650.0]), np.array([42.0]))
+        assert idx.size == 1 and vals[0] == 42.0
+        assert AXIS[idx[0]] == pytest.approx(650.0, abs=1e-3)
+        idx, vals = _sparse(AXIS, np.array([1200.0]), np.array([42.0]))
+        assert idx.size == 0
+
+    def test_empty_and_all_zero(self):
+        idx, vals = _sparse(AXIS, np.array([]), np.array([]))
+        assert idx.size == 0 and vals.size == 0
+        idx, vals = _sparse(AXIS, np.array([400.0, 401.0]), np.zeros(2))
+        assert idx.size == 0
+        assert _dense(AXIS, np.array([400.0, 401.0]), np.zeros(2)).sum() == 0.0
+
+    def test_module_function_is_what_both_methods_call(self):
+        mzs, its = _zero_suppressed_profile(7)
+        idx, vals = _tic_preserving_sparse(AXIS, mzs, its, None)
+        idx2, vals2 = _sparse(AXIS, mzs, its)
+        np.testing.assert_array_equal(idx, idx2)
+        np.testing.assert_array_equal(vals, vals2)
+
+
+class TestOnTheDefaultMRTAxis:
+    """Bins at 1.14x the sample spacing: nothing doubled, nothing skipped."""
+
+    def test_no_holes_inside_clusters(self):
+        mzs, its = _zero_suppressed_profile(8)
+        idx, vals = _sparse(AXIS, mzs, its)
+        stored = np.zeros(AXIS.size, dtype=bool)
+        stored[idx] = True
+        nz = its != 0
+        for k in np.flatnonzero(nz[1:-1]) + 1:
+            inside = (AXIS > mzs[k - 1]) & (AXIS < mzs[k + 1])
+            assert stored[inside].all()
+
+    def test_no_bin_exceeds_its_neighbouring_samples(self):
+        """Interpolation cannot put two samples' worth into one bin."""
+        mzs, its = _zero_suppressed_profile(9)
+        idx, vals = _sparse(AXIS, mzs, its)
+        scale = vals.sum() / np.interp(AXIS[idx], mzs, its).sum()
+        right = np.searchsorted(mzs, AXIS[idx])
+        left = np.clip(right - 1, 0, mzs.size - 1)
+        right = np.clip(right, 0, mzs.size - 1)
+        ceiling = np.maximum(its[left], its[right]) * scale
+        assert np.all(vals <= ceiling * (1 + 1e-12))

--- a/tests/unit/metadata/extractors/test_waters_extractor.py
+++ b/tests/unit/metadata/extractors/test_waters_extractor.py
@@ -167,15 +167,26 @@ class TestWatersMetadataExtractorEssential:
         assert essential.spectrum_type == "centroid spectrum"
 
     def test_spectrum_type_profile(self):
-        """Test profile spectrum type detection."""
+        """A profile-acquired file read as the profile trace."""
         mock_ml, handle, grid, ft, ms = _make_grid_and_ml()
         mock_ml.is_raw_spectrum_profile.return_value = True
         extractor = WatersMetadataExtractor(
-            mock_ml, handle, Path("/test/data.raw"), grid, ft, ms
+            mock_ml, handle, Path("/test/data.raw"), grid, ft, ms, use_centroid=False
         )
         essential = extractor.get_essential()
 
         assert essential.spectrum_type == "profile spectrum"
+
+    def test_spectrum_type_is_what_the_reader_delivers(self):
+        """The same profile-acquired file, read through the vendor centroider."""
+        mock_ml, handle, grid, ft, ms = _make_grid_and_ml()
+        mock_ml.is_raw_spectrum_profile.return_value = True
+        extractor = WatersMetadataExtractor(
+            mock_ml, handle, Path("/test/data.raw"), grid, ft, ms, use_centroid=True
+        )
+        essential = extractor.get_essential()
+
+        assert essential.spectrum_type == "centroid spectrum"
 
     def test_source_path(self):
         """Test source path is preserved."""
@@ -361,6 +372,9 @@ class TestNoFabricatedMassRange:
             (np.array([300.0, 400.0]), np.array([1.0, 2.0])),
             (np.array([]), np.array([])),
         ]
+        # No acquisition range, so the stored span is the range; with one
+        # reported, that setting would rightly be used instead.
+        mock_ml.get_acquisition_range.return_value = None
 
         essential = self._extractor(mock_ml, handle, grid, ft, ms).get_essential()
 
@@ -377,20 +391,83 @@ class TestWatersResamplingDetection:
     by accident, profile fell to ``DefaultDetector``'s CONSTANT axis.
     """
 
-    @pytest.mark.parametrize("is_profile", [True, False])
-    def test_reflector_tof_for_either_representation(self, is_profile):
+    @staticmethod
+    def _chain_answer(is_profile, use_centroid, instrument=None):
         from thyra.preview import _resampling_metadata_dict
         from thyra.resampling.decision_tree import ResamplingDecisionTree
-        from thyra.resampling.types import AxisType, ResamplingMethod
 
         mock_ml, handle, grid, ft, ms = _make_grid_and_ml()
         mock_ml.is_raw_spectrum_profile.return_value = is_profile
         extractor = WatersMetadataExtractor(
-            mock_ml, handle, Path("/test/data.raw"), grid, ft, ms
+            mock_ml,
+            handle,
+            Path("/test/data.raw"),
+            grid,
+            ft,
+            ms,
+            instrument=instrument,
+            use_centroid=use_centroid,
         )
         comprehensive = extractor.get_comprehensive()
         metadata = _resampling_metadata_dict(comprehensive.essential, comprehensive)
-
         tree = ResamplingDecisionTree()
-        assert tree.select_axis_type(metadata) is AxisType.REFLECTOR_TOF
-        assert tree.select_strategy(metadata) is ResamplingMethod.NEAREST_NEIGHBOR
+        return (
+            tree.select_axis_type(metadata),
+            tree.select_strategy(metadata),
+            tree.select_reference_width(metadata),
+            tree.select_tof_law(metadata),
+        )
+
+    @pytest.mark.parametrize("is_profile", [True, False])
+    def test_vendor_centroid_bins_on_reflector_tof(self, is_profile):
+        """What the reader delivers decides, not what the file was acquired in."""
+        from thyra.resampling.types import AxisType, ResamplingMethod
+
+        axis, method, width, law = self._chain_answer(is_profile, use_centroid=True)
+        assert axis is AxisType.REFLECTOR_TOF
+        assert method is ResamplingMethod.NEAREST_NEIGHBOR
+        assert width == (0.002, 1000.0)
+        assert law is None
+
+    def test_profile_trace_interpolates_on_linear_tof(self):
+        from thyra.resampling.types import AxisType, ResamplingMethod
+
+        axis, method, width, _ = self._chain_answer(True, use_centroid=False)
+        assert axis is AxisType.LINEAR_TOF
+        assert method is ResamplingMethod.TIC_PRESERVING
+        # Not an MRT and no digitiser constants: the MRT width, with a warning.
+        assert width == (0.0013, 1000.0)
+
+    def test_mrt_profile_trace_is_pinned_at_1_3_mda(self):
+        from thyra.readers.waters.instrument import WatersInstrument
+        from thyra.resampling.types import AxisType, ResamplingMethod
+
+        mrt = WatersInstrument(is_mrt=True, decided_by="OpticMode=MRT")
+        axis, method, width, _ = self._chain_answer(
+            True, use_centroid=False, instrument=mrt
+        )
+        assert axis is AxisType.LINEAR_TOF
+        assert method is ResamplingMethod.TIC_PRESERVING
+        assert width == (0.0013, 1000.0)
+
+    def test_mrt_vendor_centroid_follows_the_measured_width_law(self):
+        from thyra.readers.waters.instrument import WatersInstrument
+        from thyra.resampling.mass_axis import MRT_TOF_LAW
+        from thyra.resampling.types import AxisType, ResamplingMethod
+
+        mrt = WatersInstrument(is_mrt=True, decided_by="OpticMode=MRT")
+        axis, method, width, law = self._chain_answer(
+            True, use_centroid=True, instrument=mrt
+        )
+        assert axis is AxisType.TOF
+        assert method is ResamplingMethod.NEAREST_NEIGHBOR
+        assert width is None
+        assert law == MRT_TOF_LAW
+
+    def test_centroid_acquired_file_cannot_deliver_a_trace(self):
+        """Asked for the profile of a centroid-mode file: centroids, so reflector."""
+        from thyra.resampling.types import AxisType, ResamplingMethod
+
+        axis, method, _, _ = self._chain_answer(False, use_centroid=False)
+        assert axis is AxisType.REFLECTOR_TOF
+        assert method is ResamplingMethod.NEAREST_NEIGHBOR

--- a/tests/unit/metadata/extractors/test_waters_extractor_representation.py
+++ b/tests/unit/metadata/extractors/test_waters_extractor_representation.py
@@ -1,0 +1,185 @@
+"""The Waters extractor reports what the reader delivers, on the axis it acquired.
+
+Two facts the resampling chain acts on come from here. The spectrum
+representation must be the one the open handle is set to hand back -- the
+profile trace or the vendor centroid -- not the one the file was acquired
+in, since a profile-acquired file read in centroid mode delivers centroids.
+And the mass range must be the acquisition setting, not the span of the
+stored values, so that runs acquired with the same method share one
+generated axis.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from thyra.metadata.extractors.waters_extractor import WatersMetadataExtractor
+from thyra.readers.waters.instrument import WatersInstrument
+from thyra.resampling.constants import SpectrumType
+from thyra.resampling.data_characteristics import DataCharacteristics
+
+from .test_waters_extractor import _make_grid_and_ml
+
+MRT = WatersInstrument(
+    is_mrt=True,
+    decided_by="OpticMode=MRT",
+    optic_mode="MRT",
+    resolution=225909.053,
+    flight_path_mm=48400.0,
+    effective_voltage_v=7221.664,
+    adc_sample_frequency_ghz=1.35,
+)
+
+
+def _extractor(mock_ml, handle, grid, ft, ms, **kwargs):
+    return WatersMetadataExtractor(
+        mock_ml, handle, Path("/test/data.raw"), grid, ft, ms, **kwargs
+    )
+
+
+class TestDeliveredRepresentation:
+    def test_profile_file_read_as_profile(self):
+        mock_ml, handle, grid, ft, ms = _make_grid_and_ml()
+        mock_ml.is_raw_spectrum_profile.return_value = True
+        essential = _extractor(
+            mock_ml, handle, grid, ft, ms, use_centroid=False
+        ).get_essential()
+        assert essential.spectrum_type == SpectrumType.PROFILE
+
+    def test_profile_file_read_as_centroid(self):
+        """What MassLynx hands back is centroids, so that is what is declared."""
+        mock_ml, handle, grid, ft, ms = _make_grid_and_ml()
+        mock_ml.is_raw_spectrum_profile.return_value = True
+        essential = _extractor(
+            mock_ml, handle, grid, ft, ms, use_centroid=True
+        ).get_essential()
+        assert essential.spectrum_type == SpectrumType.CENTROID
+
+    def test_centroid_file_has_no_trace_to_give(self, caplog):
+        mock_ml, handle, grid, ft, ms = _make_grid_and_ml()
+        mock_ml.is_raw_spectrum_profile.return_value = False
+        with caplog.at_level(logging.WARNING):
+            essential = _extractor(
+                mock_ml, handle, grid, ft, ms, use_centroid=False
+            ).get_essential()
+        assert essential.spectrum_type == SpectrumType.CENTROID
+        assert "no profile trace to read" in caplog.text
+
+    def test_default_is_centroid_for_callers_that_predate_the_argument(self):
+        mock_ml, handle, grid, ft, ms = _make_grid_and_ml()
+        mock_ml.is_raw_spectrum_profile.return_value = True
+        essential = _extractor(mock_ml, handle, grid, ft, ms).get_essential()
+        assert essential.spectrum_type == SpectrumType.CENTROID
+
+
+class TestAxisMassRange:
+    def test_acquisition_range_when_it_holds_the_stored_span(self):
+        mock_ml, handle, grid, ft, ms = _make_grid_and_ml(n_peaks=10)
+        # Stored values span 100-1000 (linspace); the method was 50-1200.
+        mock_ml.get_acquisition_range.return_value = (50.0, 1200.0)
+        essential = _extractor(mock_ml, handle, grid, ft, ms).get_essential()
+        assert essential.mass_range == (50.0, 1200.0)
+
+    def test_stored_span_when_no_function_reports_a_range(self):
+        mock_ml, handle, grid, ft, ms = _make_grid_and_ml(n_peaks=10)
+        mock_ml.get_acquisition_range.return_value = None
+        essential = _extractor(mock_ml, handle, grid, ft, ms).get_essential()
+        assert essential.mass_range[0] == pytest.approx(100.0)
+        assert essential.mass_range[1] == pytest.approx(1000.0)
+
+    def test_stored_span_when_a_value_falls_outside_the_range(self, caplog):
+        """A range that would drop measured data is not used."""
+        mock_ml, handle, grid, ft, ms = _make_grid_and_ml(n_peaks=10)
+        mock_ml.get_acquisition_range.return_value = (200.0, 1000.0)
+        with caplog.at_level(logging.WARNING):
+            essential = _extractor(mock_ml, handle, grid, ft, ms).get_essential()
+        assert essential.mass_range[0] == pytest.approx(100.0)
+        assert "outside the acquisition range" in caplog.text
+
+    def test_union_over_ms_functions(self):
+        mock_ml, handle, grid, ft, ms = _make_grid_and_ml(n_peaks=10)
+        ft = {0: ft[0], 1: ft[0]}
+        ms = [0, 1]
+        mock_ml.get_acquisition_range.side_effect = lambda h, f: {
+            0: (50.0, 600.0),
+            1: (400.0, 1100.0),
+        }[f]
+        essential = _extractor(mock_ml, handle, grid, ft, ms).get_essential()
+        assert essential.mass_range == (50.0, 1100.0)
+
+
+class TestInstrumentReachesTheDetectorChain:
+    """format_specific carries what DataCharacteristics.from_metadata reads."""
+
+    def test_mrt_profile_stamps(self):
+        mock_ml, handle, grid, ft, ms = _make_grid_and_ml()
+        mock_ml.is_raw_spectrum_profile.return_value = True
+        comp = _extractor(
+            mock_ml, handle, grid, ft, ms, instrument=MRT, use_centroid=False
+        ).get_comprehensive()
+
+        specific = comp.format_specific
+        assert specific["format"] == "Waters MassLynx raw"
+        assert specific["is_mrt"] is True
+        assert specific["instrument"] == "SELECT SERIES MRT"
+        assert specific["instrument_decided_by"] == "OpticMode=MRT"
+        assert specific["spectrum_source"] == "profile_trace"
+        assert specific["profile_sample_spacing_da_at_1000"] == pytest.approx(
+            1.143e-3, rel=0.01
+        )
+        # The layout facts that were always here are still here.
+        assert specific["n_functions"] == 1
+        assert specific["pixel_count_x"] == 3
+        assert comp.instrument_info["instrument_model"] == "SELECT SERIES MRT"
+        assert comp.instrument_info["declared_resolution"] == pytest.approx(225909.053)
+
+        characteristics = DataCharacteristics.from_metadata(
+            {
+                "format_specific": specific,
+                "instrument_info": comp.instrument_info,
+                "essential_metadata": {"spectrum_type": comp.essential.spectrum_type},
+            }
+        )
+        assert characteristics.is_waters_raw
+        assert characteristics.is_waters_mrt
+        assert characteristics.is_profile_data
+        assert characteristics.profile_sample_spacing_da_at_1000 == pytest.approx(
+            1.143e-3, rel=0.01
+        )
+
+    def test_centroid_read_stamps(self):
+        mock_ml, handle, grid, ft, ms = _make_grid_and_ml()
+        comp = _extractor(
+            mock_ml, handle, grid, ft, ms, instrument=MRT, use_centroid=True
+        ).get_comprehensive()
+        assert comp.format_specific["spectrum_source"] == "vendor_centroid"
+        assert comp.essential.spectrum_type == SpectrumType.CENTROID
+
+    def test_without_an_instrument_nothing_is_claimed(self):
+        mock_ml, handle, grid, ft, ms = _make_grid_and_ml()
+        comp = _extractor(mock_ml, handle, grid, ft, ms).get_comprehensive()
+        assert "is_mrt" not in comp.format_specific
+        assert "instrument_model" not in comp.instrument_info
+        characteristics = DataCharacteristics.from_metadata(
+            {"format_specific": comp.format_specific}
+        )
+        assert characteristics.is_waters_raw
+        assert not characteristics.is_waters_mrt
+        assert characteristics.profile_sample_spacing_da_at_1000 is None
+
+    def test_spacing_is_omitted_when_it_cannot_be_predicted(self):
+        mock_ml, handle, grid, ft, ms = _make_grid_and_ml()
+        bare = WatersInstrument(is_mrt=False, decided_by="Resolution=10000")
+        comp = _extractor(
+            mock_ml, handle, grid, ft, ms, instrument=bare
+        ).get_comprehensive()
+        assert comp.format_specific["profile_sample_spacing_da_at_1000"] is None
+        characteristics = DataCharacteristics.from_metadata(
+            {"format_specific": comp.format_specific}
+        )
+        assert characteristics.profile_sample_spacing_da_at_1000 is None
+        assert np.isfinite(comp.essential.mass_range).all()

--- a/tests/unit/readers/test_waters_instrument.py
+++ b/tests/unit/readers/test_waters_instrument.py
@@ -1,0 +1,286 @@
+"""Which Waters instrument wrote a run, and what the reader does about it.
+
+The three cases the detection has to get right are the ones that exist on
+disk: a SELECT SERIES MRT run (``OpticMode = MRT``, ``Resolution`` ~225,000,
+``$$ Instrument: MRT#``), a Synapt G2-Si run (no ``OpticMode``, no
+instrument line, ``Resolution`` 10,000, tab-run key padding), and a directory
+with neither side file at all. The field values and formatting below are
+copied from those two runs.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from thyra.readers.waters.imaging_grid import ImagingGrid
+from thyra.readers.waters.instrument import (
+    MRT_RESOLUTION_THRESHOLD,
+    WatersInstrument,
+    identify_waters_instrument,
+    parse_extern_inf,
+    parse_header_txt,
+)
+from thyra.readers.waters.masslynx_lib import FunctionType, ScanInfoData
+from thyra.readers.waters.waters_reader import WatersReader
+
+# The MRT pads keys with spaces then one tab; the Synapt with runs of tabs.
+MRT_EXTERN = (
+    "Instrument Configuration:\n"
+    "Lteff                    \t48400.0\n"
+    "Veff                    \t7221.664\n"
+    "Resolution              \t225909.053\n"
+    "Acquisition Device      \tWatersADC\n"
+    "ADC Sample Frequency (GHz)\t1.35\n"
+    "\n"
+    "Function Parameters - Function 1 - TOF MS FUNCTION\n"
+    "ADC Sample Frequency (GHz)                   \t1.35\n"
+    "ADC Pusher Period (us)                       \t187.0\n"
+    "OpticMode                                    \tMRT\n"
+    "Polarity                                     \tPositive\n"
+)
+MRT_HEADER = (
+    "$$ Version: 01.00\n"
+    "$$ Acquired Name: 20260821_MRT_FTW2\n"
+    "$$ Instrument: MRT#\n"
+    "$$ Cal Function 1: 0.000000000000000E+00,1.000000000000000E+00,T1\n"
+)
+SYNAPT_EXTERN = (
+    "Parameters for E:\\Britt.PRO\\Acqudb\\synapt on MALDI MS.exp\n"
+    "Created by 4.1 SCN957\n"
+    " \n"
+    "Instrument Configuration:\n"
+    "Lteff\t\t\t\t\t\t1800.0\n"
+    "Veff\t\t\t\t\t\t7200.50\n"
+    "Resolution\t\t\t\t\t10000\n"
+    "Min Points in Peak\t\t\t\t2\n"
+    "Acquisition Device\t\t\t\tWatersADC\n"
+    "ADC Sample Frequency (GHz)\t\t\t3.0\n"
+    "Pusher Cycle Time (\xb5s)\t\t\t\tAutomatic\n"
+    "PusherInterval\t\t\t\t\t54.000000\n"
+)
+SYNAPT_HEADER = (
+    "$$ Version: 01.00\n"
+    "$$ Acquired Name: 20201216_MDA468_slide20200630_synapt\n"
+    "$$ Job Code: 20201216_MDA468_slide20200630_synapt\n"
+)
+
+
+def _raw_dir(tmp_path, extern=None, header=None):
+    raw = tmp_path / "run.raw"
+    raw.mkdir(parents=True)
+    (raw / "_FUNC001.DAT").write_bytes(b"\x00" * 64)
+    if extern is not None:
+        (raw / "_extern.inf").write_text(extern, encoding="latin-1")
+    if header is not None:
+        (raw / "_header.txt").write_text(header, encoding="latin-1")
+    return raw
+
+
+class TestParsing:
+    def test_mrt_formatting(self):
+        fields = parse_extern_inf(MRT_EXTERN)
+        assert fields["OpticMode"] == "MRT"
+        assert fields["Resolution"] == "225909.053"
+        assert fields["ADC Pusher Period (us)"] == "187.0"
+
+    def test_synapt_tab_runs_and_latin1(self):
+        fields = parse_extern_inf(SYNAPT_EXTERN)
+        assert fields["Resolution"] == "10000"
+        assert fields["Lteff"] == "1800.0"
+        assert fields["Pusher Cycle Time (\xb5s)"] == "Automatic"
+        assert "OpticMode" not in fields
+
+    def test_first_occurrence_wins(self):
+        fields = parse_extern_inf("K\t1\nK\t2\n")
+        assert fields["K"] == "1"
+
+    def test_section_headers_are_skipped(self):
+        assert "Instrument Configuration:" not in parse_extern_inf(MRT_EXTERN)
+
+    def test_header(self):
+        fields = parse_header_txt(MRT_HEADER)
+        assert fields["Instrument"] == "MRT#"
+        assert fields["Acquired Name"] == "20260821_MRT_FTW2"
+        assert "Instrument" not in parse_header_txt(SYNAPT_HEADER)
+
+
+class TestDecision:
+    def test_mrt_run(self, tmp_path):
+        inst = identify_waters_instrument(_raw_dir(tmp_path, MRT_EXTERN, MRT_HEADER))
+        assert inst.is_mrt
+        assert inst.decided_by == "OpticMode=MRT"
+        assert inst.name == "SELECT SERIES MRT"
+        assert inst.resolution == pytest.approx(225909.053)
+
+    def test_synapt_run(self, tmp_path):
+        inst = identify_waters_instrument(
+            _raw_dir(tmp_path, SYNAPT_EXTERN, SYNAPT_HEADER)
+        )
+        assert not inst.is_mrt
+        assert inst.decided_by == "Resolution=10000"
+        assert inst.optic_mode is None
+        assert inst.instrument_label is None
+
+    def test_neither_field(self, tmp_path):
+        inst = identify_waters_instrument(_raw_dir(tmp_path))
+        assert not inst.is_mrt
+        assert inst.decided_by == "no instrument field found"
+        assert inst.resolution is None
+
+    def test_optic_mode_outranks_resolution(self, tmp_path):
+        # OpticMode says a non-MRT optic even though the resolution is high.
+        extern = MRT_EXTERN.replace("\tMRT\n", "\tV\n")
+        inst = identify_waters_instrument(_raw_dir(tmp_path, extern))
+        assert not inst.is_mrt
+        assert inst.decided_by == "OpticMode=V"
+
+    def test_header_label_when_optic_mode_is_absent(self, tmp_path):
+        inst = identify_waters_instrument(_raw_dir(tmp_path, header=MRT_HEADER))
+        assert inst.is_mrt
+        assert inst.decided_by == "$$ Instrument=MRT#"
+
+    def test_resolution_fallback(self, tmp_path):
+        extern = "Resolution\t225909.053\n"
+        inst = identify_waters_instrument(_raw_dir(tmp_path, extern))
+        assert inst.is_mrt
+        assert inst.decided_by == "Resolution=225909"
+        assert MRT_RESOLUTION_THRESHOLD == 100_000.0
+
+    def test_unparseable_resolution_is_not_a_decision(self, tmp_path):
+        inst = identify_waters_instrument(_raw_dir(tmp_path, "Resolution\tn/a\n"))
+        assert not inst.is_mrt
+        assert inst.decided_by == "no instrument field found"
+
+    def test_decision_is_logged(self, tmp_path, caplog):
+        with caplog.at_level(logging.INFO, logger="thyra.readers.waters.instrument"):
+            identify_waters_instrument(_raw_dir(tmp_path, MRT_EXTERN, MRT_HEADER))
+        assert "SELECT SERIES MRT (OpticMode=MRT)" in caplog.text
+
+
+class TestSampleSpacing:
+    """Predicted from Lteff, Veff and the ADC clock; measured values beside."""
+
+    def test_mrt(self, tmp_path):
+        inst = identify_waters_instrument(_raw_dir(tmp_path, MRT_EXTERN))
+        # 1.16 mDa measured at m/z 990-1000, 1.04 at 795-805.
+        assert inst.profile_sample_spacing_da(1000.0) == pytest.approx(
+            1.143e-3, rel=0.01
+        )
+        assert inst.profile_sample_spacing_da(800.0) == pytest.approx(
+            1.022e-3, rel=0.01
+        )
+
+    def test_synapt(self, tmp_path):
+        inst = identify_waters_instrument(_raw_dir(tmp_path, SYNAPT_EXTERN))
+        # 13.4 mDa measured at m/z 900-1000.
+        assert inst.profile_sample_spacing_da(1000.0) == pytest.approx(
+            13.8e-3, rel=0.01
+        )
+
+    def test_sqrt_law(self, tmp_path):
+        inst = identify_waters_instrument(_raw_dir(tmp_path, MRT_EXTERN))
+        ratio = inst.profile_sample_spacing_da(400.0) / inst.profile_sample_spacing_da(
+            1600.0
+        )
+        assert ratio == pytest.approx(0.5)
+
+    def test_missing_constants(self, tmp_path):
+        inst = identify_waters_instrument(_raw_dir(tmp_path))
+        assert inst.profile_sample_spacing_da(1000.0) is None
+        assert WatersInstrument(is_mrt=False, decided_by="x", flight_path_mm=1.0)
+        assert (
+            WatersInstrument(
+                is_mrt=False,
+                decided_by="x",
+                flight_path_mm=0.0,
+                effective_voltage_v=1.0,
+                adc_sample_frequency_ghz=1.0,
+            ).profile_sample_spacing_da(500.0)
+            is None
+        )
+
+
+def _grid_one_pixel():
+    scan_map = {
+        (0, 0): ScanInfoData(
+            ms_level=1,
+            polarity=0,
+            drift_scan_count=0,
+            is_profile=1,
+            precursor_mz=0.0,
+            rt=1.0,
+            laser_x_pos=0.1,
+            laser_y_pos=0.1,
+        )
+    }
+    return ImagingGrid(
+        x_index_map={100.0: 0},
+        y_index_map={100.0: 0},
+        pixel_count_x=1,
+        pixel_count_y=1,
+        pixel_size_x=0.0,
+        pixel_size_y=0.0,
+        lateral_width=0.0,
+        lateral_height=0.0,
+        scan_map=scan_map,
+    )
+
+
+class TestReaderDefault:
+    """``use_centroid=None`` follows the instrument; an explicit value wins."""
+
+    def test_mrt_defaults_to_profile(self, tmp_path):
+        reader = WatersReader(_raw_dir(tmp_path, MRT_EXTERN, MRT_HEADER))
+        assert reader.use_centroid is False
+        assert reader.instrument.is_mrt
+
+    def test_synapt_defaults_to_centroid(self, tmp_path):
+        reader = WatersReader(_raw_dir(tmp_path, SYNAPT_EXTERN, SYNAPT_HEADER))
+        assert reader.use_centroid is True
+
+    def test_unknown_defaults_to_centroid(self, tmp_path):
+        reader = WatersReader(_raw_dir(tmp_path))
+        assert reader.use_centroid is True
+        assert reader.instrument.decided_by == "no instrument field found"
+
+    @pytest.mark.parametrize("explicit", [True, False])
+    def test_explicit_choice_overrides_either_way(self, tmp_path, explicit):
+        mrt = WatersReader(
+            _raw_dir(tmp_path / "a", MRT_EXTERN, MRT_HEADER), use_centroid=explicit
+        )
+        synapt = WatersReader(
+            _raw_dir(tmp_path / "b", SYNAPT_EXTERN, SYNAPT_HEADER),
+            use_centroid=explicit,
+        )
+        assert mrt.use_centroid is explicit
+        assert synapt.use_centroid is explicit
+
+    def test_default_is_logged_with_its_reason(self, tmp_path, caplog):
+        with caplog.at_level(logging.INFO, logger="thyra.readers.waters.waters_reader"):
+            WatersReader(_raw_dir(tmp_path, MRT_EXTERN, MRT_HEADER))
+        assert "profile trace by default (OpticMode=MRT" in caplog.text
+
+    @patch("thyra.readers.waters.waters_reader.MassLynxLib")
+    @patch("thyra.readers.waters.waters_reader.build_imaging_grid")
+    def test_mrt_default_reaches_the_native_mode_switch(
+        self, mock_build_grid, mock_ml_cls, tmp_path
+    ):
+        """The decision is only real once ``set_centroid`` sees it."""
+        mock_ml = MagicMock()
+        mock_ml_cls.get_instance.return_value = mock_ml
+        mock_ml.open_file.return_value = "handle"
+        mock_ml.is_imaging_file.return_value = True
+        mock_ml.get_number_of_functions.return_value = 1
+        mock_ml.classify_function.return_value = FunctionType.MS
+        mock_build_grid.return_value = _grid_one_pixel()
+
+        reader = WatersReader(_raw_dir(tmp_path, MRT_EXTERN, MRT_HEADER))
+        reader._ensure_initialized()
+        mock_ml.set_centroid.assert_called_once_with("handle", False)
+
+        extractor = reader._create_metadata_extractor()
+        assert extractor._use_centroid is False
+        assert extractor._instrument is reader.instrument

--- a/tests/unit/resampling/test_decision_tree.py
+++ b/tests/unit/resampling/test_decision_tree.py
@@ -18,6 +18,7 @@ from thyra.resampling.instrument_detectors import (
     RapiflexDetector,
     TimsTOFDetector,
     WatersDetector,
+    WatersProfileDetector,
 )
 from thyra.resampling.types import AxisType, ResamplingMethod
 
@@ -186,6 +187,8 @@ class TestInstrumentDetectorChain:
             "FTICRDetector",
             "OrbitrapDetector",
             "PhiToFSIMSDetector",
+            "WatersProfileDetector",
+            "WatersMRTCentroidDetector",
             "WatersDetector",
             "CentroidImzMLDetector",
             "DefaultDetector",
@@ -317,18 +320,23 @@ class TestWatersDetector:
         )
 
     def test_does_not_declare_a_source_grid_law(self):
-        """MassLynx lays out the stored grid, not Thyra; no law is claimed.
+        """A centroid list has no grid; the trace's law lives on the profile detector.
 
-        Declaring one untested would open ``_gate_tic_preserving`` on data
-        whose grid Thyra has not actually identified.
+        Declaring one here would open ``_gate_tic_preserving`` on peak
+        lists, which have nothing to interpolate between.
         """
         assert self.detector.source_grid_law is None
 
-    @pytest.mark.parametrize(
-        "spectrum_type", [SpectrumType.PROFILE, SpectrumType.CENTROID, None]
-    )
-    def test_chain_answers_the_same_for_any_representation(self, spectrum_type):
-        """Profile, centroid, or undeclared: the pair is the instrument's."""
+    def test_centroid_width_is_two_mda(self):
+        """5 mDa gave 1.1 bins per FWHM at m/z 800 on the MRT; 2 mDa gives 2.8."""
+        characteristics = DataCharacteristics.from_metadata(self.WATERS_STAMP)
+        assert self.detector.get_reference_width(characteristics) == (0.002, 1000.0)
+
+    @pytest.mark.parametrize("spectrum_type", [SpectrumType.CENTROID, None])
+    def test_chain_bins_centroids_and_undeclared_by_nearest_neighbour(
+        self, spectrum_type
+    ):
+        """Centroid or undeclared: the vendor peak list, binned on reflector_tof."""
         chain = InstrumentDetectorChain()
         characteristics = DataCharacteristics.from_metadata(
             {
@@ -336,11 +344,23 @@ class TestWatersDetector:
                 "essential_metadata": {"spectrum_type": spectrum_type},
             }
         )
+        assert isinstance(chain.detect(characteristics), WatersDetector)
         assert chain.get_axis_type(characteristics) is AxisType.REFLECTOR_TOF
         assert (
             chain.get_resampling_method(characteristics)
             is ResamplingMethod.NEAREST_NEIGHBOR
         )
+        assert chain.get_reference_width(characteristics) == (0.002, 1000.0)
+
+    def test_chain_hands_the_profile_trace_to_the_profile_detector(self):
+        chain = InstrumentDetectorChain()
+        characteristics = DataCharacteristics.from_metadata(
+            {
+                **self.WATERS_STAMP,
+                "essential_metadata": {"spectrum_type": SpectrumType.PROFILE},
+            }
+        )
+        assert isinstance(chain.detect(characteristics), WatersProfileDetector)
 
     def test_beats_the_centroid_detector_in_the_chain(self):
         """A centroid Waters file is identified, not matched by accident."""
@@ -352,6 +372,116 @@ class TestWatersDetector:
             }
         )
         assert isinstance(chain.detect(characteristics), WatersDetector)
+
+
+class TestWatersProfileDetector:
+    """The profile trace: samples on the digitiser's sqrt(m/z) grid.
+
+    Measured as ``(m/z)^0.494`` on a SELECT SERIES MRT and ``(m/z)^0.498``
+    on a Synapt G2-Si, so the law is declared and ``tic_preserving`` clears
+    the gate onto a ``linear_tof`` axis. The bin width is pinned at 1.3 mDa
+    at m/z 1000 on an MRT (about 1.14 sample spacings) so every MRT run
+    with the same mass range shares one axis, and follows the run's own
+    predicted spacing on any other Waters instrument asked for its trace.
+    """
+
+    WATERS_PROFILE = {
+        "format_specific": {"format": "Waters MassLynx raw"},
+        "essential_metadata": {"spectrum_type": SpectrumType.PROFILE},
+    }
+
+    def setup_method(self):
+        self.detector = WatersProfileDetector()
+        self.chain = InstrumentDetectorChain()
+
+    def _characteristics(self, **format_specific):
+        return DataCharacteristics.from_metadata(
+            {
+                **self.WATERS_PROFILE,
+                "format_specific": {
+                    **self.WATERS_PROFILE["format_specific"],
+                    **format_specific,
+                },
+            }
+        )
+
+    def test_matches_the_profile_trace_only(self):
+        assert self.detector.matches(self._characteristics())
+        for spectrum_type in (SpectrumType.CENTROID, None):
+            characteristics = DataCharacteristics.from_metadata(
+                {
+                    "format_specific": {"format": "Waters MassLynx raw"},
+                    "essential_metadata": {"spectrum_type": spectrum_type},
+                }
+            )
+            assert not self.detector.matches(characteristics)
+
+    def test_does_not_match_other_profile_formats(self):
+        characteristics = DataCharacteristics.from_metadata(
+            {
+                "format_specific": {"format": "Rapiflex"},
+                "essential_metadata": {"spectrum_type": SpectrumType.PROFILE},
+            }
+        )
+        assert not self.detector.matches(characteristics)
+
+    def test_uses_linear_tof_and_tic_preserving(self):
+        assert self.detector.get_axis_type() is AxisType.LINEAR_TOF
+        assert self.detector.get_resampling_method() is ResamplingMethod.TIC_PRESERVING
+
+    def test_declares_the_measured_source_grid_law(self):
+        assert self.detector.source_grid_law is AxisType.LINEAR_TOF
+
+    def test_chain_clears_the_tic_preserving_gate(self):
+        """Source law equals target law, so the interpolating path is allowed."""
+        characteristics = self._characteristics()
+        assert (
+            self.chain.get_resampling_method(characteristics)
+            is ResamplingMethod.TIC_PRESERVING
+        )
+        assert self.chain.get_axis_type(characteristics) is AxisType.LINEAR_TOF
+
+    def test_mrt_width_is_pinned(self):
+        characteristics = self._characteristics(
+            is_mrt=True, profile_sample_spacing_da_at_1000=1.143e-3
+        )
+        assert characteristics.is_waters_mrt
+        assert self.detector.get_reference_width(characteristics) == (0.0013, 1000.0)
+        assert self.chain.get_reference_width(characteristics) == (0.0013, 1000.0)
+
+    def test_other_instruments_follow_their_own_sample_spacing(self):
+        """A Synapt G2-Si: 13.8 mDa per sample, times 1.14, up to 0.1 mDa."""
+        characteristics = self._characteristics(
+            is_mrt=False, profile_sample_spacing_da_at_1000=13.806e-3
+        )
+        width, reference = self.detector.get_reference_width(characteristics)
+        assert reference == 1000.0
+        assert width == pytest.approx(0.0158)
+
+    def test_unknown_spacing_falls_back_to_the_mrt_width_with_a_warning(self, caplog):
+        import logging
+
+        characteristics = self._characteristics(is_mrt=False)
+        with caplog.at_level(logging.WARNING):
+            width = self.detector.get_reference_width(characteristics)
+        assert width == (0.0013, 1000.0)
+        assert "predict its sample spacing" in caplog.text
+
+    def test_decision_tree_exposes_the_width(self):
+        tree = ResamplingDecisionTree()
+        assert tree.select_reference_width(None) is None
+        assert tree.select_reference_width({"essential_metadata": {}}) is None
+        assert tree.select_reference_width(
+            {
+                **self.WATERS_PROFILE,
+                "format_specific": {"format": "Waters MassLynx raw", "is_mrt": True},
+            }
+        ) == (0.0013, 1000.0)
+
+    def test_precedes_the_centroid_waters_detector(self):
+        assert isinstance(
+            self.chain.detect(self._characteristics()), WatersProfileDetector
+        )
 
 
 class TestAnalyzerFamilyReachability:

--- a/tests/unit/resampling/test_tof_generator.py
+++ b/tests/unit/resampling/test_tof_generator.py
@@ -188,7 +188,7 @@ class TestConverterPlan:
         assert width == pytest.approx(tof_fwhm_mda(1000.0, MRT_A, MRT_B) * 1e-3 / 3.0)
 
     def test_no_law_anywhere_is_an_error(self):
-        with pytest.raises(ValueError, match="--tof-a and --tof-b"):
+        with pytest.raises(ValueError, match="--tof-law A B"):
             _tof_plan(self._stub())
 
     def test_bin_count_goes_through_the_generator(self):

--- a/tests/unit/resampling/test_tof_generator.py
+++ b/tests/unit/resampling/test_tof_generator.py
@@ -1,0 +1,288 @@
+"""The two-term TOF width law: ``FWHM(m) = sqrt(A m + B m^2)``, bins at FWHM / k.
+
+``linear_tof`` and ``reflector_tof`` are its ``B = 0`` and ``A = 0`` limits,
+and the generator must reduce to each of them exactly. With the pair fitted
+on the SELECT SERIES MRT it must lay ``k`` bins per measured peak width at
+every m/z, and keep the 800.5477 / 800.5566 pair in separate bins.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from thyra.converters.spatialdata.base_spatialdata_converter import (
+    BaseSpatialDataConverter,
+    _normalize_resampling_config,
+    _reference_params,
+    _tof_plan,
+)
+from thyra.resampling.common_axis import CommonAxisBuilder
+from thyra.resampling.data_characteristics import DataCharacteristics
+from thyra.resampling.decision_tree import ResamplingDecisionTree
+from thyra.resampling.instrument_detectors import (
+    InstrumentDetectorChain,
+    TimsTOFDetector,
+    WatersDetector,
+    WatersMRTCentroidDetector,
+    WatersProfileDetector,
+)
+from thyra.resampling.mass_axis import (
+    DEFAULT_BINS_PER_FWHM,
+    MRT_TOF_LAW,
+    TIMSTOF_TOF_LAW,
+    LinearTOFAxisGenerator,
+    ReflectorTOFAxisGenerator,
+    TOFAxisGenerator,
+    tof_fwhm_mda,
+)
+from thyra.resampling.types import AxisType, ResamplingMethod
+
+MRT_A, MRT_B = MRT_TOF_LAW
+
+
+class TestTheLaw:
+    def test_mrt_pair_reproduces_the_measured_widths(self):
+        """2.97 / 3.79 / 4.54 mDa at m/z 400 / 600 / 800, within 0.1 mDa."""
+        got = tof_fwhm_mda([400.0, 600.0, 800.0], MRT_A, MRT_B)
+        np.testing.assert_allclose(got, [2.97, 3.79, 4.54], atol=0.1)
+
+    def test_timstof_pair_is_near_constant_ppm(self):
+        """1 / sqrt(B) = 34k: the reflector limit dominates over the lipid range."""
+        w = tof_fwhm_mda([400.0, 800.0], *TIMSTOF_TOF_LAW)
+        assert 800.0 / (w[1] * 1e-3) == pytest.approx(31_900, rel=0.02)
+        assert w[1] / w[0] == pytest.approx(1.9, abs=0.05)
+
+    @pytest.mark.parametrize(
+        "a, b", [(-1.0, 1.0), (1.0, -1.0), (0.0, 0.0), (float("nan"), 1.0)]
+    )
+    def test_invalid_pairs_are_refused(self, a, b):
+        with pytest.raises(ValueError):
+            TOFAxisGenerator(a, b)
+
+
+class TestLimits:
+    """B = 0 is the sqrt(m) grid, A = 0 the ln(m) grid the single-term generators lay."""
+
+    def test_b_zero_is_linear_tof(self):
+        ours = TOFAxisGenerator(0.02, 0.0).generate_axis(100.0, 1000.0, 5000)
+        theirs = LinearTOFAxisGenerator().generate_axis(100.0, 1000.0, 5000)
+        np.testing.assert_allclose(ours.mz_values, theirs.mz_values, rtol=1e-12)
+
+    def test_a_zero_is_reflector_tof(self):
+        ours = TOFAxisGenerator(0.0, 1e-5).generate_axis(100.0, 1000.0, 5000)
+        theirs = ReflectorTOFAxisGenerator().generate_axis(100.0, 1000.0, 5000)
+        np.testing.assert_allclose(ours.mz_values, theirs.mz_values, rtol=1e-12)
+
+    def test_general_case_sits_between_the_limits(self):
+        """Width ratio across the range: 0.5 < exponent < 1."""
+        axis = (
+            TOFAxisGenerator(MRT_A, MRT_B).generate_axis(300.0, 1000.0, 20000).mz_values
+        )
+        widths = np.diff(axis)
+        i4, i8 = np.searchsorted(axis, 400.0), np.searchsorted(axis, 800.0)
+        ratio = widths[i8] / widths[i4]
+        assert np.sqrt(2.0) < ratio < 2.0
+        assert ratio == pytest.approx(4.54 / 2.97, rel=0.02)
+
+
+class TestBinsPerFWHM:
+    def setup_method(self):
+        self.gen = TOFAxisGenerator(MRT_A, MRT_B)
+        self.k = DEFAULT_BINS_PER_FWHM
+        self.n = self.gen.bin_count(100.0, 1000.0, self.k)
+        self.axis = self.gen.generate_axis(100.0, 1000.0, self.n).mz_values
+
+    @pytest.mark.parametrize("mz", [400.0, 600.0, 800.0])
+    def test_k_bins_per_measured_width(self, mz):
+        i = int(np.searchsorted(self.axis, mz))
+        width = self.axis[i] - self.axis[i - 1]
+        assert tof_fwhm_mda(mz, MRT_A, MRT_B) * 1e-3 / width == pytest.approx(
+            self.k, rel=0.05
+        )
+
+    def test_count_matches_the_closed_form(self):
+        """The count is 1000 k times the integral of 1 / FWHM over the range."""
+        m = np.linspace(100.0, 1000.0, 200_001)
+        numeric = np.trapezoid(1.0 / tof_fwhm_mda(m, MRT_A, MRT_B), m)
+        assert self.n == pytest.approx(1e3 * self.k * numeric, rel=1e-4)
+
+    def test_axis_is_ascending_and_spans_the_range(self):
+        assert np.all(np.diff(self.axis) > 0)
+        assert self.axis[0] > 100.0 and self.axis[-1] < 1000.0
+        assert self.axis[0] == pytest.approx(100.0, abs=0.002)
+        assert self.axis[-1] == pytest.approx(1000.0, abs=0.002)
+
+    def test_the_doublet_lands_in_separate_bins(self):
+        """13C2 PC 34:1 [M+K]+ against PC 34:0 [M+K]+, 8.9 mDa apart at k = 3."""
+        a, b = np.searchsorted(self.axis, [800.5477, 800.5566])
+        assert b - a >= 5
+
+    def test_width_and_k_are_interchangeable(self):
+        k = self.gen.bins_per_fwhm_for(1000.0, 0.002)
+        assert self.gen.bin_width_at(1000.0, k) == pytest.approx(0.002)
+        assert k == pytest.approx(tof_fwhm_mda(1000.0, MRT_A, MRT_B) / 2.0)
+
+    def test_builder_needs_the_law(self):
+        builder = CommonAxisBuilder()
+        with pytest.raises(ValueError, match="tof_law"):
+            builder.build_physics_axis(100.0, 1000.0, 100, AxisType.TOF)
+        axis = builder.build_physics_axis(
+            100.0, 1000.0, 100, AxisType.TOF, tof_law=MRT_TOF_LAW
+        )
+        assert axis.axis_type is AxisType.TOF
+        assert axis.num_bins == 100
+
+
+class TestConverterPlan:
+    """``_tof_plan``: the caller's pair, else the detected one; k from width or flag."""
+
+    @staticmethod
+    def _stub(**kw):
+        base = dict(
+            _width_at_mz=None,
+            _reference_mz=1000.0,
+            _tof_a=None,
+            _tof_b=None,
+            _bins_per_fwhm=None,
+            _detected_tof_law=None,
+            _detected_reference_width=None,
+        )
+        base.update(kw)
+        return SimpleNamespace(**base)
+
+    def test_default_is_three_bins_per_fwhm_on_the_detected_law(self):
+        assert _tof_plan(self._stub(_detected_tof_law=MRT_TOF_LAW)) == (
+            MRT_A,
+            MRT_B,
+            3.0,
+        )
+
+    def test_callers_pair_wins(self):
+        a, b, k = _tof_plan(
+            self._stub(_tof_a=0.1, _tof_b=1e-4, _detected_tof_law=MRT_TOF_LAW)
+        )
+        assert (a, b) == (0.1, 1e-4)
+
+    def test_explicit_bins_per_fwhm(self):
+        assert (
+            _tof_plan(self._stub(_detected_tof_law=MRT_TOF_LAW, _bins_per_fwhm=4.0))[2]
+            == 4.0
+        )
+
+    def test_width_at_reference_derives_k(self):
+        a, b, k = _tof_plan(
+            self._stub(_detected_tof_law=MRT_TOF_LAW, _width_at_mz=0.002)
+        )
+        assert k == pytest.approx(tof_fwhm_mda(1000.0, MRT_A, MRT_B) / 2.0)
+        width, ref = _reference_params(
+            self._stub(_detected_tof_law=MRT_TOF_LAW, _width_at_mz=0.002), "tof"
+        )
+        assert (width, ref) == (0.002, 1000.0)
+
+    def test_reference_params_report_the_realised_width(self):
+        width, ref = _reference_params(self._stub(_detected_tof_law=MRT_TOF_LAW), "tof")
+        assert ref == 1000.0
+        assert width == pytest.approx(tof_fwhm_mda(1000.0, MRT_A, MRT_B) * 1e-3 / 3.0)
+
+    def test_no_law_anywhere_is_an_error(self):
+        with pytest.raises(ValueError, match="--tof-a and --tof-b"):
+            _tof_plan(self._stub())
+
+    def test_bin_count_goes_through_the_generator(self):
+        stub = self._stub(_detected_tof_law=MRT_TOF_LAW)
+        bins = BaseSpatialDataConverter._calculate_bins_from_width(
+            stub, 100.0, 1000.0, AxisType.TOF
+        )
+        assert bins == TOFAxisGenerator(MRT_A, MRT_B).bin_count(100.0, 1000.0, 3.0)
+
+
+class TestConfig:
+    def test_tof_axis_and_coefficients_normalise(self):
+        cfg = _normalize_resampling_config(
+            {"axis_type": "tof", "tof_a": "0.0185", "tof_b": 9.1e-6, "bins_per_fwhm": 4}
+        )
+        assert cfg.axis_type is AxisType.TOF
+        assert cfg.tof_a == 0.0185
+        assert cfg.tof_b == 9.1e-6
+        assert cfg.bins_per_fwhm == 4.0
+
+    def test_missing_coefficients_stay_none(self):
+        cfg = _normalize_resampling_config({"axis_type": "tof"})
+        assert cfg.tof_a is None and cfg.tof_b is None and cfg.bins_per_fwhm is None
+
+
+class TestDetectors:
+    MRT_CENTROID = {
+        "format_specific": {"format": "Waters MassLynx raw", "is_mrt": True},
+        "essential_metadata": {"spectrum_type": "centroid spectrum"},
+    }
+
+    def test_mrt_centroid_gets_the_tof_law(self):
+        chain = InstrumentDetectorChain()
+        characteristics = DataCharacteristics.from_metadata(self.MRT_CENTROID)
+        assert isinstance(chain.detect(characteristics), WatersMRTCentroidDetector)
+        assert chain.get_axis_type(characteristics) is AxisType.TOF
+        assert (
+            chain.get_resampling_method(characteristics)
+            is ResamplingMethod.NEAREST_NEIGHBOR
+        )
+        assert chain.get_tof_law(characteristics) == MRT_TOF_LAW
+        assert chain.get_reference_width(characteristics) is None
+
+    def test_mrt_profile_never_reaches_it(self):
+        """The law describes peak width, not the digitiser grid."""
+        characteristics = DataCharacteristics.from_metadata(
+            {
+                **self.MRT_CENTROID,
+                "essential_metadata": {"spectrum_type": "profile spectrum"},
+            }
+        )
+        chain = InstrumentDetectorChain()
+        assert isinstance(chain.detect(characteristics), WatersProfileDetector)
+        assert chain.get_axis_type(characteristics) is AxisType.LINEAR_TOF
+        assert not WatersMRTCentroidDetector().matches(characteristics)
+
+    def test_other_waters_centroids_keep_reflector_tof(self):
+        characteristics = DataCharacteristics.from_metadata(
+            {
+                "format_specific": {"format": "Waters MassLynx raw", "is_mrt": False},
+                "essential_metadata": {"spectrum_type": "centroid spectrum"},
+            }
+        )
+        chain = InstrumentDetectorChain()
+        assert isinstance(chain.detect(characteristics), WatersDetector)
+        assert chain.get_axis_type(characteristics) is AxisType.REFLECTOR_TOF
+        assert chain.get_tof_law(characteristics) is None
+
+    def test_timstof_declares_its_pair_but_keeps_reflector_tof(self):
+        """Opt-in: --mass-axis-type tof picks the pair up; the default is unchanged."""
+        characteristics = DataCharacteristics(is_timstof=True)
+        detector = TimsTOFDetector()
+        assert detector.get_axis_type() is AxisType.REFLECTOR_TOF
+        assert detector.get_tof_law(characteristics) == TIMSTOF_TOF_LAW
+        tree = ResamplingDecisionTree()
+        metadata = {"GlobalMetadata": {"InstrumentName": "timsTOF fleX"}}
+        assert tree.select_axis_type(metadata) is AxisType.REFLECTOR_TOF
+        assert tree.select_tof_law(metadata) == TIMSTOF_TOF_LAW
+        assert tree.select_tof_law(None) is None
+
+    def test_timstof_pair_is_within_ten_percent_of_the_shipped_axis(self):
+        """So keeping reflector_tof at 5 mDa as the default loses little.
+
+        The measured law against the reflector shape, normalised at m/z
+        1000: within 7% at m/z 400 and 3% at 600. At m/z 300 the constant
+        term shows and the gap reaches 10.2%, which is why the pair is
+        opt-in rather than a silent change to every timsTOF store.
+        """
+        mz = np.array([400.0, 600.0, 1000.0])
+        widths = tof_fwhm_mda(mz, *TIMSTOF_TOF_LAW) * 1e-3 / 3.0
+        reflector = 0.005 * mz / 1000.0
+        ratio = (widths / widths[-1]) / (reflector / reflector[-1])
+        assert np.all(np.abs(ratio - 1.0) < 0.10)
+        low = tof_fwhm_mda(300.0, *TIMSTOF_TOF_LAW) / tof_fwhm_mda(
+            1000.0, *TIMSTOF_TOF_LAW
+        )
+        assert low / 0.3 == pytest.approx(1.10, abs=0.01)

--- a/tests/unit/test_cli_tof_law.py
+++ b/tests/unit/test_cli_tof_law.py
@@ -1,57 +1,60 @@
-"""``--mass-axis-type tof``, ``--tof-a``, ``--tof-b`` and ``--bins-per-fwhm``.
+"""``--mass-axis-type tof`` and ``--tof-law A B``.
 
-The CLI only transports the two-term width law; what is pinned here is the
-transport and the validation that keeps a half-specified law from reaching
-the converter.
+One flag carries the two-term width law; the bin width is not a second
+flag, because ``--resample-width-at-mz`` at the reference m/z already says
+how wide a bin is on every axis type. What is pinned here is the transport
+into the config dict and the validation that keeps a law with no width out.
 """
 
 from __future__ import annotations
 
 import click
 import pytest
+from click.testing import CliRunner
 
-from thyra.__main__ import _build_resampling_config, _validate_tof_params
+from thyra.__main__ import _build_resampling_config, _validate_tof_law, main
 
 
 class TestValidation:
-    def test_a_and_b_come_together(self):
-        with pytest.raises(click.BadParameter, match="together"):
-            _validate_tof_params(0.0185, None, None, None)
-        with pytest.raises(click.BadParameter, match="together"):
-            _validate_tof_params(None, 9.1e-6, None, None)
-
     @pytest.mark.parametrize("a, b", [(-1.0, 1e-6), (0.01, -1e-6), (0.0, 0.0)])
     def test_the_law_must_have_a_width(self, a, b):
         with pytest.raises(click.BadParameter):
-            _validate_tof_params(a, b, None, None)
+            _validate_tof_law((a, b))
 
     def test_one_limit_alone_is_fine(self):
-        _validate_tof_params(0.0, 1e-6, None, None)
-        _validate_tof_params(0.02, 0.0, None, None)
-
-    def test_bins_per_fwhm_and_width_are_exclusive(self):
-        with pytest.raises(click.BadParameter, match="mutually exclusive"):
-            _validate_tof_params(None, None, 3.0, 0.002)
-
-    def test_bins_per_fwhm_must_be_positive(self):
-        with pytest.raises(click.BadParameter):
-            _validate_tof_params(None, None, 0.0, None)
+        _validate_tof_law((0.0, 1e-6))
+        _validate_tof_law((0.02, 0.0))
 
     def test_nothing_given_is_fine(self):
-        _validate_tof_params(None, None, None, None)
+        _validate_tof_law(None)
 
 
 class TestTransport:
     def test_defaults_are_none(self):
         cfg = _build_resampling_config("auto", "auto", None, None, None, None, 1000.0)
         assert cfg["tof_a"] is None and cfg["tof_b"] is None
-        assert cfg["bins_per_fwhm"] is None
+        assert "bins_per_fwhm" not in cfg
 
-    def test_values_are_forwarded(self):
+    def test_the_pair_is_split_into_the_api_fields(self):
         cfg = _build_resampling_config(
-            "auto", "tof", None, None, None, None, 1000.0, None, 0.0185, 9.1e-6, 4.0
+            "auto", "tof", None, None, None, None, 1000.0, None, (0.0185, 9.1e-6)
         )
         assert cfg["axis_type"] == "tof"
         assert cfg["tof_a"] == 0.0185
         assert cfg["tof_b"] == 9.1e-6
-        assert cfg["bins_per_fwhm"] == 4.0
+
+    def test_the_flag_takes_two_numbers(self, tmp_path):
+        """Click rejects a lone coefficient before any conversion starts."""
+        result = CliRunner().invoke(
+            main,
+            [
+                str(tmp_path / "in.imzML"),
+                str(tmp_path / "out.zarr"),
+                "--tof-law",
+                "0.0185",
+            ],
+        )
+        assert result.exit_code != 0
+        assert (
+            "tof-law" in result.output.lower() or "2 arguments" in result.output.lower()
+        )

--- a/tests/unit/test_cli_tof_law.py
+++ b/tests/unit/test_cli_tof_law.py
@@ -1,0 +1,57 @@
+"""``--mass-axis-type tof``, ``--tof-a``, ``--tof-b`` and ``--bins-per-fwhm``.
+
+The CLI only transports the two-term width law; what is pinned here is the
+transport and the validation that keeps a half-specified law from reaching
+the converter.
+"""
+
+from __future__ import annotations
+
+import click
+import pytest
+
+from thyra.__main__ import _build_resampling_config, _validate_tof_params
+
+
+class TestValidation:
+    def test_a_and_b_come_together(self):
+        with pytest.raises(click.BadParameter, match="together"):
+            _validate_tof_params(0.0185, None, None, None)
+        with pytest.raises(click.BadParameter, match="together"):
+            _validate_tof_params(None, 9.1e-6, None, None)
+
+    @pytest.mark.parametrize("a, b", [(-1.0, 1e-6), (0.01, -1e-6), (0.0, 0.0)])
+    def test_the_law_must_have_a_width(self, a, b):
+        with pytest.raises(click.BadParameter):
+            _validate_tof_params(a, b, None, None)
+
+    def test_one_limit_alone_is_fine(self):
+        _validate_tof_params(0.0, 1e-6, None, None)
+        _validate_tof_params(0.02, 0.0, None, None)
+
+    def test_bins_per_fwhm_and_width_are_exclusive(self):
+        with pytest.raises(click.BadParameter, match="mutually exclusive"):
+            _validate_tof_params(None, None, 3.0, 0.002)
+
+    def test_bins_per_fwhm_must_be_positive(self):
+        with pytest.raises(click.BadParameter):
+            _validate_tof_params(None, None, 0.0, None)
+
+    def test_nothing_given_is_fine(self):
+        _validate_tof_params(None, None, None, None)
+
+
+class TestTransport:
+    def test_defaults_are_none(self):
+        cfg = _build_resampling_config("auto", "auto", None, None, None, None, 1000.0)
+        assert cfg["tof_a"] is None and cfg["tof_b"] is None
+        assert cfg["bins_per_fwhm"] is None
+
+    def test_values_are_forwarded(self):
+        cfg = _build_resampling_config(
+            "auto", "tof", None, None, None, None, 1000.0, None, 0.0185, 9.1e-6, 4.0
+        )
+        assert cfg["axis_type"] == "tof"
+        assert cfg["tof_a"] == 0.0185
+        assert cfg["tof_b"] == 9.1e-6
+        assert cfg["bins_per_fwhm"] == 4.0

--- a/tests/unit/test_cli_waters_spectrum.py
+++ b/tests/unit/test_cli_waters_spectrum.py
@@ -1,0 +1,28 @@
+"""``--waters-spectrum`` is a transport for ``WatersReader(use_centroid=...)``.
+
+Omitted, nothing is forwarded, and the reader decides from the instrument
+(profile on a SELECT SERIES MRT, centroid elsewhere). Given, it is
+forwarded as the reader keyword -- the negation, since the flag names the
+representation and the keyword names the peak picker.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from thyra.__main__ import _build_reader_options
+
+
+class TestBuildReaderOptions:
+    def test_omitted_is_not_forwarded(self):
+        """``use_centroid=None`` is the reader's "decide from the instrument"."""
+        assert "use_centroid" not in _build_reader_options(True, None)
+
+    @pytest.mark.parametrize(
+        "value, use_centroid", [("centroid", True), ("profile", False)]
+    )
+    def test_an_explicit_choice_is_forwarded_as_the_reader_keyword(
+        self, value, use_centroid
+    ):
+        options = _build_reader_options(True, None, waters_spectrum=value)
+        assert options["use_centroid"] is use_centroid

--- a/thyra/__main__.py
+++ b/thyra/__main__.py
@@ -6,7 +6,7 @@ import os  # noqa: E402
 import sqlite3  # noqa: E402
 import warnings  # noqa: E402
 from pathlib import Path  # noqa: E402
-from typing import Literal, Optional  # noqa: E402
+from typing import Literal, Optional, Tuple  # noqa: E402
 
 import click  # noqa: E402
 
@@ -132,36 +132,22 @@ def _validate_resampling_params(
         )
 
 
-def _validate_tof_params(
-    tof_a: Optional[float],
-    tof_b: Optional[float],
-    bins_per_fwhm: Optional[float],
-    resample_width_at_mz: Optional[float],
-) -> None:
-    """Validate the two-term TOF width-law parameters.
+def _validate_tof_law(tof_law: Optional[Tuple[float, float]]) -> None:
+    """Validate ``--tof-law A B``: both non-negative, not both zero.
 
-    ``A`` and ``B`` come as a pair, both non-negative and not both zero
-    (the law would have no width). ``--bins-per-fwhm`` and
-    ``--resample-width-at-mz`` are two spellings of the same quantity, so
-    only one may be given.
+    A pair with no width would lay no axis. The bin width itself is not a
+    separate flag: ``--resample-width-at-mz`` at ``--resample-reference-mz``
+    fixes the bins per peak width for a ``tof`` axis exactly as it fixes the
+    width of any other, and 3 bins per peak width is the default.
     """
-    if (tof_a is None) != (tof_b is None):
+    if tof_law is None:
+        return
+    a, b = tof_law
+    if a < 0 or b < 0 or (a == 0 and b == 0):
         raise click.BadParameter(
-            "--tof-a and --tof-b must be given together", param_hint="tof_a"
-        )
-    if tof_a is not None and tof_b is not None:
-        if tof_a < 0 or tof_b < 0 or (tof_a == 0 and tof_b == 0):
-            raise click.BadParameter(
-                "The TOF width law needs A >= 0 and B >= 0 with at least one "
-                "of them positive",
-                param_hint="tof_a",
-            )
-    _validate_positive_float(bins_per_fwhm, "bins_per_fwhm", "Bins per FWHM")
-    if bins_per_fwhm is not None and resample_width_at_mz is not None:
-        raise click.BadParameter(
-            "--bins-per-fwhm and --resample-width-at-mz are mutually exclusive: "
-            "both set the bin width of a 'tof' axis",
-            param_hint="bins_per_fwhm",
+            "The TOF width law needs A >= 0 and B >= 0 with at least one of "
+            "them positive",
+            param_hint="tof_law",
         )
 
 
@@ -280,11 +266,15 @@ def _build_resampling_config(
     resample_width_at_mz: Optional[float],
     resample_reference_mz: float,
     resample_gap_tolerance: Optional[float] = None,
-    tof_a: Optional[float] = None,
-    tof_b: Optional[float] = None,
-    bins_per_fwhm: Optional[float] = None,
+    tof_law: Optional[Tuple[float, float]] = None,
 ) -> dict:
-    """Build resampling configuration dictionary."""
+    """Build resampling configuration dictionary.
+
+    ``tof_law`` is the CLI's one spelling of the two-term width law; the
+    config carries it as the ``tof_a`` / ``tof_b`` pair the Python API
+    takes. ``bins_per_fwhm`` is API-only: on the command line the width at
+    the reference m/z says the same thing.
+    """
     return {
         "method": resample_method,
         "axis_type": mass_axis_type,
@@ -294,9 +284,8 @@ def _build_resampling_config(
         "width_at_mz": resample_width_at_mz,
         "reference_mz": resample_reference_mz,
         "gap_tolerance_da": resample_gap_tolerance,
-        "tof_a": tof_a,
-        "tof_b": tof_b,
-        "bins_per_fwhm": bins_per_fwhm,
+        "tof_a": None if tof_law is None else tof_law[0],
+        "tof_b": None if tof_law is None else tof_law[1],
     }
 
 
@@ -453,9 +442,7 @@ class GroupedCommand(click.Command):
             "--resample-width-at-mz",
             "--resample-reference-mz",
             "--resample-gap-tolerance",
-            "--tof-a",
-            "--tof-b",
-            "--bins-per-fwhm",
+            "--tof-law",
         ],
         "Performance": ["--streaming", "--sparse-format"],
         "imzML-specific": ["--spectrum-type"],
@@ -686,31 +673,22 @@ class GroupedCommand(click.Command):
     help=(
         "Mass axis spacing type (default: auto-detect). 'tof' lays bins at a "
         "measured peak width sqrt(A m + B m^2) mDa, of which linear_tof "
-        "(B=0) and reflector_tof (A=0) are the limits; pass --tof-a/--tof-b "
-        "or let the instrument's own pair apply (SELECT SERIES MRT centroid, "
-        "timsTOF)."
+        "(B=0) and reflector_tof (A=0) are the limits; the instrument's own "
+        "pair applies (SELECT SERIES MRT centroid, timsTOF) unless --tof-law "
+        "gives one."
     ),
 )
 @click.option(
-    "--tof-a",
+    "--tof-law",
     type=float,
+    nargs=2,
     default=None,
-    help="A of the 'tof' width law, in mDa^2/Da (MRT 0.0185, timsTOF 0.0877)",
-)
-@click.option(
-    "--tof-b",
-    type=float,
-    default=None,
-    help="B of the 'tof' width law, dimensionless (MRT 9.1e-6, timsTOF 8.74e-4)",
-)
-@click.option(
-    "--bins-per-fwhm",
-    type=float,
-    default=None,
+    metavar="A B",
     help=(
-        "For the 'tof' axis: bins per peak width (default 3). Mutually "
-        "exclusive with --resample-width-at-mz, which fixes the same thing "
-        "at the reference m/z instead."
+        "Coefficients of the 'tof' width law, A in mDa^2/Da and B "
+        "dimensionless (MRT 0.0185 9.1e-6, timsTOF 0.0877 8.74e-4). Only "
+        "needed for an instrument Thyra has no pair for. Bins per peak "
+        "width default to 3; --resample-width-at-mz sets them otherwise."
     ),
 )
 @click.option(
@@ -850,9 +828,7 @@ def main(
     resample_reference_mz: float,
     resample_gap_tolerance: Optional[float],
     mass_axis_type: str,
-    tof_a: Optional[float],
-    tof_b: Optional[float],
-    bins_per_fwhm: Optional[float],
+    tof_law: Optional[Tuple[float, float]],
     spectrum_type: str,
     sparse_format: str,
     include_optical: bool,
@@ -890,7 +866,7 @@ def main(
     _validate_positive_float(
         resample_gap_tolerance, "resample_gap_tolerance", "Gap tolerance"
     )
-    _validate_tof_params(tof_a, tof_b, bins_per_fwhm, resample_width_at_mz)
+    _validate_tof_law(tof_law)
     _validate_positive_float(
         intensity_threshold, "intensity_threshold", "Intensity threshold"
     )
@@ -930,9 +906,7 @@ def main(
             resample_width_at_mz,
             resample_reference_mz,
             resample_gap_tolerance,
-            tof_a,
-            tof_b,
-            bins_per_fwhm,
+            tof_law,
         )
         if resample
         else None

--- a/thyra/__main__.py
+++ b/thyra/__main__.py
@@ -266,6 +266,7 @@ def _build_reader_options(
     intensity_threshold: Optional[float],
     spectrum_type: str = "auto",
     tdf_spectrum: Optional[str] = None,
+    waters_spectrum: Optional[str] = None,
 ) -> dict[str, bool | float | str]:
     """Build reader options dictionary from CLI parameters.
 
@@ -274,6 +275,9 @@ def _build_reader_options(
     mean detect, and ``"auto"`` is not a representation. ``tdf_spectrum`` is
     likewise only forwarded when given: it is a Bruker TDF option, and a
     reader for any other format would reject an unexpected keyword.
+    ``waters_spectrum`` is the same for Waters .raw, and is spelled as a
+    representation rather than as ``use_centroid`` because that is what a
+    caller is choosing; the reader keyword it sets is the negation.
     """
     options: dict[str, bool | float | str] = {
         "use_recalibrated_state": use_recalibrated
@@ -284,6 +288,8 @@ def _build_reader_options(
         options["spectrum_type"] = spectrum_type
     if tdf_spectrum is not None:
         options["tdf_spectrum"] = tdf_spectrum
+    if waters_spectrum is not None:
+        options["use_centroid"] = waters_spectrum == "centroid"
     return options
 
 
@@ -418,6 +424,7 @@ class GroupedCommand(click.Command):
             "--intensity-threshold",
             "--tdf-spectrum",
         ],
+        "Waters-specific": ["--waters-spectrum"],
         "Other": ["--dataset-id", "--handle-3d", "--z-spacing"],
         "General": ["--version", "--help"],
     }
@@ -715,6 +722,19 @@ class GroupedCommand(click.Command):
         "sums every scan and keeps all of the ion current. TDF only."
     ),
 )
+# -- Waters-specific --
+@click.option(
+    "--waters-spectrum",
+    type=click.Choice(["centroid", "profile"]),
+    default=None,
+    help=(
+        "What MassLynx hands back for one Waters .raw pixel: centroid "
+        "(the default) is the vendor peak picker, which reports one "
+        "centroid where the sampled trace has two maxima a few mDa "
+        "apart; profile is that sampled trace, which keeps them apart at "
+        "the cost of a larger store. Waters .raw only."
+    ),
+)
 # -- Other --
 @click.option(
     "--dataset-id",
@@ -771,6 +791,7 @@ def main(
     msms_table: bool,
     intensity_threshold: Optional[float],
     tdf_spectrum: Optional[str],
+    waters_spectrum: Optional[str],
     streaming: str,
     region: Optional[str],
 ):
@@ -841,7 +862,11 @@ def main(
 
     # Build reader options for format-specific settings
     reader_options = _build_reader_options(
-        use_recalibrated, intensity_threshold, spectrum_type, tdf_spectrum
+        use_recalibrated,
+        intensity_threshold,
+        spectrum_type,
+        tdf_spectrum,
+        waters_spectrum,
     )
 
     # Perform conversion

--- a/thyra/__main__.py
+++ b/thyra/__main__.py
@@ -132,6 +132,39 @@ def _validate_resampling_params(
         )
 
 
+def _validate_tof_params(
+    tof_a: Optional[float],
+    tof_b: Optional[float],
+    bins_per_fwhm: Optional[float],
+    resample_width_at_mz: Optional[float],
+) -> None:
+    """Validate the two-term TOF width-law parameters.
+
+    ``A`` and ``B`` come as a pair, both non-negative and not both zero
+    (the law would have no width). ``--bins-per-fwhm`` and
+    ``--resample-width-at-mz`` are two spellings of the same quantity, so
+    only one may be given.
+    """
+    if (tof_a is None) != (tof_b is None):
+        raise click.BadParameter(
+            "--tof-a and --tof-b must be given together", param_hint="tof_a"
+        )
+    if tof_a is not None and tof_b is not None:
+        if tof_a < 0 or tof_b < 0 or (tof_a == 0 and tof_b == 0):
+            raise click.BadParameter(
+                "The TOF width law needs A >= 0 and B >= 0 with at least one "
+                "of them positive",
+                param_hint="tof_a",
+            )
+    _validate_positive_float(bins_per_fwhm, "bins_per_fwhm", "Bins per FWHM")
+    if bins_per_fwhm is not None and resample_width_at_mz is not None:
+        raise click.BadParameter(
+            "--bins-per-fwhm and --resample-width-at-mz are mutually exclusive: "
+            "both set the bin width of a 'tof' axis",
+            param_hint="bins_per_fwhm",
+        )
+
+
 def _validate_input_path(input: Path) -> None:
     """Validate input path and format requirements."""
     if not input.exists():
@@ -247,6 +280,9 @@ def _build_resampling_config(
     resample_width_at_mz: Optional[float],
     resample_reference_mz: float,
     resample_gap_tolerance: Optional[float] = None,
+    tof_a: Optional[float] = None,
+    tof_b: Optional[float] = None,
+    bins_per_fwhm: Optional[float] = None,
 ) -> dict:
     """Build resampling configuration dictionary."""
     return {
@@ -258,6 +294,9 @@ def _build_resampling_config(
         "width_at_mz": resample_width_at_mz,
         "reference_mz": resample_reference_mz,
         "gap_tolerance_da": resample_gap_tolerance,
+        "tof_a": tof_a,
+        "tof_b": tof_b,
+        "bins_per_fwhm": bins_per_fwhm,
     }
 
 
@@ -414,6 +453,9 @@ class GroupedCommand(click.Command):
             "--resample-width-at-mz",
             "--resample-reference-mz",
             "--resample-gap-tolerance",
+            "--tof-a",
+            "--tof-b",
+            "--bins-per-fwhm",
         ],
         "Performance": ["--streaming", "--sparse-format"],
         "imzML-specific": ["--spectrum-type"],
@@ -638,10 +680,38 @@ class GroupedCommand(click.Command):
 @click.option(
     "--mass-axis-type",
     type=click.Choice(
-        ["auto", "constant", "linear_tof", "reflector_tof", "orbitrap", "fticr"]
+        ["auto", "constant", "linear_tof", "reflector_tof", "tof", "orbitrap", "fticr"]
     ),
     default="auto",
-    help="Mass axis spacing type (default: auto-detect)",
+    help=(
+        "Mass axis spacing type (default: auto-detect). 'tof' lays bins at a "
+        "measured peak width sqrt(A m + B m^2) mDa, of which linear_tof "
+        "(B=0) and reflector_tof (A=0) are the limits; pass --tof-a/--tof-b "
+        "or let the instrument's own pair apply (SELECT SERIES MRT centroid, "
+        "timsTOF)."
+    ),
+)
+@click.option(
+    "--tof-a",
+    type=float,
+    default=None,
+    help="A of the 'tof' width law, in mDa^2/Da (MRT 0.0185, timsTOF 0.0877)",
+)
+@click.option(
+    "--tof-b",
+    type=float,
+    default=None,
+    help="B of the 'tof' width law, dimensionless (MRT 9.1e-6, timsTOF 8.74e-4)",
+)
+@click.option(
+    "--bins-per-fwhm",
+    type=float,
+    default=None,
+    help=(
+        "For the 'tof' axis: bins per peak width (default 3). Mutually "
+        "exclusive with --resample-width-at-mz, which fixes the same thing "
+        "at the reference m/z instead."
+    ),
 )
 @click.option(
     "--resample-bins",
@@ -728,11 +798,12 @@ class GroupedCommand(click.Command):
     type=click.Choice(["centroid", "profile"]),
     default=None,
     help=(
-        "What MassLynx hands back for one Waters .raw pixel: centroid "
-        "(the default) is the vendor peak picker, which reports one "
-        "centroid where the sampled trace has two maxima a few mDa "
-        "apart; profile is that sampled trace, which keeps them apart at "
-        "the cost of a larger store. Waters .raw only."
+        "What MassLynx hands back for one Waters .raw pixel: centroid is "
+        "the vendor peak picker, which reports one centroid where the "
+        "sampled trace has two maxima a few mDa apart; profile is that "
+        "sampled trace, which keeps them apart at the cost of a larger "
+        "store. The default is profile on a SELECT SERIES MRT and centroid "
+        "on every other Waters instrument. Waters .raw only."
     ),
 )
 # -- Other --
@@ -779,6 +850,9 @@ def main(
     resample_reference_mz: float,
     resample_gap_tolerance: Optional[float],
     mass_axis_type: str,
+    tof_a: Optional[float],
+    tof_b: Optional[float],
+    bins_per_fwhm: Optional[float],
     spectrum_type: str,
     sparse_format: str,
     include_optical: bool,
@@ -816,6 +890,7 @@ def main(
     _validate_positive_float(
         resample_gap_tolerance, "resample_gap_tolerance", "Gap tolerance"
     )
+    _validate_tof_params(tof_a, tof_b, bins_per_fwhm, resample_width_at_mz)
     _validate_positive_float(
         intensity_threshold, "intensity_threshold", "Intensity threshold"
     )
@@ -855,6 +930,9 @@ def main(
             resample_width_at_mz,
             resample_reference_mz,
             resample_gap_tolerance,
+            tof_a,
+            tof_b,
+            bins_per_fwhm,
         )
         if resample
         else None

--- a/thyra/convert.py
+++ b/thyra/convert.py
@@ -392,6 +392,11 @@ def convert_msi(
             - tdf_spectrum: "vendor_centroid" | "scan_sum" - For Bruker
               TDF (TIMS) data, how a frame's mobility scans are collapsed
               into one spectrum per pixel (default "vendor_centroid").
+            - use_centroid: bool - For Waters .raw, whether MassLynx
+              hands back the vendor centroid (True) or the profile
+              trace (False). Default None: the profile trace on a
+              SELECT SERIES MRT, the vendor centroid on every other
+              Waters instrument. The CLI spells it --waters-spectrum.
         **kwargs: Forwarded to the converter. ``write_mobility_table``
             (default True) writes the mobility-resolved sibling table when
             the source shares one set of (m/z, mobility) features across

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -18,6 +18,10 @@ from ...core.base_reader import BaseMSIReader
 from ...metadata.types import ComprehensiveMetadata, EssentialMetadata
 from ...resampling import ResamplingDecisionTree, ResamplingMethod
 from ...resampling.gaps import zero_across_gaps
+from ...resampling.mass_axis.tof_generator import (
+    DEFAULT_BINS_PER_FWHM,
+    TOFAxisGenerator,
+)
 from ...resampling.mobility_grid import (
     MOBILITY_CHANNELS,
     MobilityGrid,
@@ -25,7 +29,7 @@ from ...resampling.mobility_grid import (
     report_channel_width,
 )
 from ...resampling.tic import preserved_tic, rescale_to_preserved_tic
-from ...resampling.types import ResamplingConfig
+from ...resampling.types import AxisType, ResamplingConfig
 from ...utils.zarr_atomic_write import install_windows_atomic_write_retry
 from ._chunking import image_chunks, table_write_config
 
@@ -169,11 +173,16 @@ def _normalize_resampling_config(
         "constant": AxisType.CONSTANT,
         "linear_tof": AxisType.LINEAR_TOF,
         "reflector_tof": AxisType.REFLECTOR_TOF,
+        "tof": AxisType.TOF,
         "orbitrap": AxisType.ORBITRAP,
         "fticr": AxisType.FTICR,
     }
 
     reference_mz = config.get("reference_mz")
+
+    def _optional_float(key: str) -> Optional[float]:
+        value = config.get(key)
+        return None if value is None else float(value)
 
     return ResamplingConfig(
         method=_resolve_config_enum(config.get("method"), method_by_name, "method"),
@@ -188,6 +197,9 @@ def _normalize_resampling_config(
         min_mz=config.get("min_mz"),
         max_mz=config.get("max_mz"),
         gap_tolerance_da=config.get("gap_tolerance_da"),
+        tof_a=_optional_float("tof_a"),
+        tof_b=_optional_float("tof_b"),
+        bins_per_fwhm=_optional_float("bins_per_fwhm"),
     )
 
 
@@ -444,6 +456,211 @@ def _nn_accumulate(
     return nonzero_indices, nonzero_values.astype(np.float64)
 
 
+def _reference_params(converter: Any, axis_name: str) -> Tuple[float, float]:
+    """``(width_da, reference_mz)`` for the axis about to be built.
+
+    Precedence: the caller's ``--resample-width-at-mz`` /
+    ``--resample-reference-mz``; then the width the detected instrument
+    declared (``_detected_reference_width``, set on the auto path only);
+    then the per-axis-type default -- 17 mDa at m/z 300 for ``linear_tof``,
+    chosen to be close to the axis SCiLS Lab produces for FlexImaging data,
+    and 5 mDa at m/z 1000 for everything else.
+
+    Module-level so that ``_calculate_bins_from_width`` and
+    ``_get_reference_params`` cannot drift apart, and so that either can be
+    driven on a bare stub carrying only the three attributes.
+    """
+    if converter._width_at_mz is not None:
+        return converter._width_at_mz, converter._reference_mz
+    if axis_name == "tof":
+        # The law and the bins-per-FWHM fix the width everywhere; report
+        # the one realised at the reference m/z.
+        a, b, k = _tof_plan(converter)
+        reference_mz = float(converter._reference_mz)
+        return float(TOFAxisGenerator(a, b).bin_width_at(reference_mz, k)), reference_mz
+    detected = getattr(converter, "_detected_reference_width", None)
+    if detected is not None:
+        return float(detected[0]), float(detected[1])
+    if axis_name == "linear_tof":
+        return 0.017, 300.0
+    return 0.005, 1000.0
+
+
+def _tof_plan(converter: Any) -> Tuple[float, float, float]:
+    """``(A, B, bins_per_fwhm)`` for an ``AxisType.TOF`` axis.
+
+    The law is the caller's ``tof_a``/``tof_b`` pair, else the pair the
+    detected instrument declared (``_detected_tof_law``). ``bins_per_fwhm``
+    is derived from ``--resample-width-at-mz`` at the reference m/z when
+    that was given, so the two parameterisations are interchangeable;
+    otherwise it is the caller's ``--bins-per-fwhm``, else 3.
+    """
+    a = getattr(converter, "_tof_a", None)
+    b = getattr(converter, "_tof_b", None)
+    if a is None or b is None:
+        law = getattr(converter, "_detected_tof_law", None)
+        if law is None:
+            raise ValueError(
+                "A 'tof' mass axis needs the width law's coefficients: pass "
+                "--tof-a and --tof-b, or convert a run whose instrument "
+                "declares them (SELECT SERIES MRT centroid, timsTOF)."
+            )
+        a, b = law
+    generator = TOFAxisGenerator(float(a), float(b))
+    if converter._width_at_mz is not None:
+        k = generator.bins_per_fwhm_for(
+            float(converter._reference_mz), float(converter._width_at_mz)
+        )
+    else:
+        k = getattr(converter, "_bins_per_fwhm", None)
+        if k is None:
+            k = DEFAULT_BINS_PER_FWHM
+    return float(a), float(b), float(k)
+
+
+def _tic_support_bins(
+    axis: NDArray[np.float64],
+    mzs: NDArray[np.float64],
+    intensities: NDArray[np.float64],
+) -> NDArray[np.int_]:
+    """Axis indices at which the linear interpolant of a spectrum can be non-zero.
+
+    ``np.interp`` draws straight lines between consecutive source points, so
+    the interpolant is non-zero only on segments with a non-zero endpoint.
+    Consecutive non-zero samples form runs; each run's support is the open
+    interval from the sample before it to the sample after it (those two are
+    where the trace touches zero), closed at the spectrum's own ends where
+    there is no such neighbour. Runs are separated by at least one zero
+    sample, so their supports never overlap and the indices come out sorted.
+
+    A zero-suppressed profile -- Waters MassLynx stores samples in clusters
+    around each peak with an explicit zero at either edge -- has supports
+    covering a small fraction of a fine axis, which is what makes the sparse
+    evaluation cheap. A spectrum with no zeros in it is one run, and its
+    support is every axis point the dense evaluation would have populated.
+
+    Args:
+        axis: Target mass axis, ascending.
+        mzs: Source m/z values, ascending.
+        intensities: Source intensities, parallel to ``mzs``.
+
+    Returns:
+        Sorted, unique axis indices. Empty when nothing is non-zero.
+    """
+    nonzero = intensities != 0
+    if not nonzero.any():
+        return np.array([], dtype=np.int_)
+
+    last = mzs.size - 1
+    edges = np.diff(np.concatenate(([False], nonzero, [False])).astype(np.int8))
+    starts = np.flatnonzero(edges == 1)
+    ends = np.flatnonzero(edges == -1) - 1
+
+    # Open at a neighbouring zero sample (the interpolant is exactly zero
+    # there), closed at the spectrum's own first or last sample.
+    lo = np.where(
+        starts == 0,
+        np.searchsorted(axis, mzs[0], side="left"),
+        np.searchsorted(axis, mzs[np.maximum(starts - 1, 0)], side="right"),
+    )
+    hi = np.where(
+        ends == last,
+        np.searchsorted(axis, mzs[last], side="right"),
+        np.searchsorted(axis, mzs[np.minimum(ends + 1, last)], side="left"),
+    )
+
+    lengths = hi - lo
+    keep = lengths > 0
+    if not keep.any():
+        return np.array([], dtype=np.int_)
+    lo = lo[keep]
+    lengths = lengths[keep]
+    offsets = np.cumsum(lengths) - lengths
+    total = int(lengths.sum())
+    return np.repeat(lo - offsets, lengths) + np.arange(total, dtype=np.int_)
+
+
+def _tic_preserving_sparse(
+    axis: NDArray[np.float64],
+    mzs: NDArray[np.float64],
+    intensities: NDArray[np.float64],
+    gap_tolerance_da: Optional[float],
+) -> Tuple[NDArray[np.int_], NDArray[np.float64]]:
+    """TIC-preserving resampling, evaluated only where it can be non-zero.
+
+    This is the operator ``BaseSpatialDataConverter._tic_preserving_resample``
+    documents -- interpolate onto the axis, zero unsupported bins, rescale to
+    the preserved TIC -- restricted to the axis points
+    :func:`_tic_support_bins` reports. Every other axis point interpolates
+    to exactly zero, so scattering the result into a zero array reproduces
+    the dense evaluation bin for bin; the sole difference is the order in
+    which the rescale sums its terms.
+
+    Measured on a Waters SELECT SERIES MRT run (13,398 pixels, ~15,000
+    stored samples per strong pixel, 1.05M-bin axis): the dense form cost
+    570 s against 16 s for nearest-neighbour binning, almost all of it in
+    interpolating onto and then scanning a million bins per pixel of which
+    ~13,000 were ever non-zero.
+
+    Args:
+        axis: Target mass axis, ascending.
+        mzs: Source m/z values, any order.
+        intensities: Source intensities, parallel to ``mzs``.
+        gap_tolerance_da: See :func:`thyra.resampling.gaps.zero_across_gaps`.
+
+    Returns:
+        ``(bin_indices, intensities)`` holding only the non-zero bins,
+        indices ascending.
+    """
+    empty = (np.array([], dtype=np.int_), np.array([], dtype=np.float64))
+    if mzs.size == 0:
+        return empty
+
+    if np.all(mzs[:-1] <= mzs[1:]):
+        mzs_sorted = mzs
+        intensities_sorted = intensities
+    else:
+        order = np.argsort(mzs)
+        mzs_sorted = mzs[order]
+        intensities_sorted = intensities[order]
+
+    if mzs_sorted.size == 1:
+        # np.interp cannot interpolate a lone point onto a grid that does
+        # not contain it -- it would return all zeros and lose the peak.
+        # Place it in its nearest bin, as the nearest_neighbor path and
+        # TICPreservingStrategy both do.
+        target_tic = preserved_tic(
+            mzs_sorted, intensities_sorted, float(axis[0]), float(axis[-1])
+        )
+        if target_tic <= 0.0:
+            return empty
+        nearest = int(np.argmin(np.abs(axis - mzs_sorted[0])))
+        return (
+            np.array([nearest], dtype=np.int_),
+            np.array([target_tic], dtype=np.float64),
+        )
+
+    indices = _tic_support_bins(axis, mzs_sorted, intensities_sorted)
+    if indices.size == 0:
+        return empty
+
+    targets = axis[indices]
+    values = np.interp(targets, mzs_sorted, intensities_sorted, left=0.0, right=0.0)
+
+    # Discard bins no source point vouches for, before the rescale so the
+    # intensity returns to the bins that were measured rather than being
+    # deleted. No-op when no tolerance was configured.
+    zero_across_gaps(values, targets, mzs_sorted, gap_tolerance_da)
+
+    # Rescale to the required TIC -- the step that makes the method live up
+    # to its name. Reads only the axis endpoints and the sum of ``values``,
+    # so the subset evaluation rescales exactly as the dense one would.
+    rescale_to_preserved_tic(values, axis, mzs_sorted, intensities_sorted)
+
+    keep = values != 0
+    return indices[keep], values[keep]
+
+
 class _SharedAxisNNCache:
     """Precomputed nearest-neighbor mapping for one recurring m/z array.
 
@@ -677,6 +894,21 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 f"sparse_format must be 'csc' or 'csr', got '{sparse_format}'"
             )
 
+        # Metadata caches (populated lazily during conversion). These have
+        # to exist before _setup_resampling below: its strategy selection
+        # extracts the reader's metadata through them, and every extractor
+        # swallows failures at DEBUG. With the caches assigned after it,
+        # that first extraction hit AttributeError on every field, the
+        # decision tree saw an empty dict, and *every* reader's method was
+        # chosen by DefaultDetector -- nearest_neighbor -- while the axis
+        # type, resolved later on the properly cached metadata, came from
+        # the right detector. Nothing noticed while the detectors agreed;
+        # the Waters profile route is the first to ask for tic_preserving.
+        self._essential_metadata_cached: Optional[EssentialMetadata] = None
+        self._comprehensive_metadata_cached: Optional[ComprehensiveMetadata] = None
+        self._spectrum_metadata_cached: Optional[Dict[str, Any]] = None
+        self._resampling_metadata_cached: Optional[Dict[str, Any]] = None
+
         # Set up resampling if enabled
         if self._resampling_config:
             self._setup_resampling()
@@ -706,12 +938,6 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         # still have to be streamed into the store once it is written. See
         # optical_image.py and _stream_pending_optical_pixels().
         self._pending_optical_images: Dict[str, "StreamedOpticalImage"] = {}
-
-        # Metadata caches (populated lazily during conversion)
-        self._essential_metadata_cached: Optional[EssentialMetadata] = None
-        self._comprehensive_metadata_cached: Optional[ComprehensiveMetadata] = None
-        self._spectrum_metadata_cached: Optional[Dict[str, Any]] = None
-        self._resampling_metadata_cached: Optional[Dict[str, Any]] = None
 
     def _setup_resampling(self) -> None:
         """Set up resampling configuration and strategy."""
@@ -750,6 +976,15 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         self._max_mz = config.max_mz
         self._width_at_mz = config.mass_width_da
         self._reference_mz = config.reference_mz
+        # Filled by _resolve_resampling_plan when the detected instrument
+        # declares a bin width and the caller set none.
+        self._detected_reference_width: Optional[Tuple[float, float]] = None
+        # The two-term TOF width law (AxisType.TOF): the caller's pair, or
+        # the detected instrument's when the axis resolves to TOF without one.
+        self._tof_a = config.tof_a
+        self._tof_b = config.tof_b
+        self._bins_per_fwhm = config.bins_per_fwhm
+        self._detected_tof_law: Optional[Tuple[float, float]] = None
         self._gap_tolerance_da = config.gap_tolerance_da
         if self._gap_tolerance_da is not None:
             logger.info(
@@ -1811,20 +2046,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         else:
             axis_name = str(axis_type).split(".")[-1].lower()
 
-        if self._width_at_mz is None:
-            # Use axis-type-specific defaults for optimal resolution
-            if axis_name == "linear_tof":
-                # LINEAR_TOF (FlexImaging): Use SCiLS-like default ~17 mDa at m/z 300
-                # This matches typical MALDI-TOF resolution and gives ~30k bins
-                width_at_mz = 0.017  # 17.0 mDa in Da
-                reference_mz = 300.0
-            else:
-                # Default for other axis types: 5.0 mDa at m/z 1000
-                width_at_mz = 0.005  # 5.0 mDa in Da
-                reference_mz = 1000.0
-        else:
-            width_at_mz = self._width_at_mz
-            reference_mz = self._reference_mz
+        width_at_mz, reference_mz = _reference_params(self, axis_name)
 
         logger.info(
             f"Calculating bins for {width_at_mz*1000:.1f} mDa width at m/z {reference_mz:.1f}"
@@ -1836,6 +2058,18 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             # For logarithmic spacing: bins ≈ ln(max_mz/min_mz) * (reference_mz / width_at_mz)
             relative_resolution = reference_mz / width_at_mz
             bins = int(np.log(max_mz / min_mz) * relative_resolution)
+
+        elif axis_name == "tof":
+            # TOF: bin width = sqrt(A m + B m^2) / k. The generator carries
+            # the closed-form integral of 1 / width, so the count is exact.
+            a, b, k = _tof_plan(self)
+            bins = TOFAxisGenerator(a, b).bin_count(min_mz, max_mz, k)
+            logger.info(
+                "TOF width law A=%.4g mDa^2/Da, B=%.4g, %.2f bins per FWHM",
+                a,
+                b,
+                k,
+            )
 
         elif axis_name == "linear_tof":
             # LINEAR_TOF: bin width = k * sqrt(m/z), where k = width_at_mz / sqrt(reference_mz)
@@ -1881,23 +2115,14 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
     def _get_reference_params(self, axis_type) -> Tuple[float, float]:
         """Get reference width and m/z for the given axis type.
 
-        Returns axis-type-specific defaults if user didn't specify.
+        Explicit setting first, then the width the detected instrument
+        asked for, then the axis-type default; see :func:`_reference_params`.
         """
-        if self._width_at_mz is not None:
-            return self._width_at_mz, self._reference_mz
-
-        # Get axis name for default selection
         if hasattr(axis_type, "value"):
             axis_name = axis_type.value
         else:
             axis_name = str(axis_type).split(".")[-1].lower()
-
-        # Use axis-type-specific defaults
-        if axis_name == "linear_tof":
-            # LINEAR_TOF (FlexImaging): Use SCiLS-like default ~17 mDa at m/z 300
-            return 0.017, 300.0
-        # Default for other axis types: 5.0 mDa at m/z 1000
-        return 0.005, 1000.0
+        return _reference_params(self, axis_name)
 
     def _resolve_resampling_plan(
         self,
@@ -1917,12 +2142,38 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         min_mz = mass_range[0] if self._min_mz is None else self._min_mz
         max_mz = mass_range[1] if self._max_mz is None else self._max_mz
 
+        tree = ResamplingDecisionTree()
         if hasattr(self, "_manual_axis_type") and self._manual_axis_type is not None:
             axis_type = self._manual_axis_type
         else:
             metadata = self._get_cached_metadata_for_resampling()
-            tree = ResamplingDecisionTree()
             axis_type = tree.select_axis_type(metadata)
+            # A detector's width goes with the axis law it chose, so it is
+            # consulted only on the auto path and only when the caller has
+            # not set a width of their own.
+            if self._width_at_mz is None:
+                self._detected_reference_width = tree.select_reference_width(metadata)
+
+        # A TOF axis without the caller's own coefficients takes the pair
+        # the instrument declares -- on the auto path (an MRT centroid
+        # conversion) and when --mass-axis-type tof was asked for by name
+        # (a timsTOF opting in).
+        if axis_type is AxisType.TOF and (
+            getattr(self, "_tof_a", None) is None
+            or getattr(self, "_tof_b", None) is None
+        ):
+            self._detected_tof_law = tree.select_tof_law(
+                self._get_cached_metadata_for_resampling()
+            )
+        elif (
+            axis_type is not AxisType.TOF and getattr(self, "_tof_a", None) is not None
+        ):
+            logger.warning(
+                "--tof-a/--tof-b were given but the mass axis resolved to %s, "
+                "which does not use a width law; they are ignored. Pass "
+                "--mass-axis-type tof to use them.",
+                getattr(axis_type, "value", axis_type),
+            )
 
         if self._width_at_mz is not None or self._target_bins is None:
             target_bins = self._calculate_bins_from_width(min_mz, max_mz, axis_type)
@@ -1937,17 +2188,29 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
 
         min_mz, max_mz, axis_type, target_bins = self._resolve_resampling_plan()
 
+        # Determine reference parameters for physics generators
+        reference_width, reference_mz = self._get_reference_params(axis_type)
+
         # Kept for provenance: the processing step must declare what was
         # actually done, and with "auto" settings the requested config
-        # says nothing about the method and axis the decision tree
-        # resolved to.  See _processing_provenance().
+        # says nothing about the method, axis and bin width the decision
+        # tree resolved to.  See _processing_provenance().
         self._resolved_resampling_plan = {
             "method": getattr(self, "_resampling_method", None),
             "axis_type": axis_type,
             "target_bins": target_bins,
             "min_mz": min_mz,
             "max_mz": max_mz,
+            "mass_width_da": reference_width,
+            "reference_mz": reference_mz,
         }
+        tof_law: Optional[Tuple[float, float]] = None
+        if axis_type is AxisType.TOF:
+            a, b, k = _tof_plan(self)
+            tof_law = (a, b)
+            self._resolved_resampling_plan.update(
+                {"tof_a": a, "tof_b": b, "bins_per_fwhm": k}
+            )
 
         if hasattr(self, "_manual_axis_type") and self._manual_axis_type is not None:
             logger.info(f"Using manually specified axis type: {axis_type}")
@@ -1962,9 +2225,6 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         # Build the physics-based axis
         builder = CommonAxisBuilder()
 
-        # Determine reference parameters for physics generators
-        reference_width, reference_mz = self._get_reference_params(axis_type)
-
         if hasattr(axis_type, "value") and axis_type.value != "constant":
             # Use physics-based generator with reference parameters
             mass_axis = builder.build_physics_axis(
@@ -1974,6 +2234,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 axis_type=axis_type,
                 reference_mz=reference_mz,
                 reference_width=reference_width,
+                tof_law=tof_law,
             )
             logger.info(
                 f"Built physics-based {axis_type} mass axis with "
@@ -2221,14 +2482,15 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                     f"sum: {np.sum(resampled_intensities):.2e}"
                 )
             else:
-                # Dense path for other methods (TIC-preserving, etc.)
-                resampled_intensities = self._resample_spectrum(mzs, intensities)
-                # Use cached indices instead of creating new array every time
-                if self._cached_mass_axis_indices is None:
-                    raise RuntimeError("Cached mass axis indices are not initialized")
-                mz_indices = self._cached_mass_axis_indices
+                # TIC-preserving, in its sparse form: only the bins under
+                # the source's clusters are evaluated, which on a
+                # zero-suppressed profile is a small fraction of the axis.
+                mz_indices, resampled_intensities = (
+                    self._tic_preserving_resample_sparse(mzs, intensities)
+                )
                 logger.debug(
-                    f"Resampled: {len(resampled_intensities)} values, "
+                    f"Resampled (sparse, TIC-preserving): "
+                    f"{len(resampled_intensities)} non-zero bins, "
                     f"sum: {np.sum(resampled_intensities):.2e}"
                 )
 
@@ -2499,55 +2761,35 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             raise RuntimeError("Common mass axis is not initialized")
 
         axis = self._common_mass_axis
-        if mzs.size == 0:
-            return np.zeros(len(axis))
-
-        # OPTIMIZED: Check if already sorted to avoid unnecessary sorting
-        if np.all(mzs[:-1] <= mzs[1:]):
-            # Already sorted - use directly
-            mzs_sorted = mzs
-            intensities_sorted = intensities
-        else:
-            # Need to sort for interpolation
-            sort_indices = np.argsort(mzs)
-            mzs_sorted = mzs[sort_indices]
-            intensities_sorted = intensities[sort_indices]
-
-        if mzs_sorted.size == 1:
-            # np.interp cannot interpolate a lone point onto a grid that
-            # does not contain it -- it would return all zeros and lose the
-            # peak. Place it in its nearest bin, as the nearest_neighbor
-            # path and TICPreservingStrategy both do.
-            resampled = np.zeros(len(axis))
-            target_tic = preserved_tic(
-                mzs_sorted, intensities_sorted, float(axis[0]), float(axis[-1])
-            )
-            if target_tic > 0.0:
-                resampled[int(np.argmin(np.abs(axis - mzs_sorted[0])))] = target_tic
-            return resampled
-
-        # Interpolate onto the common mass axis (np.interp is highly optimized)
-        resampled = np.interp(
-            axis,
-            mzs_sorted,
-            intensities_sorted,
-            left=0,
-            right=0,
+        indices, values = _tic_preserving_sparse(
+            axis, mzs, intensities, getattr(self, "_gap_tolerance_da", None)
         )
+        resampled = np.zeros(len(axis))
+        resampled[indices] = values
+        return resampled
 
-        # Discard bins no source point vouches for, before the rescale so the
-        # intensity returns to the bins that were measured rather than being
-        # deleted. No-op when no tolerance was configured.
-        zero_across_gaps(
-            resampled,
-            axis,
-            mzs_sorted,
+    def _tic_preserving_resample_sparse(
+        self, mzs: NDArray[np.float64], intensities: NDArray[np.float64]
+    ) -> Tuple[NDArray[np.int_], NDArray[np.float64]]:
+        """The sparse form of :meth:`_tic_preserving_resample`.
+
+        Same operator, same numbers: only the axis points the interpolant
+        can be non-zero at are evaluated, and only the non-zero results are
+        returned, as ``(bin_indices, intensities)`` the way the
+        nearest-neighbour path does. On a zero-suppressed profile source --
+        a Waters MRT pixel stores ~15,000 samples in clusters around its
+        peaks, on a 1.05M-bin axis -- this is what turns a 570 s conversion
+        into one that is bounded by reading the file. See
+        :func:`_tic_preserving_sparse`.
+        """
+        if self._common_mass_axis is None:
+            raise RuntimeError("Common mass axis is not initialized")
+        return _tic_preserving_sparse(
+            self._common_mass_axis,
+            mzs,
+            intensities,
             getattr(self, "_gap_tolerance_da", None),
         )
-
-        # Rescale to the required TIC. This is the step that makes the
-        # method live up to its name.
-        return rescale_to_preserved_tic(resampled, axis, mzs_sorted, intensities_sorted)
 
     def _process_resampled_spectrum(
         self,

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -492,8 +492,8 @@ def _tof_plan(converter: Any) -> Tuple[float, float, float]:
     The law is the caller's ``tof_a``/``tof_b`` pair, else the pair the
     detected instrument declared (``_detected_tof_law``). ``bins_per_fwhm``
     is derived from ``--resample-width-at-mz`` at the reference m/z when
-    that was given, so the two parameterisations are interchangeable;
-    otherwise it is the caller's ``--bins-per-fwhm``, else 3.
+    that was given, so the width flag means the same thing on every axis
+    type; otherwise it is the API's ``bins_per_fwhm``, else 3.
     """
     a = getattr(converter, "_tof_a", None)
     b = getattr(converter, "_tof_b", None)
@@ -502,8 +502,8 @@ def _tof_plan(converter: Any) -> Tuple[float, float, float]:
         if law is None:
             raise ValueError(
                 "A 'tof' mass axis needs the width law's coefficients: pass "
-                "--tof-a and --tof-b, or convert a run whose instrument "
-                "declares them (SELECT SERIES MRT centroid, timsTOF)."
+                "--tof-law A B, or convert a run whose instrument declares "
+                "them (SELECT SERIES MRT centroid, timsTOF)."
             )
         a, b = law
     generator = TOFAxisGenerator(float(a), float(b))
@@ -2169,9 +2169,9 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             axis_type is not AxisType.TOF and getattr(self, "_tof_a", None) is not None
         ):
             logger.warning(
-                "--tof-a/--tof-b were given but the mass axis resolved to %s, "
-                "which does not use a width law; they are ignored. Pass "
-                "--mass-axis-type tof to use them.",
+                "--tof-law was given but the mass axis resolved to %s, which "
+                "does not use a width law; it is ignored. Pass "
+                "--mass-axis-type tof to use it.",
                 getattr(axis_type, "value", axis_type),
             )
 

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -805,15 +805,11 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         if self._nn_route:
             return self._nearest_neighbor_resample(mzs, intensities)
 
-        # Fallback: general resampling with zero filtering
-        resampled_ints = self._resample_spectrum(mzs, intensities)
-        if self._common_mass_axis is None:
-            raise RuntimeError("Common mass axis not initialized")
-        mz_indices = self._cached_mass_axis_indices
-        if mz_indices is None or mz_indices.size != len(self._common_mass_axis):
-            mz_indices = np.arange(len(self._common_mass_axis))
-        mask = resampled_ints != 0
-        return mz_indices[mask], resampled_ints[mask]
+        # TIC-preserving, evaluated only where the interpolant can be
+        # non-zero and returned already zero-filtered. On a zero-suppressed
+        # profile source the dense form of this call -- interpolate onto
+        # every bin, then mask -- was 35x the cost of reading the file.
+        return self._tic_preserving_resample_sparse(mzs, intensities)
 
     def _create_data_structures_from_coo(
         self, coo_result: Dict[str, Any]

--- a/thyra/metadata/extractors/waters_extractor.py
+++ b/thyra/metadata/extractors/waters_extractor.py
@@ -14,9 +14,11 @@ from numpy.typing import NDArray
 from tqdm import tqdm
 
 from ...core.base_extractor import MetadataExtractor
+from ...resampling.constants import SpectrumType
 from ..types import ComprehensiveMetadata, EssentialMetadata
 
 if TYPE_CHECKING:
+    from ...readers.waters.instrument import WatersInstrument
     from ...readers.waters.masslynx_lib import MassLynxLib
 
 logger = logging.getLogger(__name__)
@@ -38,6 +40,8 @@ class WatersMetadataExtractor(MetadataExtractor):
         imaging_grid,  # ImagingGrid instance
         function_types: Dict[int, Any],
         ms_functions: List[int],
+        instrument: Optional["WatersInstrument"] = None,
+        use_centroid: bool = True,
     ):
         """Initialize Waters metadata extractor.
 
@@ -48,6 +52,15 @@ class WatersMetadataExtractor(MetadataExtractor):
             imaging_grid: Pre-built ImagingGrid with spatial metadata.
             function_types: Map of function index to FunctionType.
             ms_functions: List of MS function indices.
+            instrument: What the run's side files say about the analyser,
+                from :func:`thyra.readers.waters.instrument.identify_waters_instrument`.
+                ``None`` reports nothing instrument-specific.
+            use_centroid: Whether the reader that owns ``handle`` delivers
+                the vendor centroid (``True``) or the profile trace. The
+                representation reported in the essential metadata is the
+                one the reader *delivers*, not the one the file was
+                acquired in: downstream axis and method selection act on
+                the spectra they will actually receive.
         """
         super().__init__(ml)
         self._ml = ml
@@ -56,6 +69,8 @@ class WatersMetadataExtractor(MetadataExtractor):
         self._imaging_grid = imaging_grid
         self._function_types = function_types
         self._ms_functions = ms_functions
+        self._instrument = instrument
+        self._use_centroid = use_centroid
 
     def _extract_essential_impl(self) -> EssentialMetadata:
         """Extract essential metadata.
@@ -80,9 +95,10 @@ class WatersMetadataExtractor(MetadataExtractor):
             pixel_size = (grid.pixel_size_x, grid.pixel_size_y)
 
         # Scan all MS spectra for mass range, spectrum count, peak counts
-        mass_range, n_spectra, total_peaks, peak_counts = self._scan_all_ms_spectra(
+        observed_range, n_spectra, total_peaks, peak_counts = self._scan_all_ms_spectra(
             dimensions
         )
+        mass_range = self._axis_mass_range(observed_range)
 
         # Memory estimate: total_peaks * 2 values (mz + intensity) * 8 bytes
         estimated_memory_gb = (total_peaks * 2 * 8) / (1024**3)
@@ -103,16 +119,86 @@ class WatersMetadataExtractor(MetadataExtractor):
             peak_counts_per_pixel=peak_counts,
         )
 
-    def _detect_spectrum_type(self) -> Optional[str]:
-        """Detect whether data is centroid or profile."""
-        if self._ms_functions:
-            is_profile = self._ml.is_raw_spectrum_profile(
-                self._handle, self._ms_functions[0]
+    def _axis_mass_range(self, observed: Tuple[float, float]) -> Tuple[float, float]:
+        """The range the resampled axis is built over.
+
+        The acquisition setting (``getAcquisitionRangeStart/End``, e.g.
+        100-1000) rather than the span of the stored values (100.007-1000.000
+        on the reference MRT run), so that two runs acquired with the same
+        method land on the same generated axis and share bins -- the same
+        rule the timsTOF route follows with ``MzAcqRangeLower/Upper``. The
+        stored span alone would differ from run to run by whatever the
+        first and last stored samples happened to be.
+
+        Falls back to the stored span when no MS function reports an
+        acquisition range, or when a stored value lies outside it, since a
+        range that drops measured data is worse than one that varies.
+        """
+        acquired = [
+            r
+            for r in (
+                self._ml.get_acquisition_range(self._handle, f)
+                for f in self._ms_functions
             )
-            if is_profile:
-                return "profile spectrum"
-            return "centroid spectrum"
-        return None
+            if r is not None
+        ]
+        if not acquired:
+            logger.info(
+                "No acquisition mass range reported for %s; the resampled "
+                "axis spans the stored m/z values %.4f-%.4f",
+                self._data_path.name,
+                *observed,
+            )
+            return observed
+
+        lo = min(float(r[0]) for r in acquired)
+        hi = max(float(r[1]) for r in acquired)
+        if lo <= observed[0] and hi >= observed[1]:
+            logger.info(
+                "Mass range %.4f-%.4f taken from the acquisition setting "
+                "(stored values span %.4f-%.4f), so runs acquired with the "
+                "same method share one resampled axis",
+                lo,
+                hi,
+                *observed,
+            )
+            return (lo, hi)
+
+        logger.warning(
+            "Stored m/z values %.4f-%.4f fall outside the acquisition range "
+            "%.4f-%.4f; using the stored span so nothing is dropped",
+            *observed,
+            lo,
+            hi,
+        )
+        return observed
+
+    def _detect_spectrum_type(self) -> Optional[str]:
+        """The representation the reader delivers: profile trace or centroid.
+
+        MassLynx can hand back either for a profile-acquired file; which one
+        is a mode switch on the open handle that the owning reader has
+        already set. A centroid-acquired file has no trace to give, so it
+        is centroid whatever was asked for -- said out loud, since a caller
+        who asked for the profile would otherwise get a centroid store
+        that claims nothing was lost.
+        """
+        if not self._ms_functions:
+            return None
+        acquired_profile = self._ml.is_raw_spectrum_profile(
+            self._handle, self._ms_functions[0]
+        )
+        if not acquired_profile:
+            if not self._use_centroid:
+                logger.warning(
+                    "%s was acquired in centroid mode, so there is no profile "
+                    "trace to read; the vendor centroids are delivered instead",
+                    self._data_path.name,
+                )
+            return SpectrumType.CENTROID
+        if self._use_centroid:
+            return SpectrumType.CENTROID
+        return SpectrumType.PROFILE
 
     def _read_scan_mzs(self, func: int, scan: int) -> Optional[NDArray[np.floating]]:
         """Read m/z array for a single scan, returning None on failure."""
@@ -242,12 +328,39 @@ class WatersMetadataExtractor(MetadataExtractor):
         ``data_format`` predates it and only ever fed the stored
         format-specific block, so both are kept: renaming it would change
         stored metadata for no downstream gain.
+
+        ``is_mrt`` and ``profile_sample_spacing_da_at_1000`` are likewise
+        read by ``DataCharacteristics.from_metadata``: the first selects the
+        MRT bin width, the second lets another Waters instrument's profile
+        conversion size its bins from its own digitiser.
         """
-        return {
+        specific: Dict[str, Any] = {
             "format": "Waters MassLynx raw",
             "data_format": "waters_raw",
             "data_path": str(self._data_path),
             "is_imaging": True,
+            # What the reader delivers, as distinct from what was acquired
+            # (``acquisition_params["function_N_is_profile"]``).
+            "spectrum_source": (
+                "vendor_centroid" if self._use_centroid else "profile_trace"
+            ),
+        }
+        if self._instrument is not None:
+            spacing = self._instrument.profile_sample_spacing_da(1000.0)
+            specific.update(
+                {
+                    "instrument": self._instrument.name,
+                    "is_mrt": self._instrument.is_mrt,
+                    "instrument_decided_by": self._instrument.decided_by,
+                    "profile_sample_spacing_da_at_1000": spacing,
+                }
+            )
+        specific.update(self._function_layout())
+        return specific
+
+    def _function_layout(self) -> Dict[str, Any]:
+        """The function and grid facts that have always been reported here."""
+        return {
             "n_functions": self._ml.get_number_of_functions(self._handle),
             "ms_functions": self._ms_functions,
             "function_types": {
@@ -295,10 +408,15 @@ class WatersMetadataExtractor(MetadataExtractor):
         ``vendor``, which nothing downstream consumed, so the fact that a
         file was Waters never reached the resampling detector chain.
         """
-        return {
+        info: Dict[str, Any] = {
             "manufacturer": "Waters",
             "format": "MassLynx .raw",
         }
+        if self._instrument is not None and self._instrument.is_mrt:
+            info["instrument_model"] = self._instrument.name
+        if self._instrument is not None and self._instrument.resolution is not None:
+            info["declared_resolution"] = self._instrument.resolution
+        return info
 
     def _extract_raw_metadata(self) -> Dict[str, Any]:
         """Extract raw metadata dictionary."""

--- a/thyra/readers/waters/instrument.py
+++ b/thyra/readers/waters/instrument.py
@@ -1,0 +1,228 @@
+"""Which Waters instrument wrote a ``.raw`` directory, from its own metadata.
+
+MassLynx leaves two text files beside the ``_FUNC*.DAT`` data: ``_extern.inf``
+with the instrument configuration and per-function parameters, and
+``_header.txt`` with the acquisition header. Neither passes through the
+native library, so they are read here directly.
+
+The one distinction Thyra acts on is whether the analyser is a SELECT SERIES
+MRT. Its multi-reflecting flight path gives R ~ 170,000 (measured 130,000 at
+m/z 300 rising to 190,000 at m/z 1000 on a MALDI brain section), and at that
+resolving power the vendor peak picker is the limit rather than the analyser:
+it reports one centroid where the sampled trace has two maxima 8-9 mDa apart,
+in 96-100% of the pixels that resolve them. On a Synapt G2-Si (R ~ 26,000)
+the same test finds the picker merging nothing the profile resolves. So MRT
+runs default to the profile trace and every other Waters instrument keeps the
+vendor centroid; see :mod:`thyra.readers.waters.waters_reader`.
+
+Fields checked, in order, with what each run actually carries:
+
+======================  ==========  ===============
+field                   MRT run     Synapt G2-Si run
+======================  ==========  ===============
+``OpticMode``           ``MRT``     absent
+``$$ Instrument`` (hdr) ``MRT#``    absent
+``Resolution``          225909.053  10000
+======================  ==========  ===============
+
+``OpticMode`` is the instrument's own word for it and decides outright. The
+header line is the acquisition's instrument label. ``Resolution`` is the
+fallback: no other Waters TOF is configured anywhere near 100,000, so a
+declared resolution above that threshold is taken as MRT when the other two
+fields are missing. The decision and the field it rested on are logged, and
+returned so the metadata extractor can record them in the store.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+#: ``Resolution`` in ``_extern.inf`` at or above which a run is taken as MRT
+#: when neither ``OpticMode`` nor the header instrument label says so. The
+#: MRT declares ~225,000; a Synapt G2-Si declares 10,000, Xevo-class QTofs
+#: are in the 20,000-40,000 range. Nothing but an MRT reaches six figures.
+MRT_RESOLUTION_THRESHOLD = 100_000.0
+
+# Physical constants for the digitiser sample spacing estimate below.
+_ATOMIC_MASS_UNIT_KG = 1.66053906660e-27
+_ELEMENTARY_CHARGE_C = 1.602176634e-19
+
+
+@dataclass(frozen=True)
+class WatersInstrument:
+    """What ``_extern.inf`` and ``_header.txt`` say about the analyser.
+
+    Attributes:
+        is_mrt: Whether the run was acquired on a SELECT SERIES MRT.
+        decided_by: The field the decision rested on, as ``"field=value"``,
+            or ``"no instrument field found"`` when none of the three was
+            present and ``is_mrt`` is ``False`` by default.
+        optic_mode: ``OpticMode`` from ``_extern.inf``, if present.
+        instrument_label: ``$$ Instrument`` from ``_header.txt``, if present.
+        resolution: ``Resolution`` from ``_extern.inf``, if present and
+            numeric.
+        flight_path_mm: ``Lteff`` from ``_extern.inf`` (effective flight
+            path, mm), if present.
+        effective_voltage_v: ``Veff`` from ``_extern.inf``, if present.
+        adc_sample_frequency_ghz: ``ADC Sample Frequency (GHz)`` from
+            ``_extern.inf``, if present.
+    """
+
+    is_mrt: bool
+    decided_by: str
+    optic_mode: Optional[str] = None
+    instrument_label: Optional[str] = None
+    resolution: Optional[float] = None
+    flight_path_mm: Optional[float] = None
+    effective_voltage_v: Optional[float] = None
+    adc_sample_frequency_ghz: Optional[float] = None
+
+    @property
+    def name(self) -> str:
+        """A short label for logs and stored metadata."""
+        return "SELECT SERIES MRT" if self.is_mrt else "Waters (not MRT)"
+
+    def profile_sample_spacing_da(self, mz: float) -> Optional[float]:
+        """Predicted spacing of the profile trace's samples at ``mz``, in Da.
+
+        The trace is sampled at the ADC's fixed rate, so consecutive samples
+        are one clock period apart in flight time. With ``t = L * sqrt(m /
+        (2 e V))`` for a singly charged ion of mass ``m`` over flight path
+        ``L`` at effective voltage ``V``, one period ``dt`` spans ``dm = 2 m
+        dt / t``. On the MRT reference run this predicts 1.143 mDa at m/z
+        1000 against 1.16 mDa measured (1.5% off); on a Synapt G2-Si, 13.8
+        mDa against 13.4 measured.
+
+        Returns:
+            The spacing in Da, or ``None`` when ``Lteff``, ``Veff`` or the
+            ADC frequency is missing from ``_extern.inf``.
+        """
+        if (
+            self.flight_path_mm is None
+            or self.effective_voltage_v is None
+            or self.adc_sample_frequency_ghz is None
+            or self.flight_path_mm <= 0
+            or self.effective_voltage_v <= 0
+            or self.adc_sample_frequency_ghz <= 0
+        ):
+            return None
+        dt = 1.0 / (self.adc_sample_frequency_ghz * 1e9)
+        velocity_term = math.sqrt(
+            2.0
+            * _ELEMENTARY_CHARGE_C
+            * self.effective_voltage_v
+            * mz
+            / _ATOMIC_MASS_UNIT_KG
+        )
+        return 2.0 * dt * velocity_term / (self.flight_path_mm * 1e-3)
+
+
+def _read_text(path: Path) -> Optional[str]:
+    """Read a MassLynx side file, tolerating its Latin-1 degree signs."""
+    try:
+        return path.read_text(encoding="latin-1")
+    except OSError:
+        return None
+
+
+def parse_extern_inf(text: str) -> Dict[str, str]:
+    """Parse ``_extern.inf`` into ``{key: value}``, first occurrence wins.
+
+    Lines are ``key<tabs>value``; the MRT pads with spaces then one tab, the
+    Synapt with runs of tabs. Section headers carry no tab and are skipped.
+    ``ADC Sample Frequency (GHz)`` appears under both the instrument
+    configuration and each function's parameters with the same value, so
+    keeping the first occurrence is safe; ``OpticMode`` appears once per
+    function.
+    """
+    fields: Dict[str, str] = {}
+    for line in text.splitlines():
+        if "\t" not in line:
+            continue
+        key, _, value = line.partition("\t")
+        key = key.strip()
+        value = value.strip()
+        if key and value and key not in fields:
+            fields[key] = value
+    return fields
+
+
+def parse_header_txt(text: str) -> Dict[str, str]:
+    """Parse ``_header.txt`` (``$$ Key: value`` lines) into ``{key: value}``."""
+    fields: Dict[str, str] = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith("$$"):
+            continue
+        key, sep, value = line[2:].partition(":")
+        if sep and key.strip():
+            fields[key.strip()] = value.strip()
+    return fields
+
+
+def _float_or_none(value: Optional[str]) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def identify_waters_instrument(raw_path: Path) -> WatersInstrument:
+    """Decide whether ``raw_path`` was acquired on a SELECT SERIES MRT.
+
+    Args:
+        raw_path: The ``.raw`` directory.
+
+    Returns:
+        The decision, the field it rested on, and the raw fields consulted.
+        A directory with none of the fields is *not* MRT; that is the safe
+        answer, since it keeps the vendor centroid the reader always
+        delivered.
+    """
+    extern = parse_extern_inf(_read_text(raw_path / "_extern.inf") or "")
+    header = parse_header_txt(_read_text(raw_path / "_header.txt") or "")
+
+    optic_mode = extern.get("OpticMode")
+    instrument_label = header.get("Instrument")
+    resolution = _float_or_none(extern.get("Resolution"))
+    if optic_mode is not None:
+        is_mrt = optic_mode.upper() == "MRT"
+        decided_by = f"OpticMode={optic_mode}"
+    elif instrument_label is not None:
+        is_mrt = instrument_label.upper().startswith("MRT")
+        decided_by = f"$$ Instrument={instrument_label}"
+    elif resolution is not None:
+        is_mrt = resolution >= MRT_RESOLUTION_THRESHOLD
+        decided_by = f"Resolution={resolution:g}"
+    else:
+        is_mrt = False
+        decided_by = "no instrument field found"
+
+    decision = WatersInstrument(
+        is_mrt=is_mrt,
+        decided_by=decided_by,
+        optic_mode=optic_mode,
+        instrument_label=instrument_label,
+        resolution=resolution,
+        flight_path_mm=_float_or_none(extern.get("Lteff")),
+        effective_voltage_v=_float_or_none(extern.get("Veff")),
+        adc_sample_frequency_ghz=_float_or_none(
+            extern.get("ADC Sample Frequency (GHz)")
+        ),
+    )
+
+    logger.info(
+        "%s identified as %s (%s)",
+        raw_path.name,
+        decision.name,
+        decision.decided_by,
+    )
+    return decision

--- a/thyra/readers/waters/waters_reader.py
+++ b/thyra/readers/waters/waters_reader.py
@@ -20,6 +20,7 @@ from ...core.base_reader import BaseMSIReader
 from ...core.registry import register_reader
 from ...metadata.extractors.waters_extractor import WatersMetadataExtractor
 from .imaging_grid import ImagingGrid, build_imaging_grid
+from .instrument import WatersInstrument, identify_waters_instrument
 from .masslynx_lib import FunctionType, MassLynxLib
 
 logger = logging.getLogger(__name__)
@@ -43,7 +44,7 @@ class WatersReader(BaseMSIReader):
     def __init__(
         self,
         data_path: Path,
-        use_centroid: bool = True,
+        use_centroid: Optional[bool] = None,
         intensity_threshold: Optional[float] = None,
         **kwargs,
     ) -> None:
@@ -52,7 +53,11 @@ class WatersReader(BaseMSIReader):
         Args:
             data_path: Path to the Waters .raw directory.
             use_centroid: If True, request vendor centroiding from the DLL.
-                If False, read profile/raw data.
+                If False, read the profile trace. ``None`` (the default)
+                decides from the instrument: the profile trace on a SELECT
+                SERIES MRT, whose vendor peak picker merges near-isobars the
+                trace resolves, and the vendor centroid on every other
+                Waters instrument. See :mod:`thyra.readers.waters.instrument`.
             intensity_threshold: Minimum intensity value to include.
             **kwargs: Additional arguments passed to BaseMSIReader.
         """
@@ -60,6 +65,27 @@ class WatersReader(BaseMSIReader):
 
         # Validate the .raw directory structure
         self._validate_raw_directory()
+
+        # Which analyser wrote the run decides the default representation.
+        # Read from the side files, so it costs no native-library call and
+        # is known before the handle is opened.
+        self._instrument: WatersInstrument = identify_waters_instrument(self.data_path)
+        if use_centroid is None:
+            use_centroid = not self._instrument.is_mrt
+            logger.info(
+                "%s: reading the %s by default (%s; pass --waters-spectrum "
+                "to override)",
+                self.data_path.name,
+                "vendor centroid" if use_centroid else "profile trace",
+                self._instrument.decided_by,
+            )
+        else:
+            logger.info(
+                "%s: reading the %s as requested (%s)",
+                self.data_path.name,
+                "vendor centroid" if use_centroid else "profile trace",
+                self._instrument.name,
+            )
 
         # Lazy initialization fields
         self._ml: Optional[MassLynxLib] = None
@@ -197,6 +223,16 @@ class WatersReader(BaseMSIReader):
         """Waters MSI data is typically processed/centroided with varying m/z per pixel."""
         return False
 
+    @property
+    def instrument(self) -> WatersInstrument:
+        """What the run's own metadata says about the analyser."""
+        return self._instrument
+
+    @property
+    def use_centroid(self) -> bool:
+        """Whether spectra come from the vendor peak picker (else the profile trace)."""
+        return self._use_centroid
+
     def _create_metadata_extractor(self) -> MetadataExtractor:
         """Create Waters metadata extractor."""
         ml, handle, imaging_grid, function_types, ms_functions = (
@@ -209,6 +245,8 @@ class WatersReader(BaseMSIReader):
             imaging_grid=imaging_grid,
             function_types=function_types,
             ms_functions=ms_functions,
+            instrument=self._instrument,
+            use_centroid=self._use_centroid,
         )
 
     def get_common_mass_axis(self) -> NDArray[np.float64]:

--- a/thyra/resampling/common_axis.py
+++ b/thyra/resampling/common_axis.py
@@ -1,13 +1,17 @@
 """Common axis builder for creating unified mass axes."""
 
+from typing import Dict, Optional, Tuple
+
 import numpy as np
 
 from .mass_axis import (
+    BaseAxisGenerator,
     FTICRAxisGenerator,
     LinearAxisGenerator,
     LinearTOFAxisGenerator,
     OrbitrapAxisGenerator,
     ReflectorTOFAxisGenerator,
+    TOFAxisGenerator,
 )
 from .types import AxisType, MassAxis
 
@@ -55,6 +59,7 @@ class CommonAxisBuilder:
         axis_type: AxisType,
         reference_mz: float = 500.0,
         reference_width: float = 0.1,
+        tof_law: Optional[Tuple[float, float]] = None,
     ) -> MassAxis:
         """Create physics-based mass axis for specific analyzer types.
 
@@ -72,6 +77,9 @@ class CommonAxisBuilder:
             Reference m/z for width specification (default: 500.0)
         reference_width : float
             Mass width at reference m/z (default: 0.1)
+        tof_law : Optional[Tuple[float, float]]
+            ``(A, B)`` of the two-term width law; required for
+            ``AxisType.TOF`` and ignored otherwise.
 
         Returns
         -------
@@ -81,20 +89,25 @@ class CommonAxisBuilder:
         Raises
         ------
         ValueError
-            If axis_type is not supported
+            If axis_type is not supported, or is ``TOF`` without a law
         """
-        generator_map = {
-            AxisType.CONSTANT: LinearAxisGenerator(),
-            AxisType.LINEAR_TOF: LinearTOFAxisGenerator(),
-            AxisType.REFLECTOR_TOF: ReflectorTOFAxisGenerator(),
-            AxisType.ORBITRAP: OrbitrapAxisGenerator(),
-            AxisType.FTICR: FTICRAxisGenerator(),
-        }
+        if axis_type is AxisType.TOF:
+            if tof_law is None:
+                raise ValueError("AxisType.TOF needs tof_law=(A, B)")
+            generator: BaseAxisGenerator = TOFAxisGenerator(*tof_law)
+        else:
+            generator_map: Dict[AxisType, BaseAxisGenerator] = {
+                AxisType.CONSTANT: LinearAxisGenerator(),
+                AxisType.LINEAR_TOF: LinearTOFAxisGenerator(),
+                AxisType.REFLECTOR_TOF: ReflectorTOFAxisGenerator(),
+                AxisType.ORBITRAP: OrbitrapAxisGenerator(),
+                AxisType.FTICR: FTICRAxisGenerator(),
+            }
 
-        if axis_type not in generator_map:
-            raise ValueError(f"Unsupported axis type: {axis_type}")
+            if axis_type not in generator_map:
+                raise ValueError(f"Unsupported axis type: {axis_type}")
 
-        generator = generator_map[axis_type]
+            generator = generator_map[axis_type]
 
         return generator.generate_axis(
             min_mz, max_mz, num_bins, reference_mz, reference_width

--- a/thyra/resampling/data_characteristics.py
+++ b/thyra/resampling/data_characteristics.py
@@ -35,6 +35,13 @@ class DataCharacteristics:
     is_timstof: bool = False
     is_phi_tofsims: bool = False
     is_waters_raw: bool = False
+    # Waters only: the analyser is a SELECT SERIES MRT, per _extern.inf.
+    is_waters_mrt: bool = False
+    # Profile sources whose digitiser grid is known: the spacing between
+    # consecutive stored samples at m/z 1000, in Da. Lets a detector anchor
+    # the default bin width to the data's own sampling rather than to a
+    # constant that fits one instrument.
+    profile_sample_spacing_da_at_1000: Optional[float] = None
 
     @property
     def needs_resampling(self) -> bool:
@@ -158,6 +165,17 @@ class DataCharacteristics:
         # WatersMetadataExtractor stamps "Waters MassLynx raw"; same prefix
         # convention as the PHI flag above.
         is_waters_raw = bool(source_format and source_format.startswith("Waters "))
+        is_waters_mrt = bool(is_waters_raw and format_specific.get("is_mrt"))
+        spacing = (
+            format_specific.get("profile_sample_spacing_da_at_1000")
+            if format_specific
+            else None
+        )
+        profile_sample_spacing = (
+            float(spacing)
+            if isinstance(spacing, (int, float)) and spacing > 0
+            else None
+        )
 
         return cls(
             spectrum_type=spectrum_type,
@@ -170,4 +188,6 @@ class DataCharacteristics:
             is_timstof=is_timstof,
             is_phi_tofsims=is_phi_tofsims,
             is_waters_raw=is_waters_raw,
+            is_waters_mrt=is_waters_mrt,
+            profile_sample_spacing_da_at_1000=profile_sample_spacing,
         )

--- a/thyra/resampling/decision_tree.py
+++ b/thyra/resampling/decision_tree.py
@@ -6,10 +6,10 @@ instrument detection.
 """
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from .data_characteristics import DataCharacteristics
-from .instrument_detectors import InstrumentDetectorChain
+from .instrument_detectors import InstrumentDetectorChain, ReferenceWidth
 from .types import AxisType, ResamplingMethod
 
 logger = logging.getLogger(__name__)
@@ -86,3 +86,47 @@ class ResamplingDecisionTree:
 
         # Use detector chain to find matching instrument
         return self._detector_chain.get_axis_type(characteristics)
+
+    def select_reference_width(
+        self, metadata: Optional[Dict[str, Any]] = None
+    ) -> Optional[ReferenceWidth]:
+        """The bin width the detected instrument asks for, if any.
+
+        Parameters
+        ----------
+        metadata : Optional[Dict[str, Any]]
+            Metadata dictionary containing instrument information
+
+        Returns
+        -------
+        Optional[ReferenceWidth]
+            ``(width_da, reference_mz)`` when the matching detector declares
+            a default, otherwise ``None`` and the converter's per-axis-type
+            defaults apply.
+        """
+        if metadata is None:
+            return None
+
+        characteristics = DataCharacteristics.from_metadata(metadata)
+        return self._detector_chain.get_reference_width(characteristics)
+
+    def select_tof_law(
+        self, metadata: Optional[Dict[str, Any]] = None
+    ) -> Optional[Tuple[float, float]]:
+        """The two-term TOF width law the detected instrument declares, if any.
+
+        Parameters
+        ----------
+        metadata : Optional[Dict[str, Any]]
+            Metadata dictionary containing instrument information
+
+        Returns
+        -------
+        Optional[Tuple[float, float]]
+            ``(A, B)`` for ``AxisType.TOF``, or ``None``.
+        """
+        if metadata is None:
+            return None
+
+        characteristics = DataCharacteristics.from_metadata(metadata)
+        return self._detector_chain.get_tof_law(characteristics)

--- a/thyra/resampling/instrument_detectors.py
+++ b/thyra/resampling/instrument_detectors.py
@@ -6,13 +6,44 @@ instrument type and returning appropriate resampling parameters.
 """
 
 import logging
+import math
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from .data_characteristics import DataCharacteristics
+from .mass_axis.tof_generator import DEFAULT_BINS_PER_FWHM, MRT_TOF_LAW, TIMSTOF_TOF_LAW
 from .types import AxisType, ResamplingMethod
 
 logger = logging.getLogger(__name__)
+
+__all__ = [
+    "DEFAULT_BINS_PER_FWHM",
+    "MRT_TOF_LAW",
+    "TIMSTOF_TOF_LAW",
+]
+
+#: ``(width_da, reference_mz)``: a bin width anchored at a reference m/z.
+ReferenceWidth = Tuple[float, float]
+
+#: Default bin width for Waters vendor-centroid conversions: 2 mDa at m/z
+#: 1000. The previous 5 mDa gave 1.1 bins per measured FWHM at m/z 800 on a
+#: SELECT SERIES MRT (FWHM 4.48 mDa); 2 mDa gives 2.8, is the coarsest
+#: setting that clears two bins per peak width, and costs 24% more store.
+WATERS_CENTROID_WIDTH: ReferenceWidth = (0.002, 1000.0)
+
+#: Default bin width for SELECT SERIES MRT profile conversions: 1.3 mDa at
+#: m/z 1000, about 1.14x the digitiser's own sample spacing there (1.143 mDa
+#: predicted from Lteff, Veff and the 1.35 GHz ADC clock; 1.16 measured).
+#: Pinned rather than derived so that every MRT run with the same mass
+#: range lands on the same axis, whatever its calibration constants say.
+WATERS_MRT_PROFILE_WIDTH: ReferenceWidth = (0.0013, 1000.0)
+
+#: For a non-MRT Waters profile conversion the width follows the run's own
+#: sample spacing, at this ratio, rounded up to the nearest 0.1 mDa. The
+#: ratio is the MRT default's (1.3 / 1.143 = 1.14): bins at or just above
+#: the sample spacing, so interpolation neither skips samples nor spreads
+#: one sample over many bins.
+WATERS_PROFILE_BINS_PER_SAMPLE = 1.14
 
 
 class InstrumentDetector(ABC):
@@ -73,6 +104,37 @@ class InstrumentDetector(ABC):
         something other than a vendor format whose grid Thyra itself lays
         out, and :class:`InstrumentDetectorChain` refuses ``TIC_PRESERVING``
         for such a detector.
+        """
+        return None
+
+    def get_reference_width(
+        self, characteristics: DataCharacteristics
+    ) -> Optional[ReferenceWidth]:
+        """Default bin width for this instrument, as ``(width_da, reference_mz)``.
+
+        ``None`` -- the default -- leaves the choice to the converter's
+        per-axis-type defaults (5 mDa at m/z 1000, or 17 mDa at m/z 300 for
+        ``linear_tof``). A detector overrides this when it knows what the
+        data can support: a peak width it has measured, or a digitiser
+        grid it wants the bins to track. The converter honours it only when
+        the caller set neither ``--resample-width-at-mz`` nor
+        ``--mass-axis-type``, since a width tuned for one axis law is not
+        a sensible default for another.
+        """
+        return None
+
+    def get_tof_law(
+        self, characteristics: DataCharacteristics
+    ) -> Optional[Tuple[float, float]]:
+        """``(A, B)`` of the instrument's measured peak-width law, if known.
+
+        ``FWHM(m) = sqrt(A m + B m^2)``, in mDa; see
+        :mod:`thyra.resampling.mass_axis.tof_generator`. Used when the axis
+        resolves to :attr:`AxisType.TOF` and the caller gave no pair of
+        their own -- which is either this detector asking for that axis
+        type itself, or the caller opting in with ``--mass-axis-type tof``
+        on an instrument that declares a pair here but defaults to another
+        law. ``None`` means no law has been measured for this instrument.
         """
         return None
 
@@ -186,8 +248,21 @@ class TimsTOFDetector(InstrumentDetector):
         return ResamplingMethod.NEAREST_NEIGHBOR
 
     def get_axis_type(self) -> AxisType:
-        """Return reflector TOF axis for constant relative resolution."""
+        """Return reflector TOF axis for constant relative resolution.
+
+        The measured law (:data:`TIMSTOF_TOF_LAW`) is within 10% of this
+        axis's shape over m/z 400-1000 (the gap reaches 10% at m/z 300),
+        so the default stays here and every timsTOF store already built
+        keeps its axis; ``--mass-axis-type tof`` opts in to the measured
+        pair.
+        """
         return AxisType.REFLECTOR_TOF
+
+    def get_tof_law(
+        self, characteristics: DataCharacteristics
+    ) -> Optional[Tuple[float, float]]:
+        """The pair fitted on 180 timsTOF fleX peaks; opt-in, see above."""
+        return TIMSTOF_TOF_LAW
 
 
 class FTICRDetector(InstrumentDetector):
@@ -298,8 +373,150 @@ class PhiToFSIMSDetector(InstrumentDetector):
         return AxisType.LINEAR_TOF
 
 
+class WatersProfileDetector(InstrumentDetector):
+    """Detector for the profile trace of a Waters MassLynx .raw imaging run.
+
+    The trace is the digitiser's own record: samples at a fixed ADC clock
+    rate, so uniformly spaced in flight time, which puts their m/z spacing
+    proportional to ``sqrt(m/z)``. Measured as ``(m/z)^0.494 +- 0.005``
+    (R2 = 0.9992) on a SELECT SERIES MRT and ``(m/z)^0.498 +- 0.002``
+    (R2 = 0.9999) on a Synapt G2-Si -- the same law on both, at 1.1 mDa
+    and 13 mDa per sample respectively near m/z 1000. That is exactly
+    :attr:`AxisType.LINEAR_TOF`, so a ``linear_tof`` target axis holds the
+    bin-to-sample ratio flat across the range, where ``reflector_tof``
+    drifts from 1.15x at m/z 400 to 1.78x at m/z 800 on the same run.
+
+    The trace is zero-suppressed: only samples around peaks are stored,
+    with an explicit zero at either edge of each cluster. Profile samples
+    have width, so binning them by nearest neighbour onto an axis at about
+    the sample spacing puts two samples in one bin for ~9% of bins and
+    none in others; ``tic_preserving`` interpolates instead, which on a
+    fixed grid gives neither, and the explicit zeros mean it never draws a
+    line across an unmeasured gap.
+
+    This detector is reached by default only on a SELECT SERIES MRT, whose
+    reader defaults to the profile trace; every other Waters instrument
+    arrives here only when asked for the trace with ``--waters-spectrum
+    profile``, and then gets the same treatment with a bin width taken
+    from its own sample spacing.
+    """
+
+    @property
+    def name(self) -> str:
+        """Return detector name."""
+        return "Waters MassLynx (profile trace)"
+
+    def matches(self, characteristics: DataCharacteristics) -> bool:
+        """A MassLynx raw run whose reader delivers the profile trace."""
+        return characteristics.is_waters_raw and characteristics.is_profile_data
+
+    def get_resampling_method(self) -> ResamplingMethod:
+        """Return TIC-preserving interpolation: samples have width."""
+        return ResamplingMethod.TIC_PRESERVING
+
+    def get_axis_type(self) -> AxisType:
+        """Return linear TOF: the digitiser grid's own ``sqrt(m/z)`` law."""
+        return AxisType.LINEAR_TOF
+
+    @property
+    def source_grid_law(self) -> Optional[AxisType]:
+        """The stored trace is uniform in flight time: ``sqrt(m/z)`` spacing.
+
+        Measured on two instruments (see the class docstring); this is what
+        lets ``tic_preserving`` clear ``_gate_tic_preserving``, and it is
+        the reason the target axis is ``linear_tof`` and not the centroid
+        route's ``reflector_tof``.
+        """
+        return AxisType.LINEAR_TOF
+
+    def get_reference_width(
+        self, characteristics: DataCharacteristics
+    ) -> Optional[ReferenceWidth]:
+        """1.3 mDa at m/z 1000 on an MRT; the run's own sample spacing elsewhere.
+
+        An MRT is pinned to :data:`WATERS_MRT_PROFILE_WIDTH` so that every
+        MRT run with the same mass range shares one axis. Another Waters
+        instrument asked for its profile gets
+        :data:`WATERS_PROFILE_BINS_PER_SAMPLE` times its predicted sample
+        spacing at m/z 1000, rounded up to 0.1 mDa (a Synapt G2-Si: 13.8 mDa
+        per sample, so 15.8 mDa bins), and falls back to the MRT width with
+        a warning when ``_extern.inf`` lacks the constants to predict it.
+        """
+        if characteristics.is_waters_mrt:
+            return WATERS_MRT_PROFILE_WIDTH
+        spacing = characteristics.profile_sample_spacing_da_at_1000
+        if spacing is None:
+            logger.warning(
+                "Waters profile conversion on an instrument that is not an "
+                "MRT, and _extern.inf did not yield Lteff, Veff and the ADC "
+                "sample frequency to predict its sample spacing; defaulting "
+                "to the MRT bin width of %.1f mDa at m/z %.0f. Set "
+                "--resample-width-at-mz to the run's sample spacing if the "
+                "store comes out oversampled.",
+                WATERS_MRT_PROFILE_WIDTH[0] * 1e3,
+                WATERS_MRT_PROFILE_WIDTH[1],
+            )
+            return WATERS_MRT_PROFILE_WIDTH
+        width_mda = math.ceil(spacing * 1e3 * WATERS_PROFILE_BINS_PER_SAMPLE * 10) / 10
+        width = (width_mda / 1e3, 1000.0)
+        logger.info(
+            "Waters profile bin width from the run's own digitiser: %.3f mDa "
+            "per sample at m/z 1000, so %.1f mDa bins",
+            spacing * 1e3,
+            width_mda,
+        )
+        return width
+
+
+class WatersMRTCentroidDetector(InstrumentDetector):
+    """Detector for the vendor-centroid list of a SELECT SERIES MRT run.
+
+    A centroid list's bins should track peak width, and the MRT's measured
+    width follows neither single-term TOF law: over m/z 300-1000 the
+    log-log exponent is 0.67 +- 0.03, between ``linear_tof``'s 0.5 and
+    ``reflector_tof``'s 1.0. The two-term law ``sqrt(A m + B m^2)`` with
+    :data:`MRT_TOF_LAW` reproduces the measured 2.97 / 3.79 / 4.54 mDa at
+    m/z 400 / 600 / 800, so the axis is laid at that width over
+    :data:`DEFAULT_BINS_PER_FWHM` bins per peak.
+
+    The MRT's *profile* trace is a different matter -- its bins follow the
+    digitiser grid, not the peak width -- and :class:`WatersProfileDetector`
+    handles it ahead of this one.
+    """
+
+    @property
+    def name(self) -> str:
+        """Return detector name."""
+        return "Waters SELECT SERIES MRT (vendor centroid)"
+
+    def matches(self, characteristics: DataCharacteristics) -> bool:
+        """An MRT run whose reader delivers something other than the trace."""
+        return (
+            characteristics.is_waters_raw
+            and characteristics.is_waters_mrt
+            and not characteristics.is_profile_data
+        )
+
+    def get_resampling_method(self) -> ResamplingMethod:
+        """Return nearest-neighbour, which bins counts and cannot invent them."""
+        return ResamplingMethod.NEAREST_NEIGHBOR
+
+    def get_axis_type(self) -> AxisType:
+        """Return the two-term TOF law: bins that follow the measured width."""
+        return AxisType.TOF
+
+    def get_tof_law(
+        self, characteristics: DataCharacteristics
+    ) -> Optional[Tuple[float, float]]:
+        """The pair fitted on 229 MRT peaks."""
+        return MRT_TOF_LAW
+
+    # ``get_reference_width`` stays ``None``: the TOF axis is sized in bins
+    # per peak width, and ``DEFAULT_BINS_PER_FWHM`` is that default.
+
+
 class WatersDetector(InstrumentDetector):
-    """Detector for Waters MassLynx .raw imaging data (SELECT SERIES MRT et al.).
+    """Detector for the vendor-centroid list of a Waters MassLynx .raw run.
 
     Without this detector a Waters acquisition's fate hinged on its declared
     spectrum representation: centroid files happened to land on
@@ -308,6 +525,10 @@ class WatersDetector(InstrumentDetector):
     :class:`DefaultDetector`. That reported ``CONSTANT``, which downstream
     pairs with the 0.1 Da default bin width: R = 5,000 at m/z 500, on an
     instrument built for 100,000+.
+
+    The profile trace is handled by :class:`WatersProfileDetector`, which
+    sits ahead of this one in the chain; what reaches here is the vendor
+    peak list, or a run whose representation is undeclared.
     """
 
     @property
@@ -328,16 +549,22 @@ class WatersDetector(InstrumentDetector):
 
         SCiLS Lab 2026b calls the same law Orthogonal TOF (formerly Reflector
         TOF): bin size proportional to m/z, i.e. constant relative resolution
-        (2026b User Guide, p.75). That is the law for an orthogonal-TOF
-        instrument like the SELECT SERIES MRT.
+        (2026b User Guide, p.75). For a centroid list the axis should track
+        peak width, and measured MRT peak widths go as ``(m/z)^0.67`` --
+        between this law and ``linear_tof``, and this one errs toward more
+        bins at low m/z, where the width measurement is least certain.
         """
         return AxisType.REFLECTOR_TOF
 
-    # ``source_grid_law`` stays at the inherited ``None`` on purpose: MassLynx
-    # lays out the stored m/z grid, not Thyra, and no law has been measured
-    # for it. Declaring one untested would open ``_gate_tic_preserving`` --
-    # the gate that keeps auto-selection off the interpolating path -- on
-    # data whose grid Thyra has not actually identified.
+    def get_reference_width(
+        self, characteristics: DataCharacteristics
+    ) -> Optional[ReferenceWidth]:
+        """2 mDa at m/z 1000; see :data:`WATERS_CENTROID_WIDTH`."""
+        return WATERS_CENTROID_WIDTH
+
+    # ``source_grid_law`` stays at the inherited ``None`` on purpose: a
+    # centroid list has no grid. The profile trace's law is declared on
+    # :class:`WatersProfileDetector`, where it has been measured.
 
 
 class DefaultDetector(InstrumentDetector):
@@ -393,6 +620,11 @@ class InstrumentDetectorChain:
             FTICRDetector(),
             OrbitrapDetector(),
             PhiToFSIMSDetector(),
+            # The profile trace first: it needs the representation as well
+            # as the format, and the centroid detector matches on the
+            # format alone.
+            WatersProfileDetector(),
+            WatersMRTCentroidDetector(),
             WatersDetector(),
             # Generic spectrum type detector
             CentroidImzMLDetector(),
@@ -490,3 +722,49 @@ class InstrumentDetectorChain:
         axis_type = detector.get_axis_type()
         logger.info(f"Selected axis type: {axis_type.name}")
         return axis_type
+
+    def get_reference_width(
+        self, characteristics: DataCharacteristics
+    ) -> Optional[ReferenceWidth]:
+        """Default bin width for the detected instrument, if it declares one.
+
+        Args:
+            characteristics: Data characteristics to match
+
+        Returns:
+            ``(width_da, reference_mz)``, or ``None`` to leave the choice to
+            the converter's per-axis-type defaults.
+        """
+        detector = self.detect(characteristics)
+        width = detector.get_reference_width(characteristics)
+        if width is not None:
+            logger.info(
+                "Selected bin width: %.2f mDa at m/z %.0f (%s)",
+                width[0] * 1e3,
+                width[1],
+                detector.name,
+            )
+        return width
+
+    def get_tof_law(
+        self, characteristics: DataCharacteristics
+    ) -> Optional[Tuple[float, float]]:
+        """The detected instrument's two-term width law, if it declares one.
+
+        Args:
+            characteristics: Data characteristics to match
+
+        Returns:
+            ``(A, B)`` in the units of
+            :mod:`thyra.resampling.mass_axis.tof_generator`, or ``None``.
+        """
+        detector = self.detect(characteristics)
+        law = detector.get_tof_law(characteristics)
+        if law is not None:
+            logger.info(
+                "Selected TOF width law: A=%.4g mDa^2/Da, B=%.4g (%s)",
+                law[0],
+                law[1],
+                detector.name,
+            )
+        return law

--- a/thyra/resampling/mass_axis/__init__.py
+++ b/thyra/resampling/mass_axis/__init__.py
@@ -6,12 +6,24 @@ from .linear_generator import LinearAxisGenerator
 from .linear_tof_generator import LinearTOFAxisGenerator
 from .orbitrap_generator import OrbitrapAxisGenerator
 from .reflector_tof_generator import ReflectorTOFAxisGenerator
+from .tof_generator import (
+    DEFAULT_BINS_PER_FWHM,
+    MRT_TOF_LAW,
+    TIMSTOF_TOF_LAW,
+    TOFAxisGenerator,
+    tof_fwhm_mda,
+)
 
 __all__ = [
     "BaseAxisGenerator",
     "LinearAxisGenerator",
     "LinearTOFAxisGenerator",
     "ReflectorTOFAxisGenerator",
+    "TOFAxisGenerator",
     "OrbitrapAxisGenerator",
     "FTICRAxisGenerator",
+    "DEFAULT_BINS_PER_FWHM",
+    "MRT_TOF_LAW",
+    "TIMSTOF_TOF_LAW",
+    "tof_fwhm_mda",
 ]

--- a/thyra/resampling/mass_axis/tof_generator.py
+++ b/thyra/resampling/mass_axis/tof_generator.py
@@ -1,0 +1,157 @@
+"""Two-term time-of-flight width law: bins that follow a measured peak width.
+
+A TOF peak's width in flight time has a part that is constant (detector
+and digitiser response, pusher timing) and a part proportional to the
+flight time itself (energy spread, turnaround time), added in quadrature.
+Converted to m/z that is
+
+    FWHM(m) = sqrt(A * m + B * m^2)        m in Da, FWHM in mDa
+
+with ``A`` in mDa^2/Da and ``B`` dimensionless. The two existing TOF laws
+are its limits: ``linear_tof`` is ``B = 0`` (width goes as ``sqrt(m)``),
+``reflector_tof`` is ``A = 0`` (width goes as ``m``, constant ppm, with
+``1 / sqrt(B)`` the resolving power). Real instruments sit between them,
+and where they sit is measurable:
+
+======================  ==========  ===========  ============================
+instrument              A           B            fitted from
+======================  ==========  ===========  ============================
+SELECT SERIES MRT       0.0185      9.1e-6       229 peaks, m/z 300-1000
+timsTOF fleX            0.0877      8.74e-4      180 peaks, m/z 300-1000
+======================  ==========  ===========  ============================
+
+Refitted here from the same peak lists by least squares on ``FWHM^2 = A m +
+B m^2``: the MRT pair reproduces 2.97 / 3.79 / 4.54 mDa at m/z 400 / 600 /
+800, where the log-log fit of the same peaks gave an exponent of 0.67 --
+between the 0.5 and 1.0 the two single-term laws allow, which is why
+neither of them fits an MRT centroid list exactly.
+
+The axis lays bins at ``FWHM(m) / k`` for ``k`` bins per peak width. The
+cumulative bin count ``N(m) = 1000 k * integral dm / sqrt(A m + B m^2)`` has
+a closed form, ``(2 / sqrt(B)) asinh(sqrt(B m / A))``, so the axis is a
+uniform grid in that variable; the two limits reduce to the uniform-in-
+``sqrt(m)`` and uniform-in-``ln(m)`` grids the single-term generators lay.
+
+This law describes **peak width**, which is what a centroid list's bins
+should track. It says nothing about a digitiser's sample grid, so it must
+not be used to bin profile data: the Waters profile trace follows
+``linear_tof`` because that is how its samples are spaced, not because of
+how wide its peaks are.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+
+from ..types import AxisType, MassAxis
+from .base_generator import BaseAxisGenerator
+
+#: ``(A, B)`` fitted on 229 isolated peaks of a SELECT SERIES MRT MALDI run.
+MRT_TOF_LAW: Tuple[float, float] = (0.0185, 9.1e-6)
+
+#: ``(A, B)`` fitted on 180 isolated peaks of a timsTOF fleX MALDI run.
+TIMSTOF_TOF_LAW: Tuple[float, float] = (0.0877, 8.74e-4)
+
+#: Bins per peak width when the caller gives no width of their own.
+DEFAULT_BINS_PER_FWHM = 3.0
+
+
+def tof_fwhm_mda(mz, a: float, b: float):
+    """Peak width in mDa at ``mz`` under the two-term law."""
+    mz = np.asarray(mz, dtype=np.float64)
+    return np.sqrt(a * mz + b * mz * mz)
+
+
+def _check_law(a: float, b: float) -> None:
+    if not (np.isfinite(a) and np.isfinite(b)) or a < 0 or b < 0 or (a == 0 and b == 0):
+        raise ValueError(
+            f"A TOF width law needs A >= 0 and B >= 0 with at least one of them "
+            f"positive; got A={a!r}, B={b!r}"
+        )
+
+
+class TOFAxisGenerator(BaseAxisGenerator):
+    """Mass axis whose bin width tracks ``sqrt(A m + B m^2) / k``.
+
+    Parameters
+    ----------
+    a, b : float
+        The width law's coefficients (mDa^2/Da and dimensionless).
+    """
+
+    def __init__(self, a: float, b: float) -> None:
+        """Bind the law's coefficients, refusing a pair with no width."""
+        _check_law(a, b)
+        self.a = float(a)
+        self.b = float(b)
+
+    def cumulative(self, mz):
+        """``integral dm / sqrt(A m + B m^2)`` from 0, in Da / mDa.
+
+        Multiplied by ``1000 k`` this is the bin count below ``mz``.
+        """
+        mz = np.asarray(mz, dtype=np.float64)
+        if self.b == 0.0:
+            return 2.0 * np.sqrt(mz / self.a)
+        if self.a == 0.0:
+            return np.log(mz) / np.sqrt(self.b)
+        return (2.0 / np.sqrt(self.b)) * np.arcsinh(np.sqrt(self.b * mz / self.a))
+
+    def inverse(self, u):
+        """The m/z at which :meth:`cumulative` equals ``u``."""
+        u = np.asarray(u, dtype=np.float64)
+        if self.b == 0.0:
+            return self.a * (u / 2.0) ** 2
+        if self.a == 0.0:
+            return np.exp(u * np.sqrt(self.b))
+        return (self.a / self.b) * np.sinh(u * np.sqrt(self.b) / 2.0) ** 2
+
+    def bins_per_fwhm_for(self, reference_mz: float, reference_width: float) -> float:
+        """The ``k`` that puts a bin of ``reference_width`` Da at ``reference_mz``."""
+        return float(
+            tof_fwhm_mda(reference_mz, self.a, self.b) / (reference_width * 1e3)
+        )
+
+    def bin_count(self, min_mz: float, max_mz: float, bins_per_fwhm: float) -> int:
+        """Bins over ``[min_mz, max_mz]`` at ``bins_per_fwhm`` per peak width."""
+        span = float(self.cumulative(max_mz) - self.cumulative(min_mz))
+        return max(1, int(1e3 * bins_per_fwhm * span))
+
+    def bin_width_at(self, mz, bins_per_fwhm: float):
+        """Bin width in Da at ``mz`` for ``bins_per_fwhm`` per peak width."""
+        return tof_fwhm_mda(mz, self.a, self.b) * 1e-3 / bins_per_fwhm
+
+    def generate_axis(
+        self,
+        min_mz: float,
+        max_mz: float,
+        target_bins: int,
+        reference_mz: float = 1000.0,
+        reference_width: float = 0.005,
+    ) -> MassAxis:
+        """Distribute ``target_bins`` bins uniformly in the law's cumulative.
+
+        ``reference_mz`` and ``reference_width`` are not needed: the bin
+        count already fixes ``k``, and the law fixes the shape.
+        """
+        u = np.linspace(
+            self.cumulative(min_mz), self.cumulative(max_mz), target_bins + 1
+        )
+        edges = self.inverse(u)
+        # The inverse of the cumulative is exact in exact arithmetic; pin
+        # the ends so the axis spans precisely what was asked for.
+        edges[0], edges[-1] = min_mz, max_mz
+        centres = (edges[:-1] + edges[1:]) / 2.0
+        return MassAxis(
+            mz_values=centres,
+            min_mz=float(centres[0]),
+            max_mz=float(centres[-1]),
+            num_bins=len(centres),
+            axis_type=AxisType.TOF,
+        )
+
+    def get_axis_type(self) -> AxisType:
+        """Return the axis type this generator produces."""
+        return AxisType.TOF

--- a/thyra/resampling/types.py
+++ b/thyra/resampling/types.py
@@ -41,6 +41,11 @@ class AxisType(Enum):
         LINEAR_TOF: Linear TOF -- spacing proportional to
             ``sqrt(m/z)``.
         REFLECTOR_TOF: Reflector TOF -- spacing proportional to ``m/z``.
+        TOF: General time-of-flight -- spacing proportional to a measured
+            peak width ``sqrt(A m + B m^2)``, of which ``LINEAR_TOF``
+            (``B = 0``) and ``REFLECTOR_TOF`` (``A = 0``) are the limits.
+            Needs the two coefficients; see
+            :mod:`thyra.resampling.mass_axis.tof_generator`.
         ORBITRAP: Orbitrap -- spacing proportional to ``m/z^(3/2)``.
         FTICR: FTICR -- spacing proportional to ``m/z^2``.
         UNKNOWN: Unknown analyser; falls back to constant spacing.
@@ -49,6 +54,7 @@ class AxisType(Enum):
     CONSTANT = "constant"
     LINEAR_TOF = "linear_tof"
     REFLECTOR_TOF = "reflector_tof"
+    TOF = "tof"
     ORBITRAP = "orbitrap"
     FTICR = "fticr"
     UNKNOWN = "unknown"
@@ -116,6 +122,13 @@ class ResamplingConfig:
             straight lines are drawn across regions where nothing was
             measured.  Only affects ``tic_preserving``; ``nearest_neighbor``
             never invents a bin.  See :mod:`thyra.resampling.gaps`.
+        tof_a: ``A`` of the two-term TOF width law ``FWHM(m) = sqrt(A m +
+            B m^2)`` (mDa^2/Da), for ``AxisType.TOF``.  ``None`` takes the
+            pair the detected instrument declares, if any.
+        tof_b: ``B`` of the same law (dimensionless).
+        bins_per_fwhm: Bins per peak width for ``AxisType.TOF``.  ``None``
+            means 3, or -- when ``mass_width_da`` is set -- whatever puts
+            a bin of that width at ``reference_mz``.
     """
 
     method: Optional[ResamplingMethod] = None
@@ -126,3 +139,6 @@ class ResamplingConfig:
     min_mz: Optional[float] = None
     max_mz: Optional[float] = None
     gap_tolerance_da: Optional[float] = None
+    tof_a: Optional[float] = None
+    tof_b: Optional[float] = None
+    bins_per_fwhm: Optional[float] = None


### PR DESCRIPTION
## What changes

- **SELECT SERIES MRT runs default to the profile trace.** Identified from `_extern.inf` (`OpticMode = MRT`), the `_header.txt` instrument label, or a declared `Resolution` above 100,000; logged and stored in `format_specific`. Every other Waters instrument keeps the vendor centroid. `--waters-spectrum` overrides both ways.
- **Profile route:** `tic_preserving` onto `linear_tof` at 1.3 mDa at m/z 1000 (about 1.14 digitiser sample spacings; the trace's spacing is measured `(m/z)^0.494` on the MRT and `(m/z)^0.498` on a Synapt G2-Si, so the source law is declared and the interpolating path clears its gate). The axis is built over the acquisition mass range, not the stored span, so runs with the same method share bins. A non-MRT instrument asked for its trace gets 1.14 x its own predicted sample spacing (from `Lteff`, `Veff`, ADC clock).
- **Centroid route:** the Waters default width moves from 5 mDa to 2 mDa (2.8 bins per measured FWHM at m/z 800 instead of 1.1). An MRT centroid conversion uses the new two-term TOF width law (below).
- **Sparse `tic_preserving`.** Same operator, evaluated only at the axis points under stored clusters, returned as `(indices, values)`; the dense result bin for bin. 570 s -> 14.6 s on the reference run. Both converters use it.
- **Two-term TOF width law** (`AxisType.TOF`, `--mass-axis-type tof`, plus `--tof-law A B` only for an instrument without a detector pair): `FWHM(m) = sqrt(A m + B m^2)` mDa with a closed-form axis; `linear_tof` and `reflector_tof` are its limits. MRT pair (0.0185, 9.1e-6) and timsTOF pair (0.0877, 8.74e-4) refitted from the measured peak lists. timsTOF stays on `reflector_tof` by default; the pair is opt-in. Bins per peak width (3 by default) follow `--resample-width-at-mz` like any other axis; there is no separate flag.
- **CLI surface:** two new options over v3.17.1 (`--waters-spectrum`, `--tof-law`). `docs/cli.md` now has a "Which of these you actually need" table; a recognised instrument converts with no resampling flags at all.
- **Representation metadata:** the Waters extractor now reports the representation the reader delivers, so `uns["essential_metadata"]["spectrum_type"]` is `profile spectrum` for the new default and `centroid spectrum` for a centroid read of a profile-acquired file.
- **Pre-existing defect fixed:** `BaseSpatialDataConverter.__init__` selected the resampling method before assigning the metadata caches the extraction reads through; the failure was swallowed and every reader's auto-selected method came from `DefaultDetector` (`nearest_neighbor`) while the axis type, resolved later, came from the right detector. Old conversion logs show the pair. Rapiflex auto conversions were nearest-neighbour before this fix.

## Measured on `20260821_MRT_FTW2_CLMC.raw` (13,398 px)

| conversion | time | size | bins | TIC / raw profile | 800.5477 / 800.5566 in mean spectrum |
|---|---|---|---|---|---|
| new MRT default (profile, `tic_preserving`, `linear_tof` 1.3 mDa) | **14.6 s** | 288.9 MB | 1,051,957 | 0.999998 (1.000000 per pixel) | **+0.30 / -0.65 ppm** |
| new MRT centroid default (`tof` law, 3 bins per FWHM) | 96.2 s | 52.4 MB | 862,750 | 0.9969 | one maximum |
| before: centroid, `reflector_tof` 5 mDa | 108.7 s | 45.5 MB | 460,476 | | one maximum |
| profile, nearest-neighbour on the same 1.3 mDa axis | 16.0 s | 137.7 MB | 1,051,941 | 0.999998 | +1.64 / +2.14 ppm; 9% of bins doubled, 17% of cluster bins empty |
| profile, dense `tic_preserving` on the same axis | 570 s | | | | |

New default: 0 stored bins above the neighbouring-sample ceiling and 0 empty bins inside stored clusters over 203 sampled pixels; two conversions produce identical `var` axes. The store is 2.1x the binned trace because interpolated values are not integer ADC counts and zstd stores them at 7.5 bytes each against 3.4, and because interpolation fills the bins next to each cluster's stored zero edge (nnz 1.10x the samples).

## Tests and docs

New: `test_waters_instrument.py` (MRT / Synapt / no fields, reader default and override), `test_waters_extractor_representation.py`, `test_tic_preserving_sparse.py` (sparse == dense at rtol 1e-12), `test_detected_reference_width.py`, `test_tof_generator.py` (limits reduce to the single-term generators, k bins per FWHM within 5%, doublet in separate bins), `test_cli_waters_spectrum.py`, `test_cli_tof_law.py`. Docs: `supported-formats.md` (why MRT defaults to profile, the Synapt result, the accepted loss), `resampling.md` (detector table, gate, width defaults, "The two-term TOF law"), `cli.md`.

Unit suite: 2229 passed. `test_pandas3_string_dtypes.py` fails identically against the untouched main checkout in this environment (anndata / pandas-3 string writes) and is unrelated.

Not done: `--tof-fit` (estimating A and B from the run itself) is left for a later change.
