### PR TITLE
feat: defaults per design decisions D1-D7, and one raw read per frame per pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ for a full walkthrough, including the published example dataset
 - **Optical Alignment**: Automatic MSI-to-optical image registration for Bruker data
 - **Multi-Region Support**: Handles slides with multiple tissue sections
 - **Resampling**: Physics-aware mass axis resampling (on by default in the CLI; opt-in from the Python API)
+- **Ion Mobility and MS/MS**: TIMS acquisitions keep their mass-mobility heatmap and can carry a mobility-resolved sibling table; scheduled PASEF MS/MS acquisitions are written split apart by precursor by default. The defaults and the measurements behind them are recorded in the [design decisions](https://m4i-imaging-mass-spectrometry.github.io/thyra/design-decisions/)
 - **Validated Metadata**: Versioned, ontology-mapped metadata schema (PSI-MS, NCBITaxon, UBERON, CHEBI) with `thyra validate` and one-command METASPACE export
 - **3D Support**: Process volume data or treat as 2D slices
 - **Cross-Platform**: Windows, macOS, and Linux

--- a/docs/api.md
+++ b/docs/api.md
@@ -286,7 +286,21 @@ implementing and what each one buys you.
         - get_region_map
         - get_region_info
         - has_shared_mass_axis
+        - has_ion_mobility
+        - get_mobility_axis
+        - iter_mobility_spectra
+        - get_fragmentation
+        - iter_precursor_spectra
+        - has_frame_scans
+        - iter_frame_scans
         - close
+
+A reader whose summed spectrum, mobility point cloud and precursor spectra
+all derive from one raw read per pixel can hand that read over as a record,
+so a conversion that writes several tables reads the source once per pass
+(design decision D5). The Bruker TDF reader does; the record's contract is:
+
+::: thyra.core.frames.FrameScans
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,9 +48,9 @@ thyra input.imzML output.zarr && python analyse.py output.zarr
 | `--resample / --no-resample` | enabled | Mass axis resampling |
 | `--include-optical / --no-optical` | enabled | Include optical images in output |
 | `--mobility-table / --no-mobility-table` | enabled | Also write the mobility-resolved sibling table when the source shares one set of (m/z, ion mobility) features across pixels (see [Output Format](output-format.md#ion-mobility)) |
-| `--mobility-heatmap / --no-mobility-heatmap` | enabled | When the source has an ion mobility dimension, store the mean mass-mobility frame on the summed table as `uns["mobility_heatmap"]`; one extra pass over the source (see [Output Format](output-format.md#ion-mobility)) |
-| `--mobility-grid / --no-mobility-grid` | **disabled** | When the source carries ion mobility per pixel rather than as a shared feature list (Bruker TDF), bin the point cloud onto a common mobility grid and write the same mobility-resolved sibling table; one extra pass over the source beyond the heatmap's, a much larger table built out of core so any acquisition fits; its marginal reproduces the summed table exactly under the default `--tdf-spectrum scan_sum` (see [Output Format](output-format.md#the-same-table-from-a-common-mobility-grid)) |
-| `--msms-table / --no-msms-table` | enabled | When the source isolates several precursors per pixel in disjoint mobility slices (Bruker PASEF), also write them split apart as a demultiplexed sibling table; two extra passes over the source; the split adds back up to the summed table exactly under the default `--tdf-spectrum scan_sum` (see [Output Format](output-format.md#demultiplexed-msms-table)) |
+| `--mobility-heatmap / --no-mobility-heatmap` | enabled | When the source has an ion mobility dimension, store the mean mass-mobility frame on the summed table as `uns["mobility_heatmap"]`; on a Bruker TDF it is fed from the summed table's own passes, on other sources it is one extra pass (see [Output Format](output-format.md#ion-mobility)) |
+| `--mobility-grid / --no-mobility-grid` | **disabled** | When the source carries ion mobility per pixel rather than as a shared feature list (Bruker TDF), bin the point cloud onto a common mobility grid and write the same mobility-resolved sibling table; fed from the summed table's own two passes on the streaming route (no extra read of the source), a much larger table built out of core so any acquisition fits; its marginal reproduces the summed table exactly under the default `--tdf-spectrum scan_sum` (see [Output Format](output-format.md#the-same-table-from-a-common-mobility-grid)) |
+| `--msms-table / --no-msms-table` | enabled | When the source isolates several precursors per pixel in disjoint mobility slices (Bruker PASEF), also write them split apart as a demultiplexed sibling table; fed from the summed table's own two passes on the streaming route (no extra read of the source); the split adds back up to the summed table exactly under the default `--tdf-spectrum scan_sum` (see [Output Format](output-format.md#demultiplexed-msms-table)) |
 
 ### Examples
 
@@ -138,7 +138,10 @@ thyra tims_data.d output.zarr --mobility-grid --mobility-bins 512     --mobility
     two passes: the first counts the occupied `(m/z bin, channel)` cells and
     the second scatters every pixel straight into memmapped CSC arrays in a
     scratch directory next to the output (`.thyra_mobility_*`, removed once
-    the table is written). Memory is the count array over the grid's span --
+    the table is written). On a Bruker TDF those are the summed table's own
+    two passes: each frame is read once per pass and the read serves the
+    summed spectrum, the heatmap, the grid and the MS/MS split alike (see
+    [Design Decisions](design-decisions.md#d5-one-raw-read-per-frame-per-pass-serves-every-table)). Memory is the count array over the grid's span --
     142 MB on a default-resampled timsTOF axis -- plus one frame, whatever the
     number of pixels; disk is 12 bytes per stored non-zero while the table is
     being built. Measured on a whole 26,087-pixel timsTOF acquisition on a

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -49,8 +49,8 @@ thyra input.imzML output.zarr && python analyse.py output.zarr
 | `--include-optical / --no-optical` | enabled | Include optical images in output |
 | `--mobility-table / --no-mobility-table` | enabled | Also write the mobility-resolved sibling table when the source shares one set of (m/z, ion mobility) features across pixels (see [Output Format](output-format.md#ion-mobility)) |
 | `--mobility-heatmap / --no-mobility-heatmap` | enabled | When the source has an ion mobility dimension, store the mean mass-mobility frame on the summed table as `uns["mobility_heatmap"]`; one extra pass over the source (see [Output Format](output-format.md#ion-mobility)) |
-| `--mobility-grid / --no-mobility-grid` | **disabled** | When the source carries ion mobility per pixel rather than as a shared feature list (Bruker TDF), bin the point cloud onto a common mobility grid and write the same mobility-resolved sibling table; one extra pass over the source beyond the heatmap's, a much larger table built out of core so any acquisition fits, and it forces `--tdf-spectrum scan_sum` (see [Output Format](output-format.md#the-same-table-from-a-common-mobility-grid)) |
-| `--msms-table / --no-msms-table` | **disabled** | When the source isolates several precursors per pixel in disjoint mobility slices (Bruker PASEF), also write them split apart as a demultiplexed sibling table; two extra passes over the source, and it forces `--tdf-spectrum scan_sum` so the split adds back up to the summed table exactly (see [Output Format](output-format.md#demultiplexed-msms-table)) |
+| `--mobility-grid / --no-mobility-grid` | **disabled** | When the source carries ion mobility per pixel rather than as a shared feature list (Bruker TDF), bin the point cloud onto a common mobility grid and write the same mobility-resolved sibling table; one extra pass over the source beyond the heatmap's, a much larger table built out of core so any acquisition fits; its marginal reproduces the summed table exactly under the default `--tdf-spectrum scan_sum` (see [Output Format](output-format.md#the-same-table-from-a-common-mobility-grid)) |
+| `--msms-table / --no-msms-table` | enabled | When the source isolates several precursors per pixel in disjoint mobility slices (Bruker PASEF), also write them split apart as a demultiplexed sibling table; two extra passes over the source; the split adds back up to the summed table exactly under the default `--tdf-spectrum scan_sum` (see [Output Format](output-format.md#demultiplexed-msms-table)) |
 
 ### Examples
 
@@ -151,8 +151,11 @@ thyra tims_data.d output.zarr --mobility-grid --mobility-bins 512     --mobility
     axis' width is multiplied by 256. A default resampled timsTOF axis is
     around 140,000 bins; 200 frames of one measured acquisition filled 3.9
     million of the resulting pairs, and a whole 26,000-pixel acquisition
-    would pass the 20,000,000 ceiling the table is refused at. Reach for
-    `--resample-bins` when the whole image is wanted resolved.
+    occupies 21 million. The table is refused when the `var` frame those
+    pairs make is projected to take more than half of the machine's free
+    memory (about 330 bytes per pair, measured), and warned about past a
+    quarter. Reach for `--resample-bins` when the whole image is wanted
+    resolved on a smaller machine.
 
 !!! warning "The defaults are an alignment, and the grid changes the TIC"
     256 channels over the mobility axis' own value range is exactly what
@@ -160,12 +163,11 @@ thyra tims_data.d output.zarr --mobility-grid --mobility-bins 512     --mobility
     selects grid channels by integer index. `--mobility-bins`,
     `--mobility-min` and `--mobility-max` each give that up.
 
-    Asking for a grid also switches a TDF conversion to `--tdf-spectrum
-    scan_sum` unless that option was given explicitly, and says so at
-    `WARNING`: the grid is built from raw scans, and its marginal over
-    channels reproduces the summed table only when that table was built the
-    same way. The switch moves the stored TIC by 13 to 21 percent against a
-    default conversion of the same file.
+    The grid is built from raw scans, and its marginal over channels
+    reproduces the summed table only when that table was built the same
+    way, which the default `--tdf-spectrum scan_sum` is. An explicit
+    `vendor_centroid` is kept, said at `WARNING`, and the mismatch is
+    recorded in the grid's `uns` block.
 
 ---
 
@@ -346,7 +348,7 @@ These options only apply when converting Bruker `.d` directories.
 | `--use-recalibrated / --no-recalibrated` | enabled | Use recalibrated m/z state |
 | `--interactive-calibration` | off | Display available calibration states |
 | `--intensity-threshold FLOAT` | none | Minimum intensity filter |
-| `--tdf-spectrum {vendor_centroid,scan_sum}` | `vendor_centroid`; `scan_sum` when `--mobility-grid` or `--msms-table` is given | How a TDF (TIMS) frame's mobility scans collapse into one spectrum per pixel |
+| `--tdf-spectrum {scan_sum,vendor_centroid}` | `scan_sum` | How a TDF (TIMS) frame's mobility scans collapse into one spectrum per pixel |
 
 ### Examples
 
@@ -360,16 +362,18 @@ thyra data.d output.zarr --interactive-calibration
 # Filter low-intensity signals (useful for continuous-mode Bruker data)
 thyra data.d output.zarr --intensity-threshold 100
 
-# TIMS data: keep every ion count instead of Bruker's centroided spectrum
-thyra tims_data.d output.zarr --tdf-spectrum scan_sum
+# TIMS data: reproduce Bruker's centroided spectrum instead of the raw scan sum
+thyra tims_data.d output.zarr --tdf-spectrum vendor_centroid
 ```
 
 !!! note "TDF: the mobility ramp is summed, not sliced"
-    Every scan of a TIMS frame is read. `vendor_centroid` is Bruker's own
-    frame-level peak picker over the full ramp (parity with TSF line spectra
-    and SCiLS Lab); `scan_sum` sums every scan per digitizer index and keeps
-    all of the ion current, at three to four times the points. See
-    [Supported Formats](supported-formats.md#bruker-timstof).
+    Every scan of a TIMS frame is read. `scan_sum` (default) sums every scan
+    per digitizer index and keeps all of the ion current, which is also
+    Bruker's own per-frame total; `vendor_centroid` is Bruker's frame-level
+    peak picker over the full ramp (parity with TSF line spectra and SCiLS
+    Lab), at 87 to 96 percent of the current and a third to two thirds of
+    the points. See [Supported Formats](supported-formats.md#bruker-timstof)
+    and [Design Decisions](design-decisions.md#d1-which-spectrum-a-reader-takes).
 
 !!! warning "Intensity threshold"
     The `--intensity-threshold` option drops all peaks below the given value

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -23,9 +23,10 @@ it stated.
 one, otherwise the vendor's picked spectrum. It applies no peak picking of
 its own.
 
-**Status:** Accepted 2026-09-07. Changes the Bruker TDF default from
-`vendor_centroid` to `scan_sum` in the next minor release. Every other row of
-the table below is already what the code does.
+**Status:** Implemented 2026-09-07. The Bruker TDF default changed from
+`vendor_centroid` to `scan_sum`; the centroid stays available through
+`--tdf-spectrum vendor_centroid`. Every other row of the table below was
+already what the code does.
 
 | Source | What the file holds | What Thyra reads | Why |
 |---|---|---|---|
@@ -99,17 +100,28 @@ vendor calls TIC.
   reading the largest array available.
 
 **Known limits.** The summed table holds about three times the points per
-pixel on a short-ramp slide, half again on a long-ramp one. The full
-26k-pixel store size under `scan_sum` is not yet measured and should be
-before the release.
+pixel on a short-ramp slide, half again on a long-ramp one. Measured on
+the whole 26,087-pixel slide (2026-09-07, default mass axis, optical image
+left out, same machine):
+
+| | `vendor_centroid` | `scan_sum` | ratio |
+|---|---|---|---|
+| non-zeros in the summed table | 282,223,487 | 893,289,573 | 3.2x |
+| store on disk | 1.36 GB | 2.50 GB | 1.8x |
+| conversion, warm | 438 s | 528 s | 1.2x |
+
+The store grows less than the point count because the sharded chunks
+compress the low counts well. That is the price of the default, and the
+flag buys the old size back.
 
 ---
 
 ## D2. The MS/MS table is written by default when the schedule qualifies
 
-**Status:** Accepted 2026-09-07. `--msms-table` becomes the default for a
-Bruker PASEF acquisition with a constant, non-overlapping schedule of at
-least two precursors; `--no-msms-table` opts out.
+**Status:** Implemented 2026-09-07. `--msms-table` is the default; the
+table is written for a Bruker PASEF acquisition with a constant,
+non-overlapping schedule of at least two precursors and refused, with the
+reason logged, on everything else. `--no-msms-table` opts out.
 
 **Reason.** A scheduled PASEF acquisition fragments each precursor in turn
 at every pixel. The one-spectrum-per-pixel summed table of such a pixel is
@@ -182,11 +194,12 @@ are opt in and carry their parameters.
 
 ## D4. The grid's feature ceiling is a memory guard, not a format limit
 
-**Status:** Accepted 2026-09-07. The fixed ceiling of 20,000,000 occupied
-(m/z bin, mobility channel) pairs becomes a projection of the `var` frame's
-memory against the machine's free memory, warning past one fraction and
-refusing past a larger one, with an absolute cap kept only as documentation
-for downstream tools.
+**Status:** Implemented 2026-09-07. The fixed ceiling of 20,000,000 occupied
+(m/z bin, mobility channel) pairs became a projection of the `var` frame's
+memory (330 bytes per feature, measured) against the machine's free memory,
+warning past a quarter of it and refusing past half, with an absolute cap of
+100,000,000 kept as a statement of what downstream tools can be expected to
+open rather than as the operative guard.
 
 **Reason.** Both sibling tables are built out of core, so the remaining
 peak is the `var` frame, measured at roughly 330 bytes per feature including
@@ -226,8 +239,8 @@ about a 4 GB file on a network share, and that case is unmeasured.
 
 ## D6. The MS/MS fragment axis is the MS1 mass axis
 
-**Status:** Implemented. Condition accepted 2026-09-07: refuse or warn when
-the axis is unresampled.
+**Status:** Implemented. A condition attached to it on 2026-09-07, to refuse
+the table on an unresampled axis, was withdrawn the same day; see below.
 
 **Reason.** Fragments and precursors pass through the same TOF and have the
 same resolving power, so one mass axis per store is the accurate
@@ -238,19 +251,24 @@ meaningful and the conservation check exact.
 **Objections considered.**
 
 - *On a raw, unresampled axis fragments snap to MS1-only m/z values, and
-  any fragment outside the axis range is dropped.* Correct. The CLI always
-  resamples, so this only bites the Python API called without a resampling
-  configuration. The MS/MS table should refuse, or at least warn, on a raw
-  axis; that is the condition above.
+  any fragment outside the axis range is dropped.* This objection was
+  raised, accepted, implemented as a refusal, and then found to be wrong
+  by the existing PASEF test, which relies on the raw axis for an exact
+  equality. The premise fails because on a scheduled MS/MS acquisition the
+  summed table holds no intact ions: its spectra are the same fragment
+  peaks the split re-reads, so the raw axis is the union of the fragment
+  m/z values themselves and the mapping is exact. The refusal was removed
+  and a test now pins the raw axis as exact on both write routes.
 
-**Known limits.** MS1 resampling sets fragment resolution. That is a
-consequence of the decision, not an accident.
+**Known limits.** The resampling grid chosen for the summed table sets
+fragment resolution. That is a consequence of the decision, not an
+accident.
 
 ---
 
 ## D7. Waters: the summed table takes MS level 1 only
 
-**Status:** Accepted 2026-09-07, as a correctness fix.
+**Status:** Implemented 2026-09-07, as a correctness fix.
 
 **What was found.** The Waters reader classifies acquisition functions and
 then yields every scan of every MS-classified function as a pixel spectrum,
@@ -261,10 +279,13 @@ that MassLynx reports are parsed and then ignored. What the converter does
 with the duplicate coordinate is not verified, and no Waters MS/MS imaging
 file was available to test on; either outcome, overwrite or sum, is wrong.
 
-**Decision.** Filter the summed table to MS level 1 and record the other
-functions in the fragmentation metadata block the Bruker path already
-writes. A demultiplexed Waters table waits until a scheduled Waters
-acquisition exists to look at.
+**Decision.** Convert the MS level 1 functions only, and list the others,
+with their level, precursor m/z and scan count, under `excluded_functions`
+in the Waters-specific metadata block. The versioned `fragmentation` block
+describes the spectra in the store, so it says MS1 for such a file; a file
+with MS/MS functions only converts them and reports their precursors there,
+as the Bruker path does. A demultiplexed Waters table waits until a
+scheduled Waters acquisition exists to look at.
 
 **Objections considered.**
 

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -34,7 +34,8 @@ already what the code does.
 | Bruker TSF (TIMS off) | a vendor line spectrum, plus a raw digitizer trace | the line spectrum | the trace is a continuum with a baseline, not a peak list |
 | Bruker solariX | centroided peak lists in `peaks.sqlite`; raw transients | the peak lists | the only sparse record; transients need an FT |
 | Bruker rapifleX | profile spectra | the profile, resampled | nothing else exists; the resampler conserves current |
-| Waters | vendor centroid or profile continuum from MassLynx | the centroid (profile on request) | same shape as TSF |
+| Waters SELECT SERIES MRT | a zero-suppressed digitiser trace, plus a vendor centroid on demand | the trace, onto a digitiser-matched axis | the picker merges 8 to 9 mDa doublets the trace resolves; see [Supported Formats](supported-formats.md#waters-masslynx) |
+| every other Waters instrument | the same trace, plus a vendor centroid on demand | the centroid (profile on request) | measured on a Synapt G2-Si, the picker keeps everything the trace resolves, so the trace would cost 2 to 3 times the store for nothing |
 | imzML, mzPeak, PHI | whatever was exported | as exported | the export already made the choice |
 
 The line between TDF and TSF is the whole decision, so it was measured
@@ -68,8 +69,12 @@ peak *heights*, and `Frames.SummedIntensities` is the sum of those heights.
 The trace has a baseline of 18 on every sample, peaks 15 to 150 samples
 wide, and a total 3.4 to 3.7 times the line sum. Summing it would import a
 baseline and change the meaning of intensity from height to area. That is a
-different kind of data, and the same kind Waters offers as "profile", so TSF
-and Waters stay on the vendor's picked spectrum.
+different kind of data, so TSF stays on the vendor's line spectrum. The
+Waters trace is not the same kind: it is zero-suppressed, so it carries no
+baseline, and it is the digitiser's record. Which side of the rule a Waters
+instrument falls on is therefore decided by whether its peak picker has been
+shown to lose what the trace keeps, which is the MRT measurement in the
+next row of the table.
 
 **Why `scan_sum` is the TDF default.** Thyra's one invariant everywhere
 else is that ion current is conserved: the resampler is TIC-preserving and
@@ -98,6 +103,13 @@ vendor calls TIC.
   is a continuum with a baseline, and its line intensities are heights by
   Bruker's own definition. The rule is about sparse records, not about
   reading the largest array available.
+- *Then Waters should stay on its centroid, as this page first said.* The
+  first version of this table put every Waters instrument on the centroid
+  and called its profile "the same kind of data" as the TSF trace. That was
+  wrong on both counts, and the correction came from the measurements
+  behind the MRT profile default rather than from this page: the Waters
+  trace has no baseline, and on the MRT the picker merges near-isobars the
+  trace resolves. The rule did not change; the row did.
 
 **Known limits.** The summed table holds about three times the points per
 pixel on a short-ramp slide, half again on a long-ramp one. Measured on

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -223,17 +223,75 @@ the present fixed ceiling and is refused after one fused read; with
 
 ---
 
-## D5. One pass over the raw file for all three tables: deferred
+## D5. One raw read per frame per pass serves every table
 
-**Status:** Deferred 2026-09-07.
+**Status:** Implemented 2026-09-07, the same day it was deferred. It was
+deferred on a 400-frame warm measurement that put the grid's extra read at
+about 4 percent of wall time; the whole-slide logs from the D1 measurement
+then showed the mobility heatmap's own pass at 201 s of a 528 s conversion
+under `scan_sum` and 272 s of 438 s under the vendor centroid. The extra
+reads were 38 to 62 percent of a default conversion, not 4, and the reopen
+condition was met on the same afternoon.
 
-**Reason.** Measured warm on 400 frames, the extra read that the grid costs
-is about 4 percent of wall time. The engine's two passes, count then
-scatter, are inherent and cannot become one.
+**Decision.** A Bruker TDF reader hands each frame over once, as a record
+of its raw scan read, from which the summed spectrum, the mobility point
+cloud and the fragment spectrum of each precursor are all derived. On the
+streaming route the two passes the summed table already takes, count then
+scatter, feed the heatmap, the mobility grid and the MS/MS table from that
+same read. Two raw reads of the source per conversion, whatever is written;
+a default conversion used to take three, a grid four, a grid with the MS/MS
+split six. The engine's two passes are still inherent, so "one pass" was
+never the right name; "one read per pass" is.
 
-**Reopen when** a cold measurement on the 26k-pixel slide shows the extra
-read above about 10 percent of the conversion. The warm number says nothing
-about a 4 GB file on a network share, and that case is unmeasured.
+**What makes it safe.** Every derivation goes through the very helpers the
+reader's three iterators use, and every sink is the same accumulator the
+standalone passes feed, so the fused route cannot see different numbers.
+That was checked rather than assumed: stores written by the committed code
+and by the fused code were compared table by table on five configurations
+(the 400-frame slide with and without the grid on both write routes, and
+the 713-pixel PASEF set with its split on both routes) and were identical
+in every array, every `var` and `obs` frame and every `uns` block, index
+dtypes included. A stub source that answers both the iterators and the
+records pins the same identity in the unit tests, and pins that the fused
+route reads it exactly twice and never through the iterators.
+
+**Measured** (2026-09-07, warm, optical image left out):
+
+| conversion | before | after |
+|---|---|---|
+| 400 frames, default (heatmap) | 13 s | 11 s |
+| 400 frames, `--mobility-grid` | 32 s | 21 s |
+| 713-pixel PASEF, MS/MS split | 12 s | 9 s |
+| whole 26,087-pixel slide, default | 528 s | 454 s |
+| whole slide, `--mobility-grid --resample-bins 40000` | 1,400 s | 858 s |
+
+The grid row's "before" was measured on an earlier commit, before the
+engine's column sort was made six times faster, so part of that gain is
+the sort's; the 400-frame row above is the clean comparison for the grid.
+On the whole slide the heatmap's own pass (201 s) became part of the count
+pass, which grew from about 120 s to 266 s: what was saved is the read and
+the index-to-m/z conversion of every frame, about 55 s, plus the second
+scatter-side read. What remains is the mapping of every raw point onto the
+mass axis, 51,000 points per frame on this slide, which the heatmap and
+the grid need and the summed spectrum does not. That mapping is the next
+lever, not another read: the points of a frame share about 30,000 unique
+digitizer indices, and mapping those once and gathering would give the
+same bins for two fifths of the work. Not done here.
+
+**Objections considered.**
+
+- *The in-memory route still runs the standalone passes.* True, and left
+  so: that route holds the whole matrix in RAM and is taken by small
+  files, where the passes cost seconds. The streaming route is where a
+  file large enough for the passes to matter goes.
+- *Under `vendor_centroid` the summed spectrum cannot be derived from the
+  raw scans.* Correct; in that mode the record asks the library for the
+  centroid as a second call per frame, and the raw read still serves the
+  sinks. That mode is the opt-in.
+
+**Known limits.** Only the Bruker TDF reader hands frames over as records;
+every other source keeps its iterators and its standalone passes, which for
+an imzML mobility export is one pass over an already sparse file.
 
 ---
 

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1,0 +1,283 @@
+# Design Decisions
+
+This page records the decisions behind Thyra's defaults where a reasonable
+person could have chosen otherwise. Each entry gives the decision, the
+reason, the strongest objection that was raised against it and why it did
+not win, and the known limit. The goal is that someone who disagrees can see
+exactly which premise to argue with, and open an issue against that premise
+rather than against a number in a table.
+
+Every measurement quoted here was taken on real acquisitions on the date
+given, so a future maintainer can repeat it.
+
+**Status vocabulary.** *Implemented* means the code on `main` does this.
+*Accepted* means the decision is made and recorded but the change has not
+shipped yet. *Deferred* means no change, with the condition that would reopen
+it stated.
+
+---
+
+## D1. Which spectrum a reader takes
+
+**Decision.** Thyra reads the instrument's sparse record when the file holds
+one, otherwise the vendor's picked spectrum. It applies no peak picking of
+its own.
+
+**Status:** Accepted 2026-09-07. Changes the Bruker TDF default from
+`vendor_centroid` to `scan_sum` in the next minor release. Every other row of
+the table below is already what the code does.
+
+| Source | What the file holds | What Thyra reads | Why |
+|---|---|---|---|
+| Bruker TDF (TIMS on) | per-scan digitizer-index counts for every mobility scan, plus a vendor centroid on request | the scans, summed per index (`scan_sum`) | the sparse record; equals Bruker's own frame total |
+| Bruker TSF (TIMS off) | a vendor line spectrum, plus a raw digitizer trace | the line spectrum | the trace is a continuum with a baseline, not a peak list |
+| Bruker solariX | centroided peak lists in `peaks.sqlite`; raw transients | the peak lists | the only sparse record; transients need an FT |
+| Bruker rapifleX | profile spectra | the profile, resampled | nothing else exists; the resampler conserves current |
+| Waters | vendor centroid or profile continuum from MassLynx | the centroid (profile on request) | same shape as TSF |
+| imzML, mzPeak, PHI | whatever was exported | as exported | the export already made the choice |
+
+The line between TDF and TSF is the whole decision, so it was measured
+rather than assumed.
+
+**Measured on TDF** (2026-09-07; 30 frames of a 26k-pixel MALDI-2 slide and
+10 frames of a 20 um biofilm set):
+
+| Quantity | Slide | Biofilm |
+|---|---|---|
+| `scan_sum` total against Bruker's quasi-profile export (`tims_extract_profile_for_frame`) | identical | identical |
+| `scan_sum` total against Bruker's per-frame TIC column (`Frames.SummedIntensities`) | 1.0000 | 0.9992 |
+| vendor centroid total against the same TIC column | 0.8748 | 0.9644 |
+| centroid intensity of a strong peak against the summed indices under it | 0.97 to 0.99 | 0.98 to 0.99 |
+| points per frame, `scan_sum` over centroid | 2.9x | 1.5x |
+| raw pair intensities equal to 1 | none | none |
+
+Three things are therefore true at once. The vendor centroid reports peak
+*areas* and conserves the current inside each peak it picks. What it drops
+is every index bin that its picker assigned to no peak: 12.5 percent of the
+slide's current and 3.6 percent of the biofilm's. And Bruker's own
+definition of a frame's total ion current is the scan sum, not the centroid.
+The earlier description of the loss as "single-count noise" was wrong: these
+files contain no single counts, and the dropped current is sub-threshold
+signal.
+
+**Measured on TSF** (2026-09-07; two files from different acquisitions): the
+line spectrum's intensity equals the maximum of the digitizer trace under
+the peak exactly (ratio 1.000 on every peak checked), so TSF intensities are
+peak *heights*, and `Frames.SummedIntensities` is the sum of those heights.
+The trace has a baseline of 18 on every sample, peaks 15 to 150 samples
+wide, and a total 3.4 to 3.7 times the line sum. Summing it would import a
+baseline and change the meaning of intensity from height to area. That is a
+different kind of data, and the same kind Waters offers as "profile", so TSF
+and Waters stay on the vendor's picked spectrum.
+
+**Why `scan_sum` is the TDF default.** Thyra's one invariant everywhere
+else is that ion current is conserved: the resampler is TIC-preserving and
+every sibling table is checked against an exact identity. The vendor
+centroid was the single place where a closed, unversioned algorithm removed
+current before the store was written. Under `scan_sum` every identity holds
+by construction: the mobility heatmap's marginal is the mean spectrum, the
+mobility grid's marginal is the summed table, and the MS/MS blocks add back
+up to the summed table. And the number a reader calls TIC is the number the
+vendor calls TIC.
+
+**Objections considered.**
+
+- *The dropped current is noise, and keeping it raises the noise floor.*
+  Some of it is. Removing it is analysis, reproducible downstream by any
+  method the user chooses and documented in their own pipeline. Removing it
+  at conversion is irreversible and undocumented.
+- *Users comparing with SCiLS Lab or TSF exports will see different
+  numbers.* True. The mode is recorded in
+  `msi_metadata.processing[0].parameters.tdf_spectrum`, and
+  `--tdf-spectrum vendor_centroid` restores the vendor numbers exactly.
+- *It changes the numbers of every existing TDF pipeline.* True, and the
+  real cost. It ships as a minor release with a changelog entry, and an old
+  store can be told from a new one by the provenance field.
+- *Then TSF should sum its profile for consistency.* No. The TSF profile
+  is a continuum with a baseline, and its line intensities are heights by
+  Bruker's own definition. The rule is about sparse records, not about
+  reading the largest array available.
+
+**Known limits.** The summed table holds about three times the points per
+pixel on a short-ramp slide, half again on a long-ramp one. The full
+26k-pixel store size under `scan_sum` is not yet measured and should be
+before the release.
+
+---
+
+## D2. The MS/MS table is written by default when the schedule qualifies
+
+**Status:** Accepted 2026-09-07. `--msms-table` becomes the default for a
+Bruker PASEF acquisition with a constant, non-overlapping schedule of at
+least two precursors; `--no-msms-table` opts out.
+
+**Reason.** A scheduled PASEF acquisition fragments each precursor in turn
+at every pixel. The one-spectrum-per-pixel summed table of such a pixel is
+therefore a mixture of unrelated fragment spectra. It is not a spectrum of
+anything, and writing only that mixture is the inaccurate representation.
+The split is parameter-free, since the schedule is the instrument's own
+list, and lossless, since every recorded point falls in exactly one
+isolation window; under D1 its blocks add back to the summed table exactly.
+The refusals for a schedule that varies across pixels, overlapping windows,
+or a single precursor already fall back silently to the summed table, so the
+default never breaks a conversion. The prior-art survey in
+[Output Format](output-format.md#fragmentation-msms) found no open
+analysis-layer convention to defer to.
+
+**Objections considered.**
+
+- *It has run on one dataset: 713 pixels, 15 precursors, one schedule
+  shape.* True, and stated as a limit. The assembly engine underneath is
+  the one verified on the 26k-pixel mobility grid, and the MS/MS count span
+  is tiny, so scale is not where it would fail. A different schedule shape
+  is, and no such file exists to test on. That is a reason to document the
+  limit, not to ship the mixture by default.
+- *A default-on writes an element the user did not ask for and consumers
+  must recognise.* The sibling is discriminated by its `uns` block exactly
+  as the mobility sibling already is, and the summed table remains the
+  primary element.
+
+**Known limits.** Tested to 713 pixels, 15 precursors, one schedule shape.
+
+---
+
+## D3. The mobility grid stays opt in
+
+**Status:** Implemented. `--mobility-grid` is off by default.
+
+**Reason.** This is the opposite case to D2. Summing a TIMS pixel's
+mobility scans gives an ordinary MS1 spectrum; nothing about it is
+inaccurate. The grid is the same data unfolded along a second axis with
+choices the summed table does not need: how many mobility channels, and a
+channel width that then depends on each acquisition's ramp. Anything with
+free parameters is a derived product, and derived products are written when
+asked, with their parameters recorded, so that nobody later finds a 256 in a
+store and wonders who chose it. The lossless summary of the mobility
+dimension, the mass-mobility heatmap plus the mobility axis metadata, is
+written by default, and under D1 the heatmap's marginal equals the stored
+mean spectrum exactly.
+
+The sentence that decides D2 and D3 together: the default store contains
+what is accurate without any parameter beyond the mass axis, plus a
+lossless summary of every extra dimension. Grids over an extra dimension
+are opt in and carry their parameters.
+
+**Objections considered.**
+
+- *The mass axis is also a parameterised, derived choice, and it is
+  default.* A mass axis is necessary to build any table at all; the grid is
+  optional on top of a complete table. This is the thinnest argument on the
+  page and is recorded as such.
+- *Users will not discover it.* The conversion log says the source has
+  mobility, and this page exists.
+- *Practical costs are secondary but real.* On 400 frames the store is six
+  times larger and the conversion about five times slower warm; at the
+  default mass axis the whole 26k-pixel slide is refused (see D4). A
+  default that refuses the flagship dataset is not a default anyone can
+  rely on.
+
+**Known limits.** None beyond D4.
+
+---
+
+## D4. The grid's feature ceiling is a memory guard, not a format limit
+
+**Status:** Accepted 2026-09-07. The fixed ceiling of 20,000,000 occupied
+(m/z bin, mobility channel) pairs becomes a projection of the `var` frame's
+memory against the machine's free memory, warning past one fraction and
+refusing past a larger one, with an absolute cap kept only as documentation
+for downstream tools.
+
+**Reason.** Both sibling tables are built out of core, so the remaining
+peak is the `var` frame, measured at roughly 330 bytes per feature including
+the AnnData copies. The ceiling exists to protect that build. Raising the
+constant from 20M to 25M because the flagship slide occupies 21.1M pairs at
+the default axis would be fitting a constant to one dataset, and the
+objection to that is immediate. The honest guard is the one the grid used
+once before and that was accepted then: project bytes from the count and
+compare with what the machine has. Fractions rather than sizes, because a
+table that is routine on a workstation is fatal on a laptop.
+
+**Objections considered.**
+
+- *The per-feature constant is version and machine dependent.* It is
+  measured and documented, and a guess wrong by a factor of two still
+  refuses at half of free memory.
+
+**Known limits.** The whole slide at the default axis lands 5.5 percent over
+the present fixed ceiling and is refused after one fused read; with
+`--resample-bins 40000` it converts.
+
+---
+
+## D5. One pass over the raw file for all three tables: deferred
+
+**Status:** Deferred 2026-09-07.
+
+**Reason.** Measured warm on 400 frames, the extra read that the grid costs
+is about 4 percent of wall time. The engine's two passes, count then
+scatter, are inherent and cannot become one.
+
+**Reopen when** a cold measurement on the 26k-pixel slide shows the extra
+read above about 10 percent of the conversion. The warm number says nothing
+about a 4 GB file on a network share, and that case is unmeasured.
+
+---
+
+## D6. The MS/MS fragment axis is the MS1 mass axis
+
+**Status:** Implemented. Condition accepted 2026-09-07: refuse or warn when
+the axis is unresampled.
+
+**Reason.** Fragments and precursors pass through the same TOF and have the
+same resolving power, so one mass axis per store is the accurate
+representation. A separate fragment axis would invent a second resolution
+for the same analyser. The coupling is also what makes `mz_index`
+meaningful and the conservation check exact.
+
+**Objections considered.**
+
+- *On a raw, unresampled axis fragments snap to MS1-only m/z values, and
+  any fragment outside the axis range is dropped.* Correct. The CLI always
+  resamples, so this only bites the Python API called without a resampling
+  configuration. The MS/MS table should refuse, or at least warn, on a raw
+  axis; that is the condition above.
+
+**Known limits.** MS1 resampling sets fragment resolution. That is a
+consequence of the decision, not an accident.
+
+---
+
+## D7. Waters: the summed table takes MS level 1 only
+
+**Status:** Accepted 2026-09-07, as a correctness fix.
+
+**What was found.** The Waters reader classifies acquisition functions and
+then yields every scan of every MS-classified function as a pixel spectrum,
+keyed by laser coordinate. A two-function acquisition, MSe low and high
+energy or a data-dependent run, therefore emits two spectra at the same
+coordinate, one MS1 and one MS2. The per-scan MS level and precursor m/z
+that MassLynx reports are parsed and then ignored. What the converter does
+with the duplicate coordinate is not verified, and no Waters MS/MS imaging
+file was available to test on; either outcome, overwrite or sum, is wrong.
+
+**Decision.** Filter the summed table to MS level 1 and record the other
+functions in the fragmentation metadata block the Bruker path already
+writes. A demultiplexed Waters table waits until a scheduled Waters
+acquisition exists to look at.
+
+**Objections considered.**
+
+- *No test data.* The filter is on a field already parsed and is testable
+  with a synthetic scan record. The fix does not depend on the MS/MS table
+  work.
+
+---
+
+## D8. The `var` frame is the memory peak, and stays so
+
+**Status:** Accepted limit.
+
+With both sibling tables out of core, memory is proportional to the number
+of features, not to the number of non-zeros. That is the intended shape;
+D4 is the guard on it.

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,9 @@ The output is a single SpatialData/Zarr directory containing intensity matrices,
 | **Optics** | Optical alignment | Automatic MSI-to-microscopy registration (Bruker) |
 | **Regions** | Multi-region | Handles slides with multiple tissue sections |
 | **Resampling** | Physics-aware | Instrument-specific mass axis resampling (on by default in the CLI, opt-in from the Python API) |
+| **Ion mobility** | TIMS-aware | The summed spectrum is the instrument's own scan sum; the mass-mobility heatmap is stored by default and a mobility-resolved sibling table on request, fed from the same frame reads |
+| **MS/MS** | Demultiplexed | A scheduled PASEF acquisition is written split apart by precursor by default, next to the summed table; the schedule is recorded either way |
+| **Defaults** | Decided in the open | Every default a reasonable person could argue with is recorded with its reason and measurements in [Design Decisions](design-decisions.md) |
 | **3D** | Volume support | Process as 3D volume or separate 2D slices |
 | **Platform** | Cross-platform | Windows, macOS, Linux |
 

--- a/docs/metadata-schema.md
+++ b/docs/metadata-schema.md
@@ -129,6 +129,11 @@ which means "not reported", not "MS1". `windows` is stored as a JSON string
 mzPeak's, so an archive and a store describe a precursor the same way; see
 [Output Format](output-format.md#fragmentation-msms) for the array block
 beside it and for what `merges_precursors` means for the stored spectrum.
+Waters `.raw` fills it too, from the MS level MassLynx reports per scan: a
+file with MS/MS functions only reports their precursors here, and a file
+that also holds MS1 functions converts those alone, reports MS1, and lists
+the MS/MS functions it left out under `excluded_functions` in the
+Waters-specific block (see [Supported Formats](supported-formats.md#waters-masslynx)).
 `resolved_table` names the demultiplexed sibling table when one was written,
 mirroring `ion_mobility.resolved_table`, so both kinds of sibling are
 discoverable from this block alone.

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -418,13 +418,17 @@ the way the summed table is built on the streaming route, in two passes over
 the raw scans. The first pass counts, per `(m/z bin, channel)` cell of the
 grid, how many pixels occupy it -- a dense count over the grid's span, 142 MB
 on a default-resampled timsTOF axis, sized before the first pixel is read and
-independent of how many pixels there are. That pass is fused with the
-heatmap's: both need every point mapped onto the mass axis, and the mapping
-costs more than the vendor read, so it is done once. The second pass re-reads
-the source and scatters each pixel's cells straight into memmapped CSC arrays
-in a scratch directory next to the output (`.thyra_mobility_*`, removed once
-the table is written), 12 bytes of disk per stored non-zero. Nothing is ever
-held for the whole image: memory is the count array plus one frame.
+independent of how many pixels there are. The second pass scatters each
+pixel's cells straight into memmapped CSC arrays in a scratch directory next
+to the output (`.thyra_mobility_*`, removed once the table is written), 12
+bytes of disk per stored non-zero. Nothing is ever held for the whole image:
+memory is the count array plus one frame. On a Bruker TDF both passes are
+the summed table's own: the streaming route reads each frame once per pass
+and derives the summed spectrum, the heatmap's points, the grid's cells and
+the MS/MS split from that one read, so none of the siblings adds a read of
+the source (see [Design Decisions](design-decisions.md#d5-one-raw-read-per-frame-per-pass-serves-every-table)).
+Every point is mapped onto the mass axis once per pass and shared between
+the heatmap and the grid, since the mapping costs more than the vendor read.
 
 The size ceiling is on the pairs that carry signal, not on the pairs the grid
 spans. The two differ by an order of magnitude -- 200 frames of a measured
@@ -607,7 +611,9 @@ already holds for the TIC image.
       then scatter into memmapped CSC arrays in a scratch directory next to
       the output (`.thyra_msms_*`) -- so memory is the count array
       (`4 bytes x precursors x mass bins`) plus one frame, whatever the
-      pixel count. The largest acquisition this has run on is still 713
+      pixel count. On the streaming route those are the summed table's own
+      two passes, fed from the same frame read, so the split adds no read
+      of the source. The largest acquisition this has run on is still 713
       pixels with 15 precursors; `var` grows with the occupied pairs.
 
 !!! note "Relation to other MS/MS imaging representations"

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -376,13 +376,12 @@ Three things are worth knowing before asking for one:
   the 0.002 to 0.02 band TIMS resolving power supports; that is said at
   `INFO` and the count is not moved for it, because the alignment is worth
   more than the size.
-- **It forces `--tdf-spectrum scan_sum`,** at `WARNING`, unless that option
-  was given explicitly. A grid table is built from raw scans, so its marginal
-  reproduces the summed table only when the summed table was built from the
-  same scans; the default vendor centroid is a peak-picked spectrum over the
-  same ramp. The switch moves the stored TIC by 13 to 21 percent against a
-  default conversion of the same file, which reads as a bug if it happens
-  quietly.
+- **Its marginal reproduces the summed table under the default
+  `--tdf-spectrum scan_sum`.** A grid table is built from raw scans, so its
+  marginal reproduces the summed table only when the summed table was built
+  from the same scans, which the default is. An explicit `vendor_centroid`,
+  a peak-picked spectrum over the same ramp, is kept and said at `WARNING`;
+  `uns["mobility_marginal"]` then records by how much the two differ.
 
 **The marginal invariant.** Summing a grid table's channels within one m/z
 bin reproduces that bin's column of the summed table, per pixel. That is what
@@ -412,7 +411,7 @@ A grid is refused, at `INFO` or `WARNING` and never as an exception, when:
 | `--mobility-grid` was not given | binning is opt in: it costs a pass over the source and a much larger table |
 | the mobility axis carries no per-scan values | a reader opened without its vendor library cannot supply them, and the declared range is not a substitute |
 | the grid spans more pairs than the counting pass can hold (a raw, unresampled axis of millions of bins) | the count array is `4 bytes x bins x channels`, capped at 1 GB; resample to fewer mass bins |
-| the occupied `(m/z bin, channel)` pairs pass 20,000,000 | the count is printed; resample to fewer mass bins or ask for fewer channels |
+| the `var` frame of the occupied `(m/z bin, channel)` pairs is projected to take more than half of the machine's free memory (330 bytes per pair, measured), or the pairs pass an absolute cap of 100,000,000 | the count, the projection and the free memory are printed; resample to fewer mass bins or ask for fewer channels. A projection past a quarter of free memory is attempted with a `WARNING`. See [Design Decisions](design-decisions.md#d4-the-grids-feature-ceiling-is-a-memory-guard-not-a-format-limit) |
 
 **How it is built, and why its size does not matter.** The table is built
 the way the summed table is built on the streaming route, in two passes over
@@ -476,9 +475,9 @@ AnnData/zarr); `read_msi_metadata_blocks` and `thyra validate` decode it.
     `merges_precursors` is `True`, that spectrum holds fragments of every
     precursor the frame isolated, with nothing marking which came from
     which -- so it must not be read as the fragment spectrum of any one of
-    them. Conversion says so at `WARNING`. `--msms-table` writes the split
-    apart as a second table, below; the MSI table itself is unchanged
-    either way.
+    them. Conversion says so at `WARNING`, and by default also writes the
+    split apart as a second table, below (`--no-msms-table` turns that
+    off); the MSI table itself is unchanged either way.
 
 ```python
 if "msms_schedule" in table.uns:
@@ -493,8 +492,10 @@ if "msms_schedule" in table.uns:
 When the source isolates several precursors per pixel in **disjoint
 mobility scan ranges** (Bruker PASEF -- the targeted MALDI variant is
 Bruker's `iprm-PASEF`, which serially fragments a scheduled list of
-precursors at every pixel), `--msms-table` also writes them split apart as
-a sibling table, `{table}_msms`. Each precursor's block is its **precursor
+precursors at every pixel), Thyra also writes them split apart as a
+sibling table, `{table}_msms`, by default (`--no-msms-table` opts out; see
+[Design Decisions](design-decisions.md#d2-the-msms-table-is-written-by-default-when-the-schedule-qualifies)).
+Each precursor's block is its **precursor
 ion image**, and each column inside the block is one fragment's image:
 
 | | MSI table `{id}_z0` | MS/MS table `{id}_z0_msms` |
@@ -513,13 +514,12 @@ precursor's fragments are therefore a contiguous column block whose row
 sums are its ion image, and **the blocks add back up**: summing all
 fragment columns of every precursor reproduces the summed table's TIC per
 pixel, because each recorded point falls in exactly one isolation window.
-Exactly, because `--msms-table` selects `--tdf-spectrum scan_sum` for the
-summed table (at `WARNING`, as `--mobility-grid` does, and never over an
-explicit `--tdf-spectrum`): the split is built from the raw scans, and only
-a summed spectrum built from the same scans can add back up to it. The
-vendor centroid keeps only the current inside the peaks it picks (87 to
-96 percent on the acquisitions measured) and the two tables of one store
-would genuinely not agree.
+Exactly, under the default `--tdf-spectrum scan_sum`: the split is built
+from the raw scans, and only a summed spectrum built from the same scans
+can add back up to it. An explicit `vendor_centroid` keeps only the current
+inside the peaks it picks (87 to 96 percent on the acquisitions measured),
+so the two tables of one store would genuinely not agree; that is said at
+`WARNING` and recorded in `uns["demultiplexed_current"]`.
 
 ```python
 msms = sdata.tables["msi_z0_msms"]
@@ -578,8 +578,8 @@ split needs today.
 
 **`uns["demultiplexed_current"]`** records how much of the summed table's
 ion current the split holds: `current_ratio` over the whole image, and
-`current_ratio_pixel_min` / `_max` across pixels. Under
-`--tdf-spectrum scan_sum`, which the table selects, it is exactly `1.0`.
+`current_ratio_pixel_min` / `_max` across pixels. Under the default
+`--tdf-spectrum scan_sum` it is exactly `1.0`.
 Under an explicit `--tdf-spectrum vendor_centroid` it is **above** 1 -- the
 vendor peak picker drops the index bins it assigns to no peak while the
 split reads raw scans,

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -289,9 +289,10 @@ integer index in both directions.
 The m/z binning is the converter's own nearest-bin rule, coarsened, so under a
 lossless summed spectrum (`--tdf-spectrum scan_sum`) the heatmap summed over
 mobility, `counts.sum(axis=1)`, equals `uns["average_spectrum"]` coarsened to
-`mz_edges`. Under the default `vendor_centroid` it does not: the centroid keeps
-80 to 90 percent of the ion current and merges bins, while the heatmap is
-built from every raw point. On a Bruker source the heatmap costs one extra
+`mz_edges`. Under `vendor_centroid` it does not: the centroid keeps only the current
+inside the peaks its picker assigns (87 to 96 percent on the acquisitions
+measured, see [Design Decisions](design-decisions.md#d1-which-spectrum-a-reader-takes))
+and merges bins, while the heatmap is built from every raw point. On a Bruker source the heatmap costs one extra
 library call per frame (about a millisecond); `--no-mobility-heatmap` skips
 it.
 
@@ -516,8 +517,9 @@ Exactly, because `--msms-table` selects `--tdf-spectrum scan_sum` for the
 summed table (at `WARNING`, as `--mobility-grid` does, and never over an
 explicit `--tdf-spectrum`): the split is built from the raw scans, and only
 a summed spectrum built from the same scans can add back up to it. The
-vendor centroid keeps 80 to 90 percent of the raw ion current and the two
-tables of one store would genuinely not agree.
+vendor centroid keeps only the current inside the peaks it picks (87 to
+96 percent on the acquisitions measured) and the two tables of one store
+would genuinely not agree.
 
 ```python
 msms = sdata.tables["msi_z0_msms"]
@@ -579,7 +581,8 @@ ion current the split holds: `current_ratio` over the whole image, and
 `current_ratio_pixel_min` / `_max` across pixels. Under
 `--tdf-spectrum scan_sum`, which the table selects, it is exactly `1.0`.
 Under an explicit `--tdf-spectrum vendor_centroid` it is **above** 1 -- the
-vendor peak picker discards single counts while the split reads raw scans,
+vendor peak picker drops the index bins it assigns to no peak while the
+split reads raw scans,
 which on a real acquisition is about 1.5% overall and up to 1.14x on a
 single pixel. The two tables genuinely do not add up in that mode, and this
 block is where the store says so. It is written on every route, including

--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -114,8 +114,11 @@ instead (below). Two collapses are available through `--tdf-spectrum`:
 
 - `vendor_centroid` (default): Bruker's frame-level peak picker over the full
   ramp, the same one behind the TSF line spectrum and SCiLS Lab's import. It
-  merges neighbouring digitizer bins and drops single-count noise, which on
-  real imaging frames keeps roughly 80 to 90 percent of the raw ion current.
+  reports peak areas, merges neighbouring digitizer bins, and drops every
+  index bin its picker assigns to no peak, which on measured imaging
+  acquisitions keeps 87 to 96 percent of the raw ion current. Bruker's own
+  per-frame total (`Frames.SummedIntensities`) is the scan sum, not this.
+  See [Design Decisions](design-decisions.md#d1-which-spectrum-a-reader-takes).
 - `scan_sum`: every scan summed per digitizer index. Lossless, three to four
   times as many points per frame, and exactly the mobility marginal of the
   per-scan data.
@@ -275,6 +278,15 @@ at the cost of an axis that differs from run to run.
 (`profile spectrum` or `centroid spectrum`), `format_specific.spectrum_source`
 says which MassLynx representation it came from, and `format_specific.is_mrt`
 with `instrument_decided_by` record the instrument decision.
+**One MS level per store.** Every MS function shares the one laser grid, so
+a two-function acquisition (MSe low and high energy, or a data-dependent
+run) records an MS1 and an MS/MS spectrum at the same pixel. Thyra converts
+the MS1 function(s) only and lists the others, with their MS level and
+precursor m/z, under `excluded_functions` in the Waters-specific metadata
+block; summing an intact-ion and a fragment spectrum into one pixel would
+make a spectrum of nothing. A file with MS/MS functions only converts them
+and reports their precursors through `ms_analysis.fragmentation`, exactly as
+a Bruker MS/MS acquisition does (see [Design Decisions](design-decisions.md#d7-waters-the-summed-table-takes-ms-level-1-only)).
 
 ## PHI SmartSoft-TOF (ToF-SIMS)
 

--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -136,9 +136,10 @@ The mobility dimension itself is not thrown away. The summed table carries
 the declared range and the `TimsCalibration` row -- and `uns["mobility_heatmap"]`,
 the dataset's mean mass-mobility frame (about 4,000 m/z bins by 256 mobility
 channels) accumulated from the raw scan read of every frame. The heatmap is
-where to look to see whether mobility separates anything; it costs one extra
-library call per frame, about a millisecond, and `--no-mobility-heatmap`
-skips it. Under `scan_sum` the heatmap summed over mobility is exactly the
+where to look to see whether mobility separates anything; on the streaming
+route it is fed from the same frame read that builds the summed table, so it
+costs the mapping of every point onto the mass axis and no extra read, and
+`--no-mobility-heatmap` skips it. Under `scan_sum` the heatmap summed over mobility is exactly the
 stored mean spectrum; under `vendor_centroid` the two differ by what the
 centroid discards. See [Output Format](output-format.md#ion-mobility). A TSF
 file has no mobility dimension and gets none of this.
@@ -150,10 +151,11 @@ directly the way an imzML mobility export has; the flag bins every pixel's
 across the conversion and writes the result as `{table}_mobility` -- the same
 element, columns and sort a shared-axis source produces. The default 256
 channels over the axis' own value range are the heatmap's, so a box on the
-heatmap indexes the table's channels. It costs a second pass over the source
-(the first is shared with the heatmap), a table with 1.3 to 4 times the summed
-table's non-zeros -- built out of core, so a whole acquisition converts
-whatever its size. Under the default `--tdf-spectrum scan_sum` the table's
+heatmap indexes the table's channels. On the streaming route it is fed from
+the summed table's own two passes -- one raw read per frame per pass serves
+every table, so the grid adds no read of the source -- and it is a table
+with 1.3 to 4 times the summed table's non-zeros, built out of core, so a
+whole acquisition converts whatever its size. Under the default `--tdf-spectrum scan_sum` the table's
 marginal over channels reproduces the summed table exactly; an explicit
 `vendor_centroid` is accepted with a `WARNING` and the mismatch recorded. See
 [Output Format](output-format.md#the-same-table-from-a-common-mobility-grid).

--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -112,16 +112,18 @@ pixel the MSI table holds; `--mobility-grid` writes what was collapsed as a
 separate table (below), and `--msms-table` slices the ramp by precursor
 instead (below). Two collapses are available through `--tdf-spectrum`:
 
-- `vendor_centroid` (default): Bruker's frame-level peak picker over the full
-  ramp, the same one behind the TSF line spectrum and SCiLS Lab's import. It
+- `scan_sum` (default): every scan summed per digitizer index. Lossless,
+  1.5 to 3 times as many points per frame as the centroid, exactly the
+  mobility marginal of the per-scan data, and exactly Bruker's own
+  per-frame total (`Frames.SummedIntensities`) and its quasi-profile
+  export. This is the instrument's record, which is why it is the default;
+  see [Design Decisions](design-decisions.md#d1-which-spectrum-a-reader-takes).
+- `vendor_centroid`: Bruker's frame-level peak picker over the full ramp,
+  the same one behind the TSF line spectrum and SCiLS Lab's import. It
   reports peak areas, merges neighbouring digitizer bins, and drops every
   index bin its picker assigns to no peak, which on measured imaging
-  acquisitions keeps 87 to 96 percent of the raw ion current. Bruker's own
-  per-frame total (`Frames.SummedIntensities`) is the scan sum, not this.
-  See [Design Decisions](design-decisions.md#d1-which-spectrum-a-reader-takes).
-- `scan_sum`: every scan summed per digitizer index. Lossless, three to four
-  times as many points per frame, and exactly the mobility marginal of the
-  per-scan data.
+  acquisitions keeps 87 to 96 percent of the raw ion current. Choose it to
+  reproduce the vendor software's numbers.
 
 The choice is recorded in the store's processing provenance
 (`msi_metadata.processing[0].parameters.tdf_spectrum`), and the acquisition's
@@ -151,9 +153,9 @@ channels over the axis' own value range are the heatmap's, so a box on the
 heatmap indexes the table's channels. It costs a second pass over the source
 (the first is shared with the heatmap), a table with 1.3 to 4 times the summed
 table's non-zeros -- built out of core, so a whole acquisition converts
-whatever its size -- and a switch to
-`--tdf-spectrum scan_sum` (said at `WARNING`) so the table's marginal over
-channels reproduces the summed table exactly. See
+whatever its size. Under the default `--tdf-spectrum scan_sum` the table's
+marginal over channels reproduces the summed table exactly; an explicit
+`vendor_centroid` is accepted with a `WARNING` and the mismatch recorded. See
 [Output Format](output-format.md#the-same-table-from-a-common-mobility-grid).
 
 **MS/MS acquisitions convert, and say so.** `Frames.MsMsType` tells a survey

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
   - imzML Parser Notes: imzml-parser-notes.md
   - PHI ToF-SIMS Notes: phi-tofsims-notes.md
   - solariX Notes: solarix-notes.md
+  - Design Decisions: design-decisions.md
   - API Reference: api.md
   - Contributing: contributing.md
   - Code of Conduct: code-of-conduct.md

--- a/tests/integration/test_bruker_tdf_synthetic.py
+++ b/tests/integration/test_bruker_tdf_synthetic.py
@@ -546,13 +546,21 @@ class TestDemultiplexedStore:
         assert block["current_ratio"] == pytest.approx(1.0, abs=1e-12)
         assert block["current_ratio_pixel_max"] == pytest.approx(1.0, abs=1e-12)
 
-    def test_off_by_default(self, tmp_path):
-        """The extra pass is opt in; the schedule is recorded either way."""
+    def test_on_by_default_and_off_on_request(self, tmp_path):
+        """The split is the default (design decision D2); the schedule is recorded either way."""
         spatialdata = pytest.importorskip("spatialdata")
         _open("scan_sum").close()
         out = _convert_path(_pasef_copy(tmp_path), tmp_path / "pasef.zarr")
         sdata = spatialdata.read_zarr(out)
+        assert set(sdata.tables) == {"tims_z0", "tims_z0_msms"}
+        assert sdata.tables["tims_z0"].uns["msms_schedule"]["resolved_table"] == (
+            "tims_z0_msms"
+        )
 
+        out = _convert_path(
+            _pasef_copy(tmp_path / "again"), tmp_path / "off.zarr", msms_table=False
+        )
+        sdata = spatialdata.read_zarr(out)
         assert set(sdata.tables) == {"tims_z0"}
         assert "resolved_table" not in sdata.tables["tims_z0"].uns["msms_schedule"]
 
@@ -629,11 +637,12 @@ class TestMobilityGridStore:
         sdata = spatialdata.read_zarr(prepare_zarr_read_path(out))
         assert "tims_z0_mobility" not in sdata.tables
 
-    def test_the_flag_writes_the_sibling_and_forces_the_lossless_sum(self, tmp_path):
+    def test_the_flag_writes_the_sibling_under_the_default_lossless_sum(self, tmp_path):
         from thyra.convert import convert_msi
 
         out = tmp_path / "grid.zarr"
-        # No reader_options: the grid must pick scan_sum itself.
+        # No reader_options: the default is scan_sum (design decision D1),
+        # which is what makes the grid's marginal exact.
         assert convert_msi(
             str(FIXTURE),
             str(out),

--- a/tests/unit/converters/test_fused_passes.py
+++ b/tests/unit/converters/test_fused_passes.py
@@ -1,0 +1,286 @@
+"""The sibling tables fed from the summed table's own passes (design decision D5).
+
+A stand-in source hands its frames over as records, the way a Bruker TDF
+does, and also answers the three iterators the standalone passes use.
+Converted both ways on the streaming route, the stores must be identical
+in every table -- and the fused way must not have touched the iterators
+the sinks used to read from, which is the whole saving.
+"""
+
+from pathlib import Path
+from typing import Generator, List, Optional, Tuple
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+pytest.importorskip("spatialdata")
+
+import spatialdata  # noqa: E402
+
+from thyra.core.base_extractor import MetadataExtractor  # noqa: E402
+from thyra.core.base_reader import BaseMSIReader  # noqa: E402
+from thyra.core.mobility import MobilityAxis  # noqa: E402
+from thyra.core.msms import FragmentationSchedule, IsolationWindow  # noqa: E402
+from thyra.metadata.types import ComprehensiveMetadata, EssentialMetadata  # noqa: E402
+
+PIXELS = [(0, 0), (1, 0), (0, 1), (1, 1)]
+#: A decreasing 1/K0 ramp of 8 scans, as a TDF's is; window 0 owns scans
+#: 0..4 (1/K0 1.5 .. 1.27), window 1 scans 4..8 (1.21 .. 1.1).
+SCAN_K0 = np.linspace(1.5, 1.1, 8)
+WINDOWS = (
+    IsolationWindow(313.275, 0.5, 0.5, 34.3, scan_begin=0, scan_end=4),
+    IsolationWindow(936.578, 0.5, 0.5, 49.6, scan_begin=4, scan_end=8),
+)
+SCHEDULE = FragmentationSchedule(ms_level=2, windows=WINDOWS, source="stub")
+
+#: One point cloud per pixel: (m/z, scan, intensity). Two points at one
+#: m/z on different scans, one m/z in both windows, one pixel sparse.
+CLOUDS = {
+    0: [(100.0, 1, 10.0), (100.0, 5, 4.0), (300.0, 2, 20.0), (200.0, 6, 30.0)],
+    1: [(300.0, 0, 40.0), (200.0, 7, 50.0), (500.0, 5, 60.0)],
+    2: [(100.0, 3, 5.0), (400.0, 4, 7.0)],
+    3: [(500.0, 2, 1.0), (100.0, 6, 2.0), (500.0, 7, 3.0)],
+}
+
+
+def _summed(p: int) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
+    totals: dict = {}
+    for mz, _scan, intensity in CLOUDS[p]:
+        totals[mz] = totals.get(mz, 0.0) + intensity
+    mzs = np.array(sorted(totals), dtype=np.float64)
+    return mzs, np.array([totals[m] for m in mzs], dtype=np.float64)
+
+
+def _cloud(p: int):
+    points = sorted(CLOUDS[p], key=lambda t: (t[1], t[0]))
+    mzs = np.array([t[0] for t in points], dtype=np.float64)
+    mobility = np.array([SCAN_K0[t[1]] for t in points], dtype=np.float64)
+    intensities = np.array([t[2] for t in points], dtype=np.float64)
+    return mzs, mobility, intensities
+
+
+def _precursors(p: int) -> List[Tuple[int, NDArray[np.float64], NDArray[np.float64]]]:
+    out = []
+    for w, window in enumerate(WINDOWS):
+        totals: dict = {}
+        for mz, scan, intensity in CLOUDS[p]:
+            if window.scan_begin <= scan < window.scan_end:
+                totals[mz] = totals.get(mz, 0.0) + intensity
+        if totals:
+            mzs = np.array(sorted(totals), dtype=np.float64)
+            out.append((w, mzs, np.array([totals[m] for m in mzs], dtype=np.float64)))
+    return out
+
+
+class _Frame:
+    def __init__(self, p: int, coords):
+        self.coords = coords
+        self._p = p
+
+    def spectrum(self):
+        return _summed(self._p)
+
+    def mobility_points(self):
+        return _cloud(self._p)
+
+    def precursor_spectra(self):
+        return _precursors(self._p)
+
+
+class _StubExtractor(MetadataExtractor):
+    def __init__(self):
+        super().__init__(data_source=None)
+
+    def _extract_essential_impl(self) -> EssentialMetadata:
+        return EssentialMetadata(
+            dimensions=(2, 2, 1),
+            coordinate_bounds=(0.0, 1.0, 0.0, 1.0),
+            mass_range=(100.0, 500.0),
+            pixel_size=(10.0, 10.0),
+            n_spectra=4,
+            total_peaks=12,
+            estimated_memory_gb=0.0,
+            source_path="stub_fused",
+            spectrum_type="centroid spectrum",
+        )
+
+    def _extract_comprehensive_impl(self) -> ComprehensiveMetadata:
+        return ComprehensiveMetadata(
+            essential=self._extract_essential_impl(),
+            format_specific={"format": "stub"},
+            acquisition_params={},
+            instrument_info={},
+            raw_metadata={},
+        )
+
+
+class FusedStubReader(BaseMSIReader):
+    """A TIMS PASEF source in miniature that also hands its frames over as records."""
+
+    frame_scans = True
+
+    def __init__(self):
+        super().__init__(Path("stub_fused"))
+        self.mobility_passes = 0
+        self.precursor_passes = 0
+        self.frame_passes = 0
+
+    def _create_metadata_extractor(self) -> MetadataExtractor:
+        return _StubExtractor()
+
+    @property
+    def has_shared_mass_axis(self) -> bool:
+        return False
+
+    def get_common_mass_axis(self) -> NDArray[np.float64]:
+        return np.array([100.0, 200.0, 300.0, 400.0, 500.0])
+
+    def iter_spectra(self, batch_size: Optional[int] = None) -> Generator:
+        for p, (x, y) in enumerate(PIXELS):
+            mzs, intensities = _summed(p)
+            yield (x, y, 0), mzs, intensities
+
+    # -- mobility ----------------------------------------------------------
+
+    @property
+    def has_ion_mobility(self) -> bool:
+        return True
+
+    @property
+    def has_shared_mobility_axis(self) -> bool:
+        return False
+
+    def get_mobility_axis(self) -> Optional[MobilityAxis]:
+        return MobilityAxis(
+            kind_accession="MS:1002815",
+            kind_name="inverse reduced ion mobility",
+            unit_accession="MS:1002814",
+            unit_name="volt-second per square centimeter",
+            values=SCAN_K0.copy(),
+            acq_range=(1.1, 1.5),
+            source="stub",
+        )
+
+    def iter_mobility_spectra(self, batch_size: Optional[int] = None) -> Generator:
+        self.mobility_passes += 1
+        for p, (x, y) in enumerate(PIXELS):
+            mzs, mobility, intensities = _cloud(p)
+            yield (x, y, 0), mzs, mobility, intensities
+
+    # -- MS/MS -------------------------------------------------------------
+
+    def get_fragmentation(self) -> Optional[FragmentationSchedule]:
+        return SCHEDULE
+
+    def iter_precursor_spectra(self, batch_size: Optional[int] = None) -> Generator:
+        self.precursor_passes += 1
+        for p, (x, y) in enumerate(PIXELS):
+            for window, mzs, intensities in _precursors(p):
+                yield (x, y, 0), window, mzs, intensities
+
+    # -- the records --------------------------------------------------------
+
+    @property
+    def has_frame_scans(self) -> bool:
+        return self.frame_scans
+
+    def iter_frame_scans(self, batch_size: Optional[int] = None) -> Generator:
+        self.frame_passes += 1
+        for p, (x, y) in enumerate(PIXELS):
+            yield _Frame(p, (x, y, 0))
+
+    def close(self) -> None:
+        pass
+
+
+class UnfusedStubReader(FusedStubReader):
+    frame_scans = False
+
+
+RESAMPLED = {
+    "method": "nearest_neighbor",
+    "axis_type": "constant",
+    "target_bins": 43,
+    "min_mz": 90.0,
+    "max_mz": 510.0,
+}
+
+
+def _convert(reader, out: Path, **kwargs) -> Path:
+    from thyra.converters.spatialdata.streaming_converter import (
+        StreamingSpatialDataConverter,
+    )
+    from thyra.utils.windows_paths import prepare_zarr_output_path
+
+    out = prepare_zarr_output_path(out, "stub")
+    converter = StreamingSpatialDataConverter(
+        reader,
+        out,
+        dataset_id="stub",
+        pixel_size_um=10.0,
+        resampling_config=RESAMPLED,
+        mobility_grid=True,
+        **kwargs,
+    )
+    assert converter.convert(), "conversion reported failure"
+    return out
+
+
+def _read(out: Path):
+    from thyra.utils.windows_paths import prepare_zarr_read_path
+
+    return spatialdata.read_zarr(prepare_zarr_read_path(out))
+
+
+def _dense(table) -> np.ndarray:
+    X = table.X
+    return np.asarray(X.toarray() if hasattr(X, "toarray") else X)
+
+
+class TestFusedPasses:
+    def test_the_fused_store_is_the_unfused_store(self, tmp_path):
+        fused, unfused = FusedStubReader(), UnfusedStubReader()
+        a = _read(_convert(fused, tmp_path / "fused.zarr"))
+        b = _read(_convert(unfused, tmp_path / "unfused.zarr"))
+
+        assert set(a.tables) == set(b.tables)
+        assert set(a.tables) == {"stub_z0", "stub_z0_mobility", "stub_z0_msms"}
+        for key in a.tables:
+            ta, tb = a.tables[key], b.tables[key]
+            np.testing.assert_array_equal(_dense(ta), _dense(tb))
+            assert list(ta.var.index) == list(tb.var.index)
+            assert list(ta.obs.index) == list(tb.obs.index)
+            for column in ta.var.columns:
+                np.testing.assert_array_equal(
+                    ta.var[column].to_numpy(), tb.var[column].to_numpy()
+                )
+        heat_a = a.tables["stub_z0"].uns["mobility_heatmap"]["counts"]
+        heat_b = b.tables["stub_z0"].uns["mobility_heatmap"]["counts"]
+        np.testing.assert_array_equal(np.asarray(heat_a), np.asarray(heat_b))
+
+    def test_the_fused_route_reads_the_source_twice_and_never_the_iterators(
+        self, tmp_path
+    ):
+        fused = FusedStubReader()
+        _convert(fused, tmp_path / "fused.zarr")
+        # Count and scatter: one read each, serving the summed table, the
+        # heatmap, the grid and the split alike.
+        assert fused.frame_passes == 2
+        assert fused.mobility_passes == 0
+        assert fused.precursor_passes == 0
+
+        unfused = UnfusedStubReader()
+        _convert(unfused, tmp_path / "unfused.zarr")
+        assert unfused.frame_passes == 0
+        # Heatmap + discovery fused into one, then the grid's scatter.
+        assert unfused.mobility_passes == 2
+        assert unfused.precursor_passes == 2
+
+    def test_the_marginals_are_exact_either_way(self, tmp_path):
+        for reader, name in ((FusedStubReader(), "f"), (UnfusedStubReader(), "u")):
+            sdata = _read(_convert(reader, tmp_path / f"{name}.zarr"))
+            grid = sdata.tables["stub_z0_mobility"].uns["mobility_marginal"]
+            split = sdata.tables["stub_z0_msms"].uns["demultiplexed_current"]
+            assert float(grid["current_ratio"]) == pytest.approx(1.0)
+            assert float(split["current_ratio"]) == pytest.approx(1.0)

--- a/tests/unit/converters/test_mobility_grid.py
+++ b/tests/unit/converters/test_mobility_grid.py
@@ -22,11 +22,14 @@ from thyra.converters.spatialdata.mobility_heatmap import (
     mobility_bin_edges,
 )
 from thyra.converters.spatialdata.mobility_table import (
+    GRID_VAR_REFUSE_FRACTION,
     MAX_GRID_VAR_ENTRIES,
+    VAR_BYTES_PER_FEATURE,
     build_mobility_table,
     grid_refusal,
     grid_var_bound,
     mobility_grid_range,
+    projected_var_gb,
     var_ceiling_refusal,
 )
 from thyra.core.base_extractor import MetadataExtractor
@@ -333,7 +336,7 @@ class TestVarCeiling:
         # measured 200-frame timsTOF acquisition occupied 3.9M of a
         # possible 35.5M), so refusing on the bound would turn away
         # conversions that fit ninefold over.
-        axis = np.linspace(100.0, 1000.0, 100_000)
+        axis = np.linspace(100.0, 1000.0, 400_000)
         grid = build_mobility_grid(1.1, 1.5)
         assert grid_var_bound(axis, grid) > MAX_GRID_VAR_ENTRIES
         assert grid_refusal(GridStubReader(), axis, grid) is None
@@ -383,12 +386,47 @@ class TestVarCeiling:
         assert "--resample-bins" in refusal
 
     def test_the_count_is_what_is_refused_with_the_number_printed(self):
-        assert var_ceiling_refusal(MAX_GRID_VAR_ENTRIES) is None
-        refusal = var_ceiling_refusal(MAX_GRID_VAR_ENTRIES + 1)
+        # The absolute cap, with memory taken out of the question.
+        plenty = 1e9
+        assert var_ceiling_refusal(MAX_GRID_VAR_ENTRIES, available_gb=plenty) is None
+        refusal = var_ceiling_refusal(MAX_GRID_VAR_ENTRIES + 1, available_gb=plenty)
         assert refusal is not None
         assert f"{MAX_GRID_VAR_ENTRIES + 1:,}" in refusal
         assert f"{MAX_GRID_VAR_ENTRIES:,}" in refusal
         assert "--mobility-bins" in refusal
+
+    def test_the_operative_guard_is_the_projected_var_memory(self, caplog):
+        # Design decision D4: the ceiling is a memory guard, not a constant
+        # fitted to a dataset. 10M features project to ~3.1 GB at the
+        # measured bytes-per-feature; that is refused on a machine with
+        # 4 GB free (over half), warned about with 10 GB free (over a
+        # quarter), and silent with 100 GB free.
+        n = 10_000_000
+        gb = projected_var_gb(n)
+        assert gb == pytest.approx(n * VAR_BYTES_PER_FEATURE / 1024**3)
+
+        refusal = var_ceiling_refusal(n, available_gb=4.0)
+        assert refusal is not None
+        assert f"{gb:.1f} GB" in refusal
+        assert "4.0 GB free" in refusal
+        assert "--resample-bins" in refusal and "--mobility-bins" in refusal
+
+        with caplog.at_level("WARNING"):
+            assert var_ceiling_refusal(n, available_gb=10.0) is None
+        assert "projected to need" in caplog.text
+
+        caplog.clear()
+        with caplog.at_level("WARNING"):
+            assert var_ceiling_refusal(n, available_gb=100.0) is None
+        assert "projected to need" not in caplog.text
+
+    def test_the_fractions_are_of_free_memory_not_fixed_sizes(self):
+        # The same table is fine on a workstation and refused on a laptop.
+        n = 10_000_000
+        gb = projected_var_gb(n)
+        just_enough = gb / GRID_VAR_REFUSE_FRACTION + 1e-6
+        assert var_ceiling_refusal(n, available_gb=just_enough) is None
+        assert var_ceiling_refusal(n, available_gb=just_enough * 0.9) is not None
 
 
 def _stub_obs():

--- a/tests/unit/converters/test_msms_defaults.py
+++ b/tests/unit/converters/test_msms_defaults.py
@@ -1,0 +1,188 @@
+"""The demultiplexed MS/MS table's defaults, on a real conversion.
+
+Design decisions D2 and D6 (``docs/design-decisions.md``): the table is
+written by default when the schedule allows an exact split, opted out of
+with ``msms_table=False``, and exact on a resampled axis and on the raw
+one alike, because the fragment axis is the summed table's axis and both
+are built from the same points. A stand-in PASEF reader with two
+precursors on disjoint ramp slices goes down both write routes.
+"""
+
+from pathlib import Path
+from typing import Generator, Optional
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+pytest.importorskip("spatialdata")
+
+import spatialdata  # noqa: E402
+
+from thyra.core.base_extractor import MetadataExtractor  # noqa: E402
+from thyra.core.base_reader import BaseMSIReader  # noqa: E402
+from thyra.core.msms import FragmentationSchedule, IsolationWindow  # noqa: E402
+from thyra.metadata.types import ComprehensiveMetadata, EssentialMetadata  # noqa: E402
+
+WINDOWS = (
+    IsolationWindow(313.275, 0.5, 0.5, 34.3, scan_begin=150, scan_end=200),
+    IsolationWindow(936.578, 0.5, 0.5, 49.6, scan_begin=20, scan_end=60),
+)
+SCHEDULE = FragmentationSchedule(ms_level=2, windows=WINDOWS, source="stub")
+
+PIXELS = [(0, 0), (1, 0), (0, 1), (1, 1)]
+
+# (window index, m/z values, intensities) per pixel; the summed spectrum
+# is their sum, so the split adds back up exactly.
+SPLIT = {
+    0: [(0, [100.0, 300.0], [10.0, 20.0]), (1, [200.0], [30.0])],
+    1: [(0, [300.0], [40.0]), (1, [200.0, 500.0], [50.0, 60.0])],
+    2: [(0, [100.0], [5.0]), (1, [400.0], [7.0])],
+    3: [(0, [500.0], [1.0]), (1, [100.0, 500.0], [2.0, 3.0])],
+}
+
+
+class _StubExtractor(MetadataExtractor):
+    def __init__(self):
+        super().__init__(data_source=None)
+
+    def _extract_essential_impl(self) -> EssentialMetadata:
+        return EssentialMetadata(
+            dimensions=(2, 2, 1),
+            coordinate_bounds=(0.0, 1.0, 0.0, 1.0),
+            mass_range=(100.0, 500.0),
+            pixel_size=(10.0, 10.0),
+            n_spectra=4,
+            total_peaks=12,
+            estimated_memory_gb=0.0,
+            source_path="stub_msms",
+            spectrum_type="centroid spectrum",
+        )
+
+    def _extract_comprehensive_impl(self) -> ComprehensiveMetadata:
+        return ComprehensiveMetadata(
+            essential=self._extract_essential_impl(),
+            format_specific={"format": "stub"},
+            acquisition_params={},
+            instrument_info={},
+            raw_metadata={},
+        )
+
+
+class MsmsStubReader(BaseMSIReader):
+    """A PASEF acquisition in miniature: two precursors per pixel."""
+
+    def __init__(self):
+        super().__init__(Path("stub_msms"))
+
+    def _create_metadata_extractor(self) -> MetadataExtractor:
+        return _StubExtractor()
+
+    @property
+    def has_shared_mass_axis(self) -> bool:
+        return False
+
+    def get_common_mass_axis(self) -> NDArray[np.float64]:
+        return np.array([100.0, 200.0, 300.0, 400.0, 500.0])
+
+    def iter_spectra(self, batch_size: Optional[int] = None) -> Generator:
+        for p, (x, y) in enumerate(PIXELS):
+            summed: dict = {}
+            for _window, mzs, intensities in SPLIT[p]:
+                for mz, i in zip(mzs, intensities):
+                    summed[mz] = summed.get(mz, 0.0) + i
+            mzs = np.array(sorted(summed), dtype=np.float64)
+            yield (x, y, 0), mzs, np.array([summed[m] for m in mzs])
+
+    def get_fragmentation(self) -> Optional[FragmentationSchedule]:
+        return SCHEDULE
+
+    def iter_precursor_spectra(self, batch_size: Optional[int] = None) -> Generator:
+        for p, (x, y) in enumerate(PIXELS):
+            for window, mzs, intensities in SPLIT[p]:
+                yield (
+                    (x, y, 0),
+                    window,
+                    np.asarray(mzs, dtype=np.float64),
+                    np.asarray(intensities, dtype=np.float64),
+                )
+
+    def close(self) -> None:
+        pass
+
+
+#: A constant-width axis at 10 Da from 90 to 510, so every m/z the stub
+#: emits sits on a bin centre and nearest-bin mapping is exact.
+RESAMPLED = {
+    "method": "nearest_neighbor",
+    "axis_type": "constant",
+    "target_bins": 43,
+    "min_mz": 90.0,
+    "max_mz": 510.0,
+}
+
+
+def _convert(out: Path, streaming: bool, **kwargs):
+    from thyra.utils.windows_paths import prepare_zarr_output_path
+
+    out = prepare_zarr_output_path(out, "stub")
+    if streaming:
+        from thyra.converters.spatialdata.streaming_converter import (
+            StreamingSpatialDataConverter as Converter,
+        )
+    else:
+        from thyra.converters.spatialdata.spatialdata_2d_converter import (
+            SpatialData2DConverter as Converter,
+        )
+
+    converter = Converter(
+        MsmsStubReader(), out, dataset_id="stub", pixel_size_um=10.0, **kwargs
+    )
+    assert converter.convert(), "conversion reported failure"
+    return out
+
+
+def _read(out: Path):
+    from thyra.utils.windows_paths import prepare_zarr_read_path
+
+    return spatialdata.read_zarr(prepare_zarr_read_path(out))
+
+
+@pytest.mark.parametrize("streaming", [False, True], ids=["in_memory", "streaming"])
+class TestTheDefault:
+    def test_a_qualifying_source_gets_the_split_without_asking(
+        self, tmp_path, streaming
+    ):
+        sdata = _read(
+            _convert(tmp_path / "s.zarr", streaming, resampling_config=RESAMPLED)
+        )
+        assert set(sdata.tables) == {"stub_z0", "stub_z0_msms"}
+        split = sdata.tables["stub_z0_msms"]
+        assert split.n_obs == 4
+        assert set(split.var["precursor_index"].to_numpy()) == {0, 1}
+        ratio = split.uns["demultiplexed_current"]["current_ratio"]
+        assert float(ratio) == pytest.approx(1.0)
+
+    def test_opting_out_writes_only_the_summed_table(self, tmp_path, streaming):
+        sdata = _read(
+            _convert(
+                tmp_path / "s.zarr",
+                streaming,
+                resampling_config=RESAMPLED,
+                msms_table=False,
+            )
+        )
+        assert set(sdata.tables) == {"stub_z0"}
+
+    def test_a_raw_axis_gets_the_split_exactly(self, tmp_path, streaming):
+        # D6: the fragment axis is the summed table's axis. Unresampled,
+        # that axis is the union of the fragment m/z values the split
+        # re-reads, so the mapping is exact and the blocks add back up.
+        sdata = _read(_convert(tmp_path / "s.zarr", streaming))
+        assert set(sdata.tables) == {"stub_z0", "stub_z0_msms"}
+        split = sdata.tables["stub_z0_msms"]
+        ratio = split.uns["demultiplexed_current"]["current_ratio"]
+        assert float(ratio) == pytest.approx(1.0)
+        assert float(split.uns["demultiplexed_current"]["current_ratio_pixel_max"]) == (
+            pytest.approx(1.0)
+        )

--- a/tests/unit/readers/test_bruker_tdf_reader.py
+++ b/tests/unit/readers/test_bruker_tdf_reader.py
@@ -81,9 +81,11 @@ class TestTdfWiring:
             reader.dll_manager, "tdf", tdf_spectrum="scan_sum"
         )
 
-    def test_default_mode_is_the_vendor_centroid(self):
+    def test_default_mode_is_the_scan_sum(self):
+        # Design decision D1: the instrument's own record is the default,
+        # the vendor centroid the opt-in.
         reader, _, _ = _make_reader("tdf")
-        assert reader.tdf_spectrum == "vendor_centroid"
+        assert reader.tdf_spectrum == "scan_sum"
 
     def test_unknown_mode_is_rejected_before_touching_the_sdk(self):
         with pytest.raises(ValueError, match="tdf_spectrum"):

--- a/tests/unit/readers/test_waters_reader.py
+++ b/tests/unit/readers/test_waters_reader.py
@@ -457,3 +457,132 @@ class TestWatersReaderProperties:
         r = repr(reader)
         assert "grid=3x2" in r
         reader.close()
+
+
+def _two_function_grid(levels, precursors=None):
+    """A 3x1 grid where every function records a scan at each of 3 pixels.
+
+    ``levels`` maps function index -> MS level; ``precursors`` maps function
+    index -> a precursor m/z per scan (a constant, or a list per scan).
+    """
+    precursors = precursors or {}
+    positions = [(0.1, 0.05), (0.2, 0.05), (0.3, 0.05)]
+    scan_map = {}
+    for func, level in levels.items():
+        per_scan = precursors.get(func, 0.0)
+        for scan, (x_mm, y_mm) in enumerate(positions):
+            mz = per_scan[scan] if isinstance(per_scan, list) else per_scan
+            info = _make_scan_info(x_mm, y_mm, ms_level=level)
+            scan_map[(func, scan)] = ScanInfoData(
+                **{**info.__dict__, "precursor_mz": mz, "collision_energy": 25.0}
+            )
+    return ImagingGrid(
+        x_index_map={100.0: 0, 200.0: 1, 300.0: 2},
+        y_index_map={50.0: 0},
+        pixel_count_x=3,
+        pixel_count_y=1,
+        pixel_size_x=100.0,
+        pixel_size_y=100.0,
+        lateral_width=200.0,
+        lateral_height=0.0,
+        scan_map=scan_map,
+    )
+
+
+def _open_reader(mock_ml_cls, mock_build_grid, mock_waters_data, grid, n_funcs):
+    mock_ml = MagicMock()
+    mock_ml_cls.get_instance.return_value = mock_ml
+    mock_ml.is_imaging_file.return_value = True
+    mock_ml.get_number_of_functions.return_value = n_funcs
+    mock_ml.classify_function.return_value = FunctionType.MS
+    mock_ml.get_number_of_scans_in_function.return_value = 3
+    mock_ml.read_spectrum.return_value = (
+        np.array([100.0, 200.0]),
+        np.array([1.0, 2.0]),
+    )
+    mock_build_grid.return_value = grid
+    return WatersReader(mock_waters_data), mock_ml
+
+
+class TestWatersReaderMsLevels:
+    """One MS level per store: MS1 wins, MS/MS is recorded, not summed in."""
+
+    @patch("thyra.readers.waters.waters_reader.MassLynxLib")
+    @patch("thyra.readers.waters.waters_reader.build_imaging_grid")
+    def test_ms1_and_msms_functions_convert_the_ms1_only(
+        self, mock_build_grid, mock_ml_cls, mock_waters_data
+    ):
+        grid = _two_function_grid({0: 1, 1: 2}, {1: 500.25})
+        reader, mock_ml = _open_reader(
+            mock_ml_cls, mock_build_grid, mock_waters_data, grid, 2
+        )
+        spectra = list(reader.iter_spectra())
+
+        # Three pixels, one spectrum each, all read from function 0
+        assert len(spectra) == 3
+        assert {c for c, _, _ in spectra} == {(0, 0, 0), (1, 0, 0), (2, 0, 0)}
+        assert {call.args[1] for call in mock_ml.read_spectrum.call_args_list} == {0}
+
+        schedule = reader.get_fragmentation()
+        assert schedule.ms_level == 1 and not schedule.is_msms
+
+        excluded = reader._excluded_functions
+        assert set(excluded) == {1}
+        assert excluded[1]["ms_level"] == 2
+        assert excluded[1]["precursor_mz"] == pytest.approx(500.25)
+        assert excluded[1]["n_scans"] == 3
+
+        block = reader._create_metadata_extractor()._extract_waters_specific()
+        assert block["ms_functions"] == [0]
+        assert block["excluded_functions"]["1"]["precursor_mz"] == pytest.approx(500.25)
+        reader.close()
+
+    @patch("thyra.readers.waters.waters_reader.MassLynxLib")
+    @patch("thyra.readers.waters.waters_reader.build_imaging_grid")
+    def test_msms_only_file_converts_and_reports_its_precursor(
+        self, mock_build_grid, mock_ml_cls, mock_waters_data
+    ):
+        grid = _two_function_grid({0: 2}, {0: 760.585})
+        reader, _ = _open_reader(
+            mock_ml_cls, mock_build_grid, mock_waters_data, grid, 1
+        )
+        assert len(list(reader.iter_spectra())) == 3
+        assert reader._excluded_functions == {}
+
+        schedule = reader.get_fragmentation()
+        assert schedule.ms_level == 2 and schedule.constant_across_pixels
+        assert len(schedule.windows) == 1
+        assert schedule.windows[0].target == pytest.approx(760.585)
+        assert schedule.windows[0].collision_energy == pytest.approx(25.0)
+        assert not schedule.merges_precursors
+        reader.close()
+
+    @patch("thyra.readers.waters.waters_reader.MassLynxLib")
+    @patch("thyra.readers.waters.waters_reader.build_imaging_grid")
+    def test_data_dependent_precursors_are_not_a_constant_schedule(
+        self, mock_build_grid, mock_ml_cls, mock_waters_data
+    ):
+        grid = _two_function_grid({0: 2}, {0: [500.0, 600.0, 700.0]})
+        reader, _ = _open_reader(
+            mock_ml_cls, mock_build_grid, mock_waters_data, grid, 1
+        )
+        schedule = reader.get_fragmentation()
+        assert schedule.ms_level == 2
+        assert not schedule.constant_across_pixels
+        assert schedule.windows == ()
+        reader.close()
+
+    @patch("thyra.readers.waters.waters_reader.MassLynxLib")
+    @patch("thyra.readers.waters.waters_reader.build_imaging_grid")
+    def test_two_ms1_functions_are_both_kept(
+        self, mock_build_grid, mock_ml_cls, mock_waters_data
+    ):
+        grid = _two_function_grid({0: 1, 1: 1})
+        reader, mock_ml = _open_reader(
+            mock_ml_cls, mock_build_grid, mock_waters_data, grid, 2
+        )
+        spectra = list(reader.iter_spectra())
+        assert len(spectra) == 6
+        assert {call.args[1] for call in mock_ml.read_spectrum.call_args_list} == {0, 1}
+        assert reader.get_fragmentation().ms_level == 1
+        reader.close()

--- a/thyra/__main__.py
+++ b/thyra/__main__.py
@@ -570,21 +570,21 @@ class GroupedCommand(click.Command):
         "mobility grid and write the same mobility-resolved sibling table "
         "(default: disabled; one extra pass over the source beyond the "
         "heatmap's and a much larger table, built out of core so any "
-        "acquisition fits). Also switches the summed spectrum to "
-        "--tdf-spectrum scan_sum unless that was given explicitly, which "
-        "moves the stored TIC"
+        "acquisition fits). Its marginal over channels reproduces the summed "
+        "table exactly under the default --tdf-spectrum scan_sum"
     ),
 )
 @click.option(
     "--msms-table/--no-msms-table",
-    default=False,
+    default=None,
     help=(
         "When the source isolates several precursors per pixel in disjoint "
         "mobility slices (Bruker PASEF), also write them split apart as a "
         "demultiplexed sibling table next to the summed MSI table "
-        "(default: disabled; two extra passes over the source). Also switches "
-        "the summed spectrum to --tdf-spectrum scan_sum unless that was given "
-        "explicitly, so the split adds back up to it exactly"
+        "(default: enabled, since the summed spectrum of such a pixel mixes "
+        "unrelated fragment spectra; two extra passes over an MS/MS source, "
+        "nothing on any other). The split adds back up to the summed table "
+        "exactly under the default --tdf-spectrum scan_sum"
     ),
 )
 @click.option(
@@ -765,9 +765,10 @@ class GroupedCommand(click.Command):
     default=None,
     help=(
         "How a TDF (TIMS) frame's mobility scans are collapsed into one "
-        "spectrum per pixel: vendor_centroid (default) is Bruker's frame-level "
-        "peak picker over the full ramp, matching TSF line spectra; scan_sum "
-        "sums every scan and keeps all of the ion current. TDF only."
+        "spectrum per pixel: scan_sum (default) sums every scan and keeps all "
+        "of the ion current, matching Bruker's own per-frame total; "
+        "vendor_centroid is Bruker's frame-level peak picker over the full "
+        "ramp, matching TSF line spectra and SCiLS Lab. TDF only."
     ),
 )
 # -- Waters-specific --
@@ -838,7 +839,7 @@ def main(
     mobility_bins: int,
     mobility_min: Optional[float],
     mobility_max: Optional[float],
-    msms_table: bool,
+    msms_table: Optional[bool],
     intensity_threshold: Optional[float],
     tdf_spectrum: Optional[str],
     waters_spectrum: Optional[str],
@@ -942,7 +943,10 @@ def main(
         mobility_bins=mobility_bins,
         mobility_min=mobility_min,
         mobility_max=mobility_max,
-        msms_table=msms_table,
+        # Passed only when given: the converter's own default applies
+        # otherwise, and an explicit request is what the lossless-spectrum
+        # check in convert.py reacts to.
+        **({} if msms_table is None else {"msms_table": msms_table}),
     )
 
     ok = _handle_post_conversion(success, output)

--- a/thyra/__main__.py
+++ b/thyra/__main__.py
@@ -558,7 +558,8 @@ class GroupedCommand(click.Command):
         "When the source has an ion mobility dimension (Bruker TDF with TIMS "
         "engaged, an imzML export with a mobility array), store the mean "
         "mass-mobility frame on the summed table as uns['mobility_heatmap'] "
-        "(default: enabled; one extra pass over the source)"
+        "(default: enabled; fed from the summed table's own passes on a "
+        "Bruker TDF, one extra pass over any other source)"
     ),
 )
 @click.option(
@@ -568,8 +569,8 @@ class GroupedCommand(click.Command):
         "When the source carries ion mobility per pixel rather than as a "
         "shared feature list (Bruker TDF), bin the point cloud onto a common "
         "mobility grid and write the same mobility-resolved sibling table "
-        "(default: disabled; one extra pass over the source beyond the "
-        "heatmap's and a much larger table, built out of core so any "
+        "(default: disabled; fed from the summed table's own passes on the "
+        "streaming route, and a much larger table, built out of core so any "
         "acquisition fits). Its marginal over channels reproduces the summed "
         "table exactly under the default --tdf-spectrum scan_sum"
     ),
@@ -582,8 +583,9 @@ class GroupedCommand(click.Command):
         "mobility slices (Bruker PASEF), also write them split apart as a "
         "demultiplexed sibling table next to the summed MSI table "
         "(default: enabled, since the summed spectrum of such a pixel mixes "
-        "unrelated fragment spectra; two extra passes over an MS/MS source, "
-        "nothing on any other). The split adds back up to the summed table "
+        "unrelated fragment spectra; fed from the summed table's own passes "
+        "on the streaming route, nothing on a source that is not MS/MS). The "
+        "split adds back up to the summed table "
         "exactly under the default --tdf-spectrum scan_sum"
     ),
 )

--- a/thyra/convert.py
+++ b/thyra/convert.py
@@ -132,11 +132,12 @@ def _force_scan_sum(reader_class: Any, options: Dict[str, Any], what: str) -> No
     is built from the raw scans, so it reproduces the summed table (the
     grid's marginal over channels, the split's blocks added back up) only
     when that table was built from the same scans. The vendor centroid is
-    a peak-picked spectrum over the same ramp and keeps 80-90% of the ion
-    current, so with it the two tables of one store genuinely do not add
-    up.
+    a peak-picked spectrum over the same ramp and keeps only the current
+    inside the peaks it picks (87-96% on measured acquisitions), so with
+    it the two tables of one store genuinely do not add up.
 
-    The switch moves the stored TIC by 13-21%, which reads as a bug if it
+    The switch moves the stored TIC by 4-14% on measured acquisitions,
+    which reads as a bug if it
     happens quietly, so it is said at WARNING -- and never applied over an
     explicit ``--tdf-spectrum``, which is the caller saying they want the
     other one and will live with the mismatch, which the sibling's

--- a/thyra/convert.py
+++ b/thyra/convert.py
@@ -126,49 +126,28 @@ def _create_reader(
 
 
 def _force_scan_sum(reader_class: Any, options: Dict[str, Any], what: str) -> None:
-    """Switch a TDF reader to the lossless summed spectrum, out loud.
+    """Say out loud when a sibling table will not add up to the summed one.
 
     A sibling table -- the mobility grid, the demultiplexed MS/MS table --
     is built from the raw scans, so it reproduces the summed table (the
     grid's marginal over channels, the split's blocks added back up) only
-    when that table was built from the same scans. The vendor centroid is
-    a peak-picked spectrum over the same ramp and keeps only the current
-    inside the peaks it picks (87-96% on measured acquisitions), so with
-    it the two tables of one store genuinely do not add up.
-
-    The switch moves the stored TIC by 4-14% on measured acquisitions,
-    which reads as a bug if it
-    happens quietly, so it is said at WARNING -- and never applied over an
-    explicit ``--tdf-spectrum``, which is the caller saying they want the
-    other one and will live with the mismatch, which the sibling's
-    ``uns`` block then records.
+    when that table was built from the same scans. The default
+    ``scan_sum`` is built from them, so nothing needs switching; the
+    vendor centroid is a peak-picked spectrum over the same ramp that
+    keeps only the current inside the peaks it picks (87-96% on measured
+    acquisitions), so an explicit ``--tdf-spectrum vendor_centroid`` is
+    the caller saying they want the mismatch, which the sibling's ``uns``
+    block then records. It is said at WARNING rather than overridden.
     """
-    import inspect
-
-    if "tdf_spectrum" in options:
-        logger.warning(
-            "A %s table was asked for with --tdf-spectrum %s. The table reads "
-            "raw scans, so it will not add back up to the summed table; its "
-            "uns block records by how much.",
-            what,
-            options["tdf_spectrum"],
-        )
+    mode = options.get("tdf_spectrum")
+    if mode is None or mode == "scan_sum":
         return
-    try:
-        accepted = inspect.signature(reader_class.__init__).parameters
-    except (TypeError, ValueError):  # pragma: no cover - defensive
-        return
-    if "tdf_spectrum" not in accepted:
-        return
-    options["tdf_spectrum"] = "scan_sum"
     logger.warning(
-        "Writing a %s table, so the summed spectrum is built with "
-        "--tdf-spectrum scan_sum instead of the default vendor centroid: the "
-        "table must add back up to the summed table, and only the lossless "
-        "sum does. This moves the stored TIC by 13-21%% against a default "
-        "conversion of the same file. Pass --tdf-spectrum vendor_centroid to "
-        "keep the centroid and accept the mismatch.",
+        "A %s table was asked for with --tdf-spectrum %s. The table reads "
+        "raw scans, so it will not add back up to the summed table; its "
+        "uns block records by how much.",
         what,
+        mode,
     )
 
 
@@ -390,9 +369,9 @@ def convert_msi(
               to include. Default: None (no filtering).
             - use_recalibrated_state: bool - For Bruker data,
               use active/recalibrated calibration (default True).
-            - tdf_spectrum: "vendor_centroid" | "scan_sum" - For Bruker
+            - tdf_spectrum: "scan_sum" | "vendor_centroid" - For Bruker
               TDF (TIMS) data, how a frame's mobility scans are collapsed
-              into one spectrum per pixel (default "vendor_centroid").
+              into one spectrum per pixel (default "scan_sum").
             - use_centroid: bool - For Waters .raw, whether MassLynx
               hands back the vendor centroid (True) or the profile
               trace (False). Default None: the profile trace on a
@@ -411,12 +390,14 @@ def convert_msi(
             shared feature axis (Bruker TDF) by binning the point cloud
             onto a common mobility grid; ``mobility_bins`` (default 256,
             the heatmap's own channel count), ``mobility_min`` and
-            ``mobility_max`` size that grid. Asking for it also switches
-            a TDF reader to ``tdf_spectrum="scan_sum"`` unless the caller
-            set that option explicitly, which moves the stored TIC.
-            ``msms_table`` (default False) writes the demultiplexed MS/MS
+            ``mobility_max`` size that grid. Its marginal reproduces the
+            summed table exactly under the default
+            ``tdf_spectrum="scan_sum"``; an explicit ``"vendor_centroid"``
+            is kept, with a warning, and the mismatch recorded.
+            ``msms_table`` (default True) writes the demultiplexed MS/MS
             sibling table when the source isolates several precursors per
-            pixel in disjoint mobility slices (Bruker PASEF).
+            pixel in disjoint mobility slices (Bruker PASEF); refused with
+            a reason, and nothing written, on any other source.
             - max_mass_axis_length: int - For processed-mode imzML
               converted with --no-resample, give up once the raw
               mass axis exceeds this many unique m/z values. This

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -1665,8 +1665,9 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         binned the same way, differing only in whether mobility was kept.
         Under ``--tdf-spectrum scan_sum`` that holds exactly; under the
         vendor centroid it cannot, because the centroid is a peak-picked
-        spectrum over the same ramp and keeps 80-90% of the ion current
-        while the grid reads raw scans. A store whose two tables disagree
+        spectrum over the same ramp and keeps only the current inside the
+        peaks it picks (87-96% on measured acquisitions) while the grid
+        reads raw scans. A store whose two tables disagree
         must say by how much rather than leave a reader to find it by
         subtraction.
 
@@ -1791,7 +1792,8 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         The two tables agree exactly under ``--tdf-spectrum scan_sum``,
         which writing this table now selects; under an explicit
         ``vendor_centroid`` they do not, because the vendor peak picker
-        drops single counts while the split reads raw scans, so the
+        drops the index bins it assigns to no peak while the split reads
+        raw scans, so the
         demultiplexed table holds *more*. That is not a defect, but a
         store whose two tables disagree must say so rather than leave a
         reader to find it by subtraction. ``row_totals`` stands in for the

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -716,7 +716,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         mobility_bins: int = MOBILITY_CHANNELS,
         mobility_min: Optional[float] = None,
         mobility_max: Optional[float] = None,
-        msms_table: bool = False,
+        msms_table: bool = True,
         **kwargs: Any,
     ) -> None:
         """Initialize the base SpatialData converter.
@@ -772,11 +772,15 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             msms_table: When the source isolates several precursors per
                 pixel in disjoint mobility slices (Bruker PASEF), also
                 write them split apart as a demultiplexed sibling table
-                (``{table}_msms``) beside the summed MSI table
-                (default: False -- opt in, it costs an extra pass over
-                the source). Refused with a reason rather than
-                approximated when the schedule is not separable; see
-                ``msms_table.py``. Never changes the MSI table itself.
+                (``{table}_msms``) beside the summed MSI table (default:
+                True -- the summed spectrum of such a pixel is a mixture
+                of unrelated fragment spectra, so the split is the
+                accurate representation; design decision D2). Refused
+                with a reason rather than approximated when the schedule
+                is not separable, which is also what happens on every
+                source that is not MS/MS, so the default costs a source
+                that has nothing to split nothing; see ``msms_table.py``.
+                Never changes the MSI table itself.
             apply_optical_alignment: If True (default) and the MSI source
                 has FlexImaging Area metadata, compute an alignment that
                 places MSI raster coordinates in optical-image pixel
@@ -882,7 +886,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         self._mobility_heatmap_enabled = bool(mobility_heatmap)
         self._mobility_heatmap_block: Optional[Dict[str, Any]] = None
         self._mobility_heatmap_built = False
-        # The demultiplexed MS/MS sibling (see msms_table.py): opt-in, and
+        # The demultiplexed MS/MS sibling (see msms_table.py): on by default, and
         # -- once a finalize step has decided for its slice -- the element
         # key it gets, so the MSI table's uns can name it.
         self._write_msms_table = bool(msms_table)
@@ -1734,6 +1738,10 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         if refusal is not None:
             logger.info("No demultiplexed MS/MS table: %s", refusal)
             return None
+        # The fragment axis is the summed table's axis whatever that axis
+        # is (design decision D6): resampled, it is the grid the user chose
+        # for the whole store; raw, it is the union of the very fragment
+        # m/z values the split re-reads, so the mapping is exact either way.
         return msms_table_key(table_key)
 
     def _attach_msms_table(

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -876,6 +876,15 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         # converter ran it fused with the heatmap's pass (see
         # _prepare_sibling_scans); consumed by _attach_sibling_tables.
         self._grid_discovery: Any = None
+        # The MS/MS table's accumulator when the converter fed it from the
+        # summed table's own passes (see fused_passes.py); consumed by
+        # _attach_sibling_tables like the grid's discovery.
+        self._msms_accumulator: Any = None
+        # Whether the sibling sinks were fed from the summed table's passes
+        # already, so _prepare_sibling_scans has nothing left to scan; and
+        # whether the sibling tables were planned before those passes.
+        self._sibling_scans_done = False
+        self._siblings_planned = False
         # Scratch directories holding the memmapped matrices of sibling
         # tables until they are written; released by _release_sibling_scratch.
         self._sibling_scratch: List[Tuple[Any, Path]] = []
@@ -1446,7 +1455,13 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         built here once and cached for every ``uns`` block that asks; a
         route that never calls this still gets it from
         :meth:`_ensure_mobility_heatmap` on first demand.
+
+        A no-op when the sinks were already fed from the summed table's
+        own passes (the streaming route with a reader that hands its
+        frames over as records; see ``fused_passes.py``).
         """
+        if self._sibling_scans_done:
+            return
         self._grid_discovery = None
         try:
             if not getattr(self.reader, "has_ion_mobility", False):
@@ -1518,6 +1533,67 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         from .csc_assembly import scratch_directory
 
         return scratch_directory(f".thyra_{prefix}_", parent=self.output_path.parent)
+
+    def _register_sibling_scratch(self, prefix: str, assembly: Any) -> Path:
+        """A scratch directory for ``assembly``, released with the others once written."""
+        scratch = self._new_sibling_scratch(prefix)
+        self._sibling_scratch.append((assembly, scratch))
+        return scratch
+
+    def _fused_sibling_passes(self, table_key: str) -> Any:
+        """The sibling sinks to feed from the summed table's own passes, or ``None``.
+
+        Only for a reader that hands its frames over as records
+        (:attr:`~thyra.core.base_reader.BaseMSIReader.has_frame_scans`);
+        plans the siblings of ``table_key`` first, since the sinks are
+        theirs. ``None`` when nothing wants the frames, in which case the
+        passes read the summed spectra as they always did and
+        :meth:`_prepare_sibling_scans` scans on its own later.
+        """
+        if not getattr(self.reader, "has_frame_scans", False):
+            return None
+        if self._common_mass_axis is None or self._dimensions is None:
+            return None
+        self._mobility_table_key = self._plan_mobility_table(table_key)
+        self._msms_table_key = self._plan_msms_table(table_key)
+        self._siblings_planned = True
+        from .fused_passes import SiblingPasses
+        from .mobility_table import GridDiscovery
+        from .msms_table import new_msms_accumulator
+
+        n_x, n_y, n_z = self._dimensions
+        n_grid = int(n_x * n_y * n_z)
+        heatmap = self._pending_heatmap()
+        discovery = None
+        if self._mobility_table_key is not None and self._mobility_grid is not None:
+            try:
+                # Rows are handed to the sinks by the passes themselves,
+                # so the lookup a standalone pass would use is not needed.
+                discovery = GridDiscovery(
+                    self._common_mass_axis,
+                    self._mobility_grid,
+                    lambda coords: None,
+                    n_grid,
+                )
+            except MemoryError as e:
+                logger.warning("No mobility-resolved table: %s", e)
+        msms = None
+        if self._msms_table_key is not None:
+            msms = new_msms_accumulator(self.reader, self._common_mass_axis, n_grid)
+        if heatmap is None and discovery is None and msms is None:
+            return None
+        self._sibling_scans_done = True
+        return SiblingPasses(
+            self._common_mass_axis, heatmap=heatmap, discovery=discovery, msms=msms
+        )
+
+    def _take_fused_results(self, passes: Any) -> None:
+        """Keep what the fused passes built for the finalize step to write."""
+        if passes.heatmap_wanted:
+            self._mobility_heatmap_built = True
+            self._mobility_heatmap_block = passes.heatmap_block
+        self._grid_discovery = passes.discovery
+        self._msms_accumulator = passes.msms
 
     def _release_sibling_scratch(self, tables: Optional[Dict[str, Any]] = None) -> None:
         """Drop the sibling tables' memmaps and remove their scratch directories.
@@ -1606,10 +1682,14 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         from .mobility_table import build_mobility_table
 
         discovery, self._grid_discovery = self._grid_discovery, None
-        scratch = self._new_sibling_scratch("mobility")
-        self._sibling_scratch.append(
-            (None if discovery is None else discovery.assembly, scratch)
-        )
+        # The fused passes allocate and register their own scratch; a
+        # discovery without one is scattered by the builder on a new one.
+        scratch = None if discovery is None else discovery.scratch
+        if scratch is None:
+            scratch = self._new_sibling_scratch("mobility")
+            self._sibling_scratch.append(
+                (None if discovery is None else discovery.assembly, scratch)
+            )
         try:
             return build_mobility_table(
                 self.reader,
@@ -1638,8 +1718,11 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         """The demultiplexed sibling of one slice, on a scratch directory of its own."""
         from .msms_table import build_msms_table
 
-        scratch = self._new_sibling_scratch("msms")
-        self._sibling_scratch.append((None, scratch))
+        accumulator, self._msms_accumulator = self._msms_accumulator, None
+        scratch = None if accumulator is None else accumulator.scratch
+        if scratch is None:
+            scratch = self._new_sibling_scratch("msms")
+            self._sibling_scratch.append((None, scratch))
         try:
             return build_msms_table(
                 self.reader,
@@ -1650,6 +1733,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 uns,
                 z_value=z_value,
                 scratch=scratch,
+                accumulator=accumulator,
             )
         except Exception as e:
             logger.error("Could not build the demultiplexed MS/MS table: %s", e)

--- a/thyra/converters/spatialdata/fused_passes.py
+++ b/thyra/converters/spatialdata/fused_passes.py
@@ -1,0 +1,164 @@
+"""The sibling tables fed from the summed table's own passes (design decision D5).
+
+The streaming route builds the summed table in two passes over the
+source: count, then scatter. The mass-mobility heatmap, the mobility
+grid and the demultiplexed MS/MS table are each built the same way, and
+each used to take its own passes -- on a whole slide the heatmap's pass
+alone was 40 to 60 percent of a conversion. When the reader hands its
+frames over as records (:mod:`thyra.core.frames`), one raw read per frame
+per pass serves everything: the summed spectrum is derived from it, and
+so are the mobility point cloud and the precursor spectra the sinks want.
+
+:class:`SiblingPasses` holds those sinks. The converter's pass loops call
+:meth:`SiblingPasses.count` and :meth:`SiblingPasses.scatter` once per
+frame with the row the frame is getting; everything the sinks see goes
+through the same mapping and the same accumulators the standalone passes
+use (``map_points_to_axis``, ``GridDiscovery``, ``MsmsAccumulator``), so
+the tables come out identical to the ones the standalone passes build.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ...core.frames import FrameScans
+from .mobility_heatmap import (
+    MobilityHeatmap,
+    finish_mobility_heatmap,
+    map_points_to_axis,
+)
+from .mobility_table import GridDiscovery, GridScatter, _report_discovery
+from .msms_table import MsmsAccumulator
+
+logger = logging.getLogger(__name__)
+
+
+class SiblingPasses:
+    """The sinks of every sibling table, fed frame by frame by the converter.
+
+    Args:
+        axis: The common mass axis every sink maps onto.
+        heatmap: The heatmap accumulator, or ``None`` when none is wanted.
+        discovery: The grid's pass-1 accumulator, or ``None`` when no grid
+            table is planned.
+        msms: The MS/MS table's accumulator, or ``None`` when no split is
+            planned.
+    """
+
+    def __init__(
+        self,
+        axis: NDArray[np.float64],
+        heatmap: Optional[MobilityHeatmap] = None,
+        discovery: Optional[GridDiscovery] = None,
+        msms: Optional[MsmsAccumulator] = None,
+    ) -> None:
+        """Hold the sinks; nothing is read until the converter's passes feed them."""
+        self.axis = np.asarray(axis, dtype=np.float64)
+        self.heatmap = heatmap
+        self.heatmap_wanted = heatmap is not None
+        self.discovery = discovery
+        self.msms = msms
+        self.heatmap_block: Optional[Dict[str, Any]] = None
+        self.grid_scatter: Optional[GridScatter] = None
+        self.grid_scratch: Optional[Path] = None
+        self.msms_scratch: Optional[Path] = None
+        self._counting_finished = False
+
+    @property
+    def wants_mobility(self) -> bool:
+        """Whether any sink still needs the frames' point clouds."""
+        return self.heatmap is not None or self.discovery is not None
+
+    @property
+    def wants_precursors(self) -> bool:
+        """Whether the MS/MS accumulator is still in play."""
+        return self.msms is not None
+
+    @property
+    def empty(self) -> bool:
+        """Whether there is nothing left to feed."""
+        return not (self.wants_mobility or self.wants_precursors)
+
+    # -- pass 1 ----------------------------------------------------------
+
+    def count(self, frame: FrameScans, row: Optional[int]) -> None:
+        """Feed one frame to every pass-1 sink.
+
+        ``row`` is the row the frame's pixel gets in the summed table, or
+        ``None`` when it gets none (an empty spectrum, a coordinate off
+        the grid): the row-bound sinks skip it, exactly as their own pass
+        skips a pixel that is not in ``obs``. The heatmap is a mean over
+        every pixel with points and takes the frame either way.
+        """
+        if self.wants_mobility:
+            points = frame.mobility_points()
+            if points is not None:
+                mapped = map_points_to_axis(self.axis, *points)
+                if self.heatmap is not None:
+                    self.heatmap.add_mapped(frame.coords, *mapped)
+                if self.discovery is not None:
+                    self.discovery.add_mapped_row(row, *mapped)
+        if self.msms is not None:
+            self.msms.count(row, frame.precursor_spectra())
+
+    def finish_counting(
+        self, n_rows: int, scratch_for: Callable[[str, Any], Path]
+    ) -> None:
+        """Close pass 1: the heatmap block, the grid's verdict, the allocations.
+
+        ``n_rows`` is the summed table's row count, known only now, which
+        the assemblies size their index dtype from. ``scratch_for(prefix,
+        assembly)`` gives a scratch directory per sibling for the memmaps
+        pass 2 scatters into, registered with the assembly so the caller
+        can release both once the table is written. A sibling that pass 1
+        rules out is never scattered.
+        """
+        if self._counting_finished:
+            return
+        self._counting_finished = True
+        if self.heatmap is not None:
+            self.heatmap_block = finish_mobility_heatmap(self.heatmap)
+            self.heatmap = None
+        # A sibling pass 1 rules out keeps its accumulator, verdict inside,
+        # so the builder reaches the same (memoised) verdict and writes no
+        # table; only its pass-2 sink is dropped.
+        if self.discovery is not None:
+            self.discovery.assembly.n_rows = int(n_rows)
+            self.discovery.finish()
+            if _report_discovery(self.discovery):
+                self.grid_scratch = scratch_for("mobility", self.discovery.assembly)
+                self.discovery.scratch = self.grid_scratch
+                self.discovery.assembly.allocate(self.grid_scratch)
+                self.grid_scatter = GridScatter(self.discovery)
+        if self.msms is not None:
+            self.msms.assembly.n_rows = int(n_rows)
+            if self.msms.finish_counting():
+                self.msms_scratch = scratch_for("msms", self.msms.assembly)
+                self.msms.scratch = self.msms_scratch
+                self.msms.allocate(self.msms_scratch)
+
+    # -- pass 2 ----------------------------------------------------------
+
+    def scatter(self, frame: FrameScans, row: Optional[int]) -> None:
+        """Feed one frame to every pass-2 sink; ``row`` as for :meth:`count`."""
+        if row is None:
+            return
+        if self.grid_scatter is not None:
+            points = frame.mobility_points()
+            if points is not None:
+                self.grid_scatter.add_mapped_row(
+                    row, *map_points_to_axis(self.axis, *points)
+                )
+        if self.msms is not None and self.msms.has_rows:
+            self.msms.scatter(row, frame.precursor_spectra())
+
+    def finish_scattering(self) -> None:
+        """Mark every scattered sibling as built; the builders then skip their passes."""
+        if self.discovery is not None and self.grid_scatter is not None:
+            self.discovery.scattered = True
+        if self.msms is not None and self.msms.has_rows:
+            self.msms.scattered = True
+        self.grid_scatter = None

--- a/thyra/converters/spatialdata/mobility_heatmap.py
+++ b/thyra/converters/spatialdata/mobility_heatmap.py
@@ -18,7 +18,8 @@ own nearest-bin mapping onto the common axis, coarsened, so that under a
 lossless summed spectrum (``--tdf-spectrum scan_sum``) the heatmap's
 marginal over mobility is the stored mean spectrum coarsened to the same
 bins. Under the vendor centroid it is not, and cannot be: the centroid
-keeps 80-90% of the ion current and merges bins, and the heatmap is built
+keeps only the current inside the peaks it picks (87-96% on measured
+acquisitions) and merges bins, and the heatmap is built
 from the raw points, not from the centroid.
 
 The raw pass itself is :func:`scan_mobility`, which maps every pixel's

--- a/thyra/converters/spatialdata/mobility_table.py
+++ b/thyra/converters/spatialdata/mobility_table.py
@@ -590,6 +590,15 @@ class GridDiscovery:
         self.n_features: Optional[int] = None
         #: The var ceiling's answer once the count is known.
         self.refusal: Optional[str] = None
+        #: What :func:`_report_discovery` decided, once it has (``None``
+        #: until then), so the verdict is reached and logged once.
+        self.decided: Optional[bool] = None
+        #: Whether pass 2 has already been run through this discovery's
+        #: assembly (the converter's fused passes do that); the builder
+        #: then takes the matrix as it is.
+        self.scattered = False
+        #: The scratch directory the fused passes allocated on, if any.
+        self.scratch: Optional[Path] = None
 
     def add_mapped(
         self,
@@ -600,7 +609,23 @@ class GridDiscovery:
         n_dropped: int,
     ) -> None:
         """Count one pixel already mapped by :func:`map_points_to_axis`."""
-        row = self.row_for(coords)
+        self.add_mapped_row(
+            self.row_for(coords), bins, mobility, intensities, n_dropped
+        )
+
+    def add_mapped_row(
+        self,
+        row: Optional[int],
+        bins: NDArray[np.int64],
+        mobility: NDArray[np.float64],
+        intensities: NDArray[np.float64],
+        n_dropped: int,
+    ) -> None:
+        """Count one mapped pixel whose row the caller already knows.
+
+        ``None`` is a pixel with no row in the table, skipped exactly as
+        :meth:`add_mapped` skips one ``row_for`` cannot place.
+        """
         if row is None:
             self.n_skipped += 1
             return
@@ -658,8 +683,65 @@ def _grid_feature_var(
     )
 
 
+class GridScatter:
+    """Pass 2 of the grid route: one mapped pixel into the allocated CSC arrays.
+
+    Built on a :class:`GridDiscovery` whose assembly has been allocated;
+    the same cell keys pass 1 counted, now with their values.
+    """
+
+    def __init__(self, discovery: GridDiscovery) -> None:
+        """Scatter into ``discovery``'s assembly, which must be allocated."""
+        self.discovery = discovery
+        self.grid = discovery.grid
+        self.assembly = discovery.assembly
+        self.n_channels = int(discovery.grid.n_channels)
+
+    def add_mapped(
+        self,
+        coords: Coords,
+        bins: NDArray[np.int64],
+        mobility: NDArray[np.float64],
+        intensities: NDArray[np.float64],
+        _n_dropped: int,
+    ) -> None:
+        """Scatter one pixel already mapped by :func:`map_points_to_axis`."""
+        self.add_mapped_row(
+            self.discovery.row_for(coords), bins, mobility, intensities, _n_dropped
+        )
+
+    def add_mapped_row(
+        self,
+        row: Optional[int],
+        bins: NDArray[np.int64],
+        mobility: NDArray[np.float64],
+        intensities: NDArray[np.float64],
+        _n_dropped: int,
+    ) -> None:
+        """Scatter one mapped pixel whose row the caller already knows."""
+        if row is None:
+            return
+        keys, values = grid_cells(
+            bins,
+            self.grid.assign(mobility).astype(np.int64),
+            intensities,
+            self.n_channels,
+        )
+        self.assembly.scatter(row, keys, values)
+
+
 def _report_discovery(discovery: GridDiscovery) -> bool:
-    """Say what pass 1 found; whether there is a table to build at all."""
+    """Say what pass 1 found; whether there is a table to build at all.
+
+    Decided and logged once: a second call returns the first verdict.
+    """
+    if discovery.decided is not None:
+        return discovery.decided
+    discovery.decided = _decide_discovery(discovery)
+    return discovery.decided
+
+
+def _decide_discovery(discovery: GridDiscovery) -> bool:
     if discovery.n_skipped:
         logger.warning(
             "%d mobility spectra had no row in the MSI table and were skipped",
@@ -695,7 +777,9 @@ def _build_from_grid(
 
     ``discovery`` is pass 1 already run (fused into the heatmap's pass by
     the converter); without it the pass runs here. Pass 2 then re-reads
-    the source and scatters each pixel straight into the CSC arrays.
+    the source and scatters each pixel straight into the CSC arrays --
+    unless the converter's fused passes have scattered already
+    (``discovery.scattered``), in which case the matrix is taken as it is.
     """
     axis = np.asarray(common_mass_axis, dtype=np.float64)
     if discovery is None:
@@ -707,22 +791,15 @@ def _build_from_grid(
     if not _report_discovery(discovery):
         return None
     assembly = discovery.assembly
-    assembly.allocate(scratch)
     n_channels = int(grid.n_channels)
-
-    class _Scatter:
-        def add_mapped(
-            self, coords: Coords, bins: Any, mobility: Any, intensities: Any, _n: int
-        ) -> None:
-            row = row_for(coords)
-            if row is None:
-                return
-            keys, values = grid_cells(
-                bins, grid.assign(mobility).astype(np.int64), intensities, n_channels
-            )
-            assembly.scatter(row, keys, values)
-
-    scan_mobility(reader, axis, _Scatter(), description="Mobility grid: scattering")
+    if not discovery.scattered:
+        assembly.allocate(scratch)
+        scan_mobility(
+            reader,
+            axis,
+            GridScatter(discovery),
+            description="Mobility grid: scattering",
+        )
     matrix = assembly.matrix()
     var = _grid_feature_var(assembly.unique_keys, axis, grid)
     logger.info(

--- a/thyra/converters/spatialdata/mobility_table.py
+++ b/thyra/converters/spatialdata/mobility_table.py
@@ -409,13 +409,48 @@ def _feature_var(
 # The common-grid mechanism: a per-pixel point cloud, binned
 # ----------------------------------------------------------------------
 
-#: Features a grid table's ``var`` may hold before the grid is refused --
-#: occupied ``(m/z bin, mobility channel)`` pairs, not the pairs the grid
-#: spans. The two differ by an order of magnitude on real data (a measured
-#: 200-frame timsTOF acquisition occupied 3.9M of a possible 35.5M), which
-#: is why the count is checked and not the bound: refusing on the bound
-#: would turn away conversions that fit ninefold over.
-MAX_GRID_VAR_ENTRIES = 20_000_000
+#: Absolute cap on the features a grid table's ``var`` may hold -- occupied
+#: ``(m/z bin, mobility channel)`` pairs, not the pairs the grid spans. The
+#: two differ by an order of magnitude on real data (a measured 200-frame
+#: timsTOF acquisition occupied 3.9M of a possible 35.5M), which is why the
+#: count is checked and not the bound. The cap is a statement of what a
+#: downstream tool can be expected to open, not the operative guard: that
+#: is the memory projection below (design decision D4), which is what
+#: refuses on a real machine long before this number.
+MAX_GRID_VAR_ENTRIES = 100_000_000
+
+#: Process memory the ``var`` frame costs per feature while it is built,
+#: AnnData copies included. Measured 2026-09-07 on a real grid: a private
+#: peak 4.4 GB above baseline at 13.27M features.
+VAR_BYTES_PER_FEATURE = 330
+
+#: Fractions of the machine's free memory the projected ``var`` frame may
+#: take before the conversion warns, and before it refuses. Fractions and
+#: not sizes: a table that is routine on a workstation is fatal on a
+#: laptop, and the same number cannot be right for both.
+GRID_VAR_WARN_FRACTION = 0.25
+GRID_VAR_REFUSE_FRACTION = 0.5
+
+#: What to assume is free when the machine will not say. Generous on
+#: purpose: a guess must never be the thing that refuses a conversion
+#: that would have fitted.
+ASSUMED_FREE_GB = 8.0
+
+
+def available_memory_gb() -> float:
+    """The machine's free memory in GB, or :data:`ASSUMED_FREE_GB`."""
+    try:
+        import psutil
+
+        return float(psutil.virtual_memory().available) / 1024**3
+    except Exception as e:  # pragma: no cover - platform-dependent
+        logger.debug("Could not read available memory: %s", e)
+        return ASSUMED_FREE_GB
+
+
+def projected_var_gb(n_features: int) -> float:
+    """What building a ``var`` frame of this many features is expected to cost."""
+    return float(n_features) * VAR_BYTES_PER_FEATURE / 1024**3
 
 
 def grid_var_bound(common_mass_axis: NDArray[np.float64], grid: MobilityGrid) -> int:
@@ -429,16 +464,51 @@ def grid_var_bound(common_mass_axis: NDArray[np.float64], grid: MobilityGrid) ->
     return int(np.asarray(common_mass_axis).size) * int(grid.n_channels)
 
 
-def var_ceiling_refusal(n_features: int) -> Optional[str]:
-    """Why a grid table this wide must not be built, or ``None``."""
-    if n_features <= MAX_GRID_VAR_ENTRIES:
-        return None
-    return (
-        f"the grid occupies {n_features:,} (m/z bin, mobility channel) pairs, "
-        f"above the var ceiling of {MAX_GRID_VAR_ENTRIES:,}; resample to "
-        f"fewer mass bins or ask for fewer mobility channels "
-        f"(--mobility-bins)"
+def var_ceiling_refusal(
+    n_features: int, available_gb: Optional[float] = None
+) -> Optional[str]:
+    """Why a grid table this wide must not be built, or ``None``.
+
+    The operative test is memory: the ``var`` frame is the peak of an
+    out-of-core build, its cost per feature is measured, and the machine's
+    free memory is known, so the projection is compared with what is
+    there -- refused past :data:`GRID_VAR_REFUSE_FRACTION` of it, warned
+    about past :data:`GRID_VAR_WARN_FRACTION`. The absolute cap is checked
+    first and is far above any real table.
+
+    ``available_gb`` overrides the machine's own answer, for tests.
+    """
+    levers = (
+        "resample to fewer mass bins (--resample-bins) or ask for fewer "
+        "mobility channels (--mobility-bins)"
     )
+    if n_features > MAX_GRID_VAR_ENTRIES:
+        return (
+            f"the grid occupies {n_features:,} (m/z bin, mobility channel) "
+            f"pairs, above the var ceiling of {MAX_GRID_VAR_ENTRIES:,}; {levers}"
+        )
+    gb = projected_var_gb(n_features)
+    free = available_memory_gb() if available_gb is None else float(available_gb)
+    if gb > free * GRID_VAR_REFUSE_FRACTION:
+        return (
+            f"the grid occupies {n_features:,} (m/z bin, mobility channel) "
+            f"pairs, and building their var frame is projected to need "
+            f"{gb:.1f} GB ({VAR_BYTES_PER_FEATURE} bytes per feature, measured) "
+            f"against {free:.1f} GB free, more than the "
+            f"{GRID_VAR_REFUSE_FRACTION:.0%} of free memory a conversion may "
+            f"take; {levers}"
+        )
+    if gb > free * GRID_VAR_WARN_FRACTION:
+        logger.warning(
+            "The mobility grid occupies %s pairs; building their var frame "
+            "is projected to need %.1f GB of the %.1f GB free. It will be "
+            "attempted; %s to make it smaller.",
+            f"{n_features:,}",
+            gb,
+            free,
+            levers,
+        )
+    return None
 
 
 def grid_refusal(

--- a/thyra/converters/spatialdata/msms_table.py
+++ b/thyra/converters/spatialdata/msms_table.py
@@ -39,7 +39,7 @@ precursors costs the same memory as a 700-pixel one with 15.
 
 import logging
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, Optional, Sequence, Tuple
 
 import numpy as np
 import pandas as pd
@@ -288,6 +288,95 @@ def _feature_var(
     )
 
 
+class MsmsAccumulator:
+    """The two passes of the demultiplexed table, one pixel-precursor pair at a time.
+
+    Pass 1 (:meth:`count`) records which ``(precursor, column)`` keys each
+    row occupies; :meth:`finish_counting` says whether anything was
+    accumulated and names the columns; :meth:`allocate` backs the CSC
+    arrays with files; pass 2 (:meth:`scatter`) writes the values. The
+    standalone :func:`_demultiplex` drives it from
+    ``iter_precursor_spectra``; the converter's fused passes drive it from
+    frame records. Either way every key comes from the same
+    :class:`_Demultiplexer`, so the two cannot disagree on what a row holds.
+    """
+
+    def __init__(
+        self, axis: NDArray[np.float64], window_rank: NDArray[np.int64], n_rows: int
+    ) -> None:
+        """Allocate the count over ``windows x axis``; refuses a span too wide."""
+        n_windows = int(window_rank.size)
+        self.demux = _Demultiplexer(axis, window_rank)
+        self.assembly = CscAssembly(n_windows * int(axis.size), n_rows)
+        self.n_skipped = 0
+        self.n_rows_seen = 0
+        #: :meth:`finish_counting`'s verdict, ``None`` until it has run.
+        self.has_rows: Optional[bool] = None
+        #: Whether pass 2 has been run (the converter's fused passes set it).
+        self.scattered = False
+        #: The scratch directory the fused passes allocated on, if any.
+        self.scratch: Optional[Path] = None
+
+    def count(
+        self,
+        row: Optional[int],
+        spectra: Sequence[Tuple[int, NDArray[np.float64], NDArray[np.float64]]],
+    ) -> None:
+        """Pass 1 for one pixel: its precursor spectra, or none when it has no row."""
+        if row is None:
+            self.n_skipped += len(spectra)
+            return
+        for window_index, mzs, intensities in spectra:
+            keys, _values = self.demux.entries(window_index, mzs, intensities)
+            if keys.size:
+                self.n_rows_seen += 1
+            self.assembly.count(row, keys)
+
+    def finish_counting(self) -> bool:
+        """Say what pass 1 found; whether there is a table to build at all."""
+        if self.n_skipped:
+            logger.warning(
+                "%d demultiplexed spectra had no row in the MSI table and were skipped",
+                self.n_skipped,
+            )
+        if self.demux.n_dropped:
+            logger.warning(
+                "%d fragment peaks fell outside the mass axis and were dropped "
+                "from the demultiplexed table",
+                self.demux.n_dropped,
+            )
+        if self.n_rows_seen == 0:
+            logger.warning(
+                "No demultiplexed spectra matched the MSI table; no MS/MS table written"
+            )
+            self.has_rows = False
+            return False
+        self.assembly.finish_counting()
+        self.has_rows = True
+        return True
+
+    def allocate(self, scratch: Path) -> None:
+        """Back the CSC arrays with files in ``scratch``."""
+        self.assembly.allocate(scratch)
+
+    def scatter(
+        self,
+        row: Optional[int],
+        spectra: Sequence[Tuple[int, NDArray[np.float64], NDArray[np.float64]]],
+    ) -> None:
+        """Pass 2 for one pixel."""
+        if row is None:
+            return
+        for window_index, mzs, intensities in spectra:
+            keys, values = self.demux.entries(window_index, mzs, intensities)
+            self.assembly.scatter(row, keys, values)
+
+    def result(self) -> Tuple[sparse.csc_matrix, NDArray[np.int64], CscAssembly]:
+        """``(matrix, unique keys, assembly)`` once pass 2 is complete."""
+        assert self.assembly.unique_keys is not None
+        return self.assembly.matrix(), self.assembly.unique_keys, self.assembly
+
+
 def _demultiplex(
     reader: BaseMSIReader,
     row_for: RowLookup,
@@ -299,49 +388,38 @@ def _demultiplex(
     """Two passes over the precursor spectra; ``(matrix, keys, assembly)`` or ``None``."""
     from tqdm import tqdm
 
-    n_windows = int(window_rank.size)
-    demux = _Demultiplexer(axis, window_rank)
-    assembly = CscAssembly(n_windows * int(axis.size), n_obs)
-    n_skipped = 0
-    n_rows_seen = 0
+    accumulator = MsmsAccumulator(axis, window_rank, n_obs)
     with tqdm(desc="MS/MS table: counting", unit="spectrum") as pbar:
         for coords, window_index, mzs, intensities in reader.iter_precursor_spectra():
             pbar.update(1)
-            row = row_for(coords)
-            if row is None:
-                n_skipped += 1
-                continue
-            keys, _values = demux.entries(window_index, mzs, intensities)
-            if keys.size:
-                n_rows_seen += 1
-            assembly.count(row, keys)
-    if n_skipped:
-        logger.warning(
-            "%d demultiplexed spectra had no row in the MSI table and were skipped",
-            n_skipped,
-        )
-    if demux.n_dropped:
-        logger.warning(
-            "%d fragment peaks fell outside the mass axis and were dropped "
-            "from the demultiplexed table",
-            demux.n_dropped,
-        )
-    if n_rows_seen == 0:
-        logger.warning(
-            "No demultiplexed spectra matched the MSI table; no MS/MS table written"
-        )
+            accumulator.count(row_for(coords), [(window_index, mzs, intensities)])
+    if not accumulator.finish_counting():
         return None
-    assembly.finish_counting()
-    assembly.allocate(scratch)
+    accumulator.allocate(scratch)
     with tqdm(desc="MS/MS table: scattering", unit="spectrum") as pbar:
         for coords, window_index, mzs, intensities in reader.iter_precursor_spectra():
             pbar.update(1)
-            row = row_for(coords)
-            if row is None:
-                continue
-            keys, values = demux.entries(window_index, mzs, intensities)
-            assembly.scatter(row, keys, values)
-    return assembly.matrix(), assembly.unique_keys, assembly
+            accumulator.scatter(row_for(coords), [(window_index, mzs, intensities)])
+    return accumulator.result()
+
+
+def new_msms_accumulator(
+    reader: BaseMSIReader, common_mass_axis: NDArray[np.float64], n_rows: int
+) -> Optional[MsmsAccumulator]:
+    """An accumulator for ``reader``'s schedule, or ``None`` when it must not be split.
+
+    What the converter's fused passes feed. Same refusals and the same
+    precursor axis as :func:`build_msms_table`, which then takes the
+    accumulator back once the passes have run.
+    """
+    schedule = reader.get_fragmentation()
+    if schedule is None or demultiplex_refusal(schedule) is not None:
+        return None
+    axis = np.asarray(common_mass_axis, dtype=np.float64)
+    if axis.size == 0:
+        return None
+    _mz, _mobility, window_rank = _precursor_axis(schedule, _window_mobility(reader))
+    return MsmsAccumulator(axis, window_rank, n_rows)
 
 
 def build_msms_table(
@@ -354,6 +432,7 @@ def build_msms_table(
     z_value: Optional[int] = None,
     pixel_key: Optional[Callable[[Coords], Optional[str]]] = None,
     scratch: Optional[Path] = None,
+    accumulator: Optional[MsmsAccumulator] = None,
 ) -> Optional[Any]:
     """Build the demultiplexed MS/MS table for one MSI table, or ``None``.
 
@@ -372,6 +451,9 @@ def build_msms_table(
             ``obs`` index label; the default matches on ``(x, y[, z])``.
         scratch: Directory for the memmapped CSC arrays the table is built
             on; see :func:`~thyra.converters.spatialdata.mobility_table.build_mobility_table`.
+        accumulator: The two passes already run by the converter's fused
+            passes (:func:`new_msms_accumulator`, fed frame by frame);
+            ``None`` runs them here over ``iter_precursor_spectra``.
 
     Returns:
         A ``TableModel``-parsed AnnData, or ``None`` when the acquisition
@@ -391,21 +473,30 @@ def build_msms_table(
         schedule, _window_mobility(reader)
     )
     n_obs = int(len(obs))
-    owns_scratch = scratch is None
-    workdir = scratch_directory("thyra_msms_") if scratch is None else Path(scratch)
-    built = None
-    try:
-        built = _demultiplex(
-            reader,
-            row_lookup(obs, z_value, pixel_key),
-            axis,
-            window_rank,
-            n_obs,
-            workdir,
+    if accumulator is not None:
+        if not accumulator.has_rows or not accumulator.scattered:
+            return None
+        built: Optional[Tuple[Any, NDArray[np.int64], CscAssembly]] = (
+            accumulator.result()
         )
-    finally:
-        if built is None and owns_scratch:
-            remove_scratch(workdir)
+        owns_scratch = False
+        workdir = Path(accumulator.scratch) if accumulator.scratch else Path()
+    else:
+        owns_scratch = scratch is None
+        workdir = scratch_directory("thyra_msms_") if scratch is None else Path(scratch)
+        built = None
+        try:
+            built = _demultiplex(
+                reader,
+                row_lookup(obs, z_value, pixel_key),
+                axis,
+                window_rank,
+                n_obs,
+                workdir,
+            )
+        finally:
+            if built is None and owns_scratch:
+                remove_scratch(workdir)
     if built is None:
         return None
     matrix, unique_keys, assembly = built

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -15,7 +15,7 @@ import shutil
 import tempfile
 import warnings
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import Any, Dict, Generator, List, Literal, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -1131,9 +1131,16 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         temp_dir.mkdir(parents=True, exist_ok=True)
 
         try:
+            # The sibling tables' sinks, fed from the two passes below when
+            # the reader hands its frames over as records (design decision
+            # D5): one raw read per frame per pass for every table.
+            passes = self._fused_sibling_passes(f"{self.dataset_id}_z0")
+
             # Step 1: Pre-scan - count entries per column (no caching)
             logger.info("Step 1/3: Pre-scan (counting entries per column)...")
-            prescan_result = self._prescan_count_columns(n_grid, n_cols, n_x, n_y)
+            prescan_result = self._prescan_count_columns(
+                n_grid, n_cols, n_x, n_y, passes
+            )
 
             col_counts = prescan_result["col_counts"]
             total_nnz = prescan_result["total_nnz"]
@@ -1149,6 +1156,8 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                 prescan_result["occupancy"], n_grid
             )
             n_rows = int(kept_grid.size)
+            if passes is not None:
+                passes.finish_counting(n_rows, self._register_sibling_scratch)
 
             # The other paths set this in _finalize_data; the root attrs
             # builder reads it for msi_dataset_info["non_empty_pixels"],
@@ -1166,8 +1175,11 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
             # Step 3: Main pass - process and scatter directly to CSC
             logger.info("Step 3/3: Processing spectra and scattering to CSC...")
             rows_in_order = self._scatter_spectra_direct(
-                mm_indices, mm_data, indptr, n_x, n_y, row_of_grid, pixel_count
+                mm_indices, mm_data, indptr, n_x, n_y, row_of_grid, pixel_count, passes
             )
+            if passes is not None:
+                passes.finish_scattering()
+                self._take_fused_results(passes)
             if not rows_in_order:
                 sort_csc_columns(mm_indices, mm_data, indptr, n_rows)
 
@@ -1244,8 +1256,40 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
             )
         return kept_grid, row_of_grid
 
+    def _iter_pass_spectra(
+        self, passes: Any, phase: str
+    ) -> Generator[Tuple[Tuple[int, int, int], Any, Any, Any], None, None]:
+        """The summed spectra of one pass, with the frame record they came from.
+
+        Yields ``(coords, mzs, intensities, frame)``: ``frame`` is the
+        record the sinks are fed from, or ``None`` when the pass reads
+        the summed spectra directly (no sinks, or a reader without
+        records). A frame whose summed spectrum is empty is not yielded,
+        exactly as ``iter_spectra`` never yields it, but the sinks of
+        ``phase`` (``"count"`` or ``"scatter"``) still see it with no row,
+        which is what their own pass would have shown them.
+        """
+        if passes is None or passes.empty:
+            for coords, mzs, intensities in self.reader.iter_spectra(
+                batch_size=self._buffer_size
+            ):
+                yield coords, mzs, intensities, None
+            return
+        feed = getattr(passes, phase)
+        for frame in self.reader.iter_frame_scans(batch_size=self._buffer_size):
+            spectrum = frame.spectrum()
+            if spectrum is None:
+                feed(frame, None)
+                continue
+            yield frame.coords, spectrum[0], spectrum[1], frame
+
     def _prescan_count_columns(
-        self, n_grid: int, n_cols: int, n_x: int, n_y: int
+        self,
+        n_grid: int,
+        n_cols: int,
+        n_x: int,
+        n_y: int,
+        passes: Any = None,
     ) -> Dict[str, Any]:
         """Pre-scan spectra to count entries per column without caching.
 
@@ -1254,6 +1298,8 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         2. Computes TIC values per pixel
         3. Accumulates total intensity for average spectrum
         4. Records which grid positions carry a spectrum at all
+        5. Feeds the sibling tables' pass-1 sinks, when ``passes`` is given,
+           from the same frame read (see ``fused_passes.py``)
 
         No data is cached to disk - we'll reprocess spectra in the main pass.
 
@@ -1261,6 +1307,7 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
             n_grid: Number of grid positions
             n_cols: Number of m/z bins
             n_x, n_y: Spatial dimensions
+            passes: The sibling sinks to feed, or ``None``
 
         Returns:
             Dictionary with col_counts, total_nnz, tic_values, avg_spectrum,
@@ -1285,11 +1332,11 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
 
         with tqdm(
             total=total_spectra,
-            desc="Pre-scan",
+            desc="Pre-scan" if passes is None else "Pre-scan + sibling tables",
             unit="spectrum",
         ) as pbar:
-            for coords, mzs, intensities in self.reader.iter_spectra(
-                batch_size=self._buffer_size
+            for coords, mzs, intensities, frame in self._iter_pass_spectra(
+                passes, "count"
             ):
                 x, y, z = coords
 
@@ -1297,6 +1344,15 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                 mz_indices, resampled_ints = self._process_spectrum(mzs, intensities)
 
                 nnz = len(mz_indices)
+                if frame is not None:
+                    # The row the sinks count under is the grid position,
+                    # which is the table row's own order: rows are numbered
+                    # in grid order once the empty positions are dropped.
+                    # A spectrum that gets no row (empty, or off the grid)
+                    # is a pixel the siblings skip, as their own pass
+                    # skips one that is not in obs.
+                    gets_row = nnz > 0 and 0 <= y < n_y and 0 <= x < n_x
+                    passes.count(frame, (y * n_x + x) if gets_row else None)
                 if nnz > 0:
                     # Accumulate for average spectrum (vectorized). Left
                     # outside the bounds check to match the COO pre-scan,
@@ -1376,11 +1432,14 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         n_y: int,
         row_of_grid: NDArray[np.int64],
         pixel_count: int,
+        passes: Any = None,
     ) -> bool:
         """Process spectra and scatter directly to CSC arrays.
 
         This is the main pass that processes spectra again (same resampling
         as pre-scan) and scatters values directly to their CSC positions.
+        With ``passes`` it also scatters the sibling tables from the same
+        frame read (see ``fused_passes.py``).
 
         Args:
             mm_indices: Memory-mapped array for row indices
@@ -1416,11 +1475,11 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
 
         with tqdm(
             total=pixel_count,
-            desc="Scatter to CSC",
+            desc="Scatter to CSC" if passes is None else "Scatter to CSC + siblings",
             unit="spectrum",
         ) as pbar:
-            for coords, mzs, intensities in self.reader.iter_spectra(
-                batch_size=self._buffer_size
+            for coords, mzs, intensities, frame in self._iter_pass_spectra(
+                passes, "scatter"
             ):
                 x, y, z = coords
 
@@ -1436,6 +1495,9 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                 row_idx = -1
                 if len(mz_indices) > 0 and 0 <= y < n_y and 0 <= x < n_x:
                     row_idx = int(row_of_grid[y * n_x + x])
+
+                if frame is not None:
+                    passes.scatter(frame, row_idx if row_idx >= 0 else None)
 
                 if row_idx >= 0:
                     if row_idx < last_row:
@@ -1571,10 +1633,13 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         # Decide on the sibling tables before uns is written, so the
         # table's uns can name them (see _collect_mobility_axis), and run
         # the raw mobility pass once for the heatmap and the grid's
-        # discovery together. The siblings' obs mirrors this table's rows:
-        # one per kept grid position, indexed by the grid index as a string.
-        self._mobility_table_key = self._plan_mobility_table(slice_id)
-        self._msms_table_key = self._plan_msms_table(slice_id)
+        # discovery together -- unless both were done from the summed
+        # table's own passes already (see _fused_sibling_passes). The
+        # siblings' obs mirrors this table's rows: one per kept grid
+        # position, indexed by the grid index as a string.
+        if not self._siblings_planned:
+            self._mobility_table_key = self._plan_mobility_table(slice_id)
+            self._msms_table_key = self._plan_msms_table(slice_id)
         sibling_obs = self._sibling_obs(kept_grid, n_x, region_key)
         self._prepare_sibling_scans(sibling_obs, z_value=0)
 

--- a/thyra/core/base_reader.py
+++ b/thyra/core/base_reader.py
@@ -11,6 +11,7 @@ from ..metadata.types import ComprehensiveMetadata, EssentialMetadata
 
 if TYPE_CHECKING:
     from .base_extractor import MetadataExtractor
+    from .frames import FrameScans
     from .mobility import MobilityAxis
     from .msms import FragmentationSchedule
 
@@ -238,6 +239,40 @@ class BaseMSIReader(ABC):
             Mapping of column name to per-channel values, or None.
         """
         return None
+
+    # ------------------------------------------------------------------
+    # One read per frame for every table
+    #
+    # A source whose summed spectrum, mobility point cloud and precursor
+    # spectra are all functions of one raw read per pixel can hand that
+    # read over once, as a record, so a converter that writes several
+    # tables reads the source once per pass rather than once per table.
+    # See ``thyra.core.frames`` and design decision D5.
+    # ------------------------------------------------------------------
+
+    @property
+    def has_frame_scans(self) -> bool:
+        """Whether :meth:`iter_frame_scans` is available on this source."""
+        return False
+
+    def iter_frame_scans(
+        self, batch_size: Optional[int] = None
+    ) -> Generator["FrameScans", None, None]:
+        """Iterate the frames as records that derive every view of a pixel.
+
+        Yields one :class:`~thyra.core.frames.FrameScans` per frame, in
+        the same order and with the same coordinates as
+        :meth:`iter_spectra`, including frames whose summed spectrum is
+        empty (their :meth:`~thyra.core.frames.FrameScans.spectrum` is
+        ``None``), so a consumer can still count them for the sinks that
+        do not depend on the summed spectrum.
+
+        Raises:
+            NotImplementedError: When :attr:`has_frame_scans` is False.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not hand its frames over as records"
+        )
 
     # ------------------------------------------------------------------
     # Ion mobility

--- a/thyra/core/frames.py
+++ b/thyra/core/frames.py
@@ -1,0 +1,58 @@
+"""One frame's raw read, from which every table's view of it derives.
+
+A Bruker TDF frame is read as one buffer of ``(digitizer index, scan,
+intensity)`` triples, and everything the converter writes about that
+pixel is a function of that one buffer: the summed spectrum is the
+triples summed per index, the mobility point cloud is the same triples
+with the scan turned into 1/K0, and the fragment spectrum of each
+precursor is the triples of that precursor's scan range summed per index.
+The three iterators of the reader contract each read the buffer again,
+so a conversion that wants all three reads the source three times per
+pass -- which on a whole slide is most of the conversion (design decision
+D5 in ``docs/design-decisions.md``).
+
+A :class:`FrameScans` is that buffer read once, handed to the converter's
+pass loop so it can derive the summed spectrum *and* feed the sibling
+tables' sinks from it. Every derivation goes through the same helpers
+the reader's iterators use, so what a sink sees through a record is what
+it would have seen through the iterator.
+"""
+
+from typing import List, Optional, Protocol, Tuple
+
+import numpy as np
+from numpy.typing import NDArray
+
+Coords = Tuple[int, int, int]
+Spectrum = Tuple[NDArray[np.float64], NDArray[np.float64]]
+MobilityPoints = Tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]]
+PrecursorSpectrum = Tuple[int, NDArray[np.float64], NDArray[np.float64]]
+
+
+class FrameScans(Protocol):
+    """One pixel's raw read, with every view of it derived on demand.
+
+    Each method answers exactly as the corresponding reader iterator
+    would have yielded for this frame -- the same arrays, the same
+    filtering, the same "nothing" -- so a consumer fed from records is
+    fed what its own pass would have read.
+    """
+
+    coords: Coords
+
+    def spectrum(self) -> Optional[Spectrum]:
+        """``(mzs, intensities)`` as :meth:`BaseMSIReader.iter_spectra` yields, or ``None``.
+
+        ``None`` where the iterator would have skipped the frame (an
+        empty spectrum, or one emptied by the intensity threshold).
+        """
+
+    def mobility_points(self) -> Optional[MobilityPoints]:
+        """``(mzs, mobility, intensities)`` as ``iter_mobility_spectra`` yields, or ``None``."""
+
+    def precursor_spectra(self) -> List[PrecursorSpectrum]:
+        """``[(window_index, mzs, intensities), ...]`` as ``iter_precursor_spectra`` yields.
+
+        Empty when the acquisition has no separable precursor schedule
+        or the frame holds no isolated points.
+        """

--- a/thyra/core/msms.py
+++ b/thyra/core/msms.py
@@ -20,10 +20,11 @@ must not mean another in a store built from it.
 What it deliberately does **not** do is change the data. A frame that
 isolated several precursors is still summed into one spectrum per pixel;
 the schedule recorded here is what makes that visible rather than silent.
-Splitting such a frame into one spectrum per precursor is a separate,
-opt-in table with a feature axis of (precursor, fragment) pairs -- see
+Splitting such a frame into one spectrum per precursor is a separate
+sibling table with a feature axis of (precursor, fragment) pairs, written
+by default whenever the schedule allows an exact split -- see
 ``thyra.converters.spatialdata.msms_table``, which reads the schedule
-recorded here to decide whether the split is exact.
+recorded here to decide that.
 """
 
 from dataclasses import dataclass

--- a/thyra/metadata/extractors/waters_extractor.py
+++ b/thyra/metadata/extractors/waters_extractor.py
@@ -42,6 +42,7 @@ class WatersMetadataExtractor(MetadataExtractor):
         ms_functions: List[int],
         instrument: Optional["WatersInstrument"] = None,
         use_centroid: bool = True,
+        excluded_functions: Optional[Dict[int, Dict[str, Any]]] = None,
     ):
         """Initialize Waters metadata extractor.
 
@@ -51,7 +52,6 @@ class WatersMetadataExtractor(MetadataExtractor):
             data_path: Path to the Waters .raw directory.
             imaging_grid: Pre-built ImagingGrid with spatial metadata.
             function_types: Map of function index to FunctionType.
-            ms_functions: List of MS function indices.
             instrument: What the run's side files say about the analyser,
                 from :func:`thyra.readers.waters.instrument.identify_waters_instrument`.
                 ``None`` reports nothing instrument-specific.
@@ -61,6 +61,10 @@ class WatersMetadataExtractor(MetadataExtractor):
                 one the reader *delivers*, not the one the file was
                 acquired in: downstream axis and method selection act on
                 the spectra they will actually receive.
+            ms_functions: List of MS function indices that are converted.
+            excluded_functions: MS functions the reader left out because
+                the file also holds MS1 ones (MSe, data-dependent runs):
+                function index -> ``{"ms_level", "precursor_mz", "n_scans"}``.
         """
         super().__init__(ml)
         self._ml = ml
@@ -71,6 +75,7 @@ class WatersMetadataExtractor(MetadataExtractor):
         self._ms_functions = ms_functions
         self._instrument = instrument
         self._use_centroid = use_centroid
+        self._excluded_functions = dict(excluded_functions or {})
 
     def _extract_essential_impl(self) -> EssentialMetadata:
         """Extract essential metadata.
@@ -366,6 +371,12 @@ class WatersMetadataExtractor(MetadataExtractor):
             "function_types": {
                 str(f): ft.name if hasattr(ft, "name") else str(ft)
                 for f, ft in self._function_types.items()
+            },
+            # MS functions left out because the file also holds MS1 ones;
+            # the store's spectra are MS1, and this is where the MS/MS
+            # functions of an MSe or data-dependent run are still visible.
+            "excluded_functions": {
+                str(f): dict(detail) for f, detail in self._excluded_functions.items()
             },
             "pixel_count_x": self._imaging_grid.pixel_count_x,
             "pixel_count_y": self._imaging_grid.pixel_count_y,

--- a/thyra/readers/bruker/timstof/sdk/sdk_functions.py
+++ b/thyra/readers/bruker/timstof/sdk/sdk_functions.py
@@ -14,16 +14,20 @@ correct ways to do that (see :data:`TDF_SPECTRUM_MODES`):
     (``tims_extract_centroided_spectrum_for_frame_v2``) over scans
     ``0..NumScans``. This is the same peak picker behind the TSF line
     spectrum (``tsf_read_line_spectrum_v2``) and behind SCiLS Lab's import,
-    so TSF and TDF stores from the same instrument family agree. It merges
-    neighbouring digitizer bins and discards single-count noise, which on
-    real imaging frames keeps roughly 80-90% of the raw ion current.
+    so TSF and TDF stores from the same instrument family agree. It reports
+    peak areas, merges neighbouring digitizer bins and drops every index
+    bin its picker assigns to no peak, which on measured imaging
+    acquisitions keeps 87-96% of the raw ion current. Bruker's own
+    ``Frames.SummedIntensities`` is the scan sum, not the centroid total.
 
 ``scan_sum``
     The lossless alternative: every ``(index, scan)`` pair of the frame is
     read with ``tims_read_scans_v2`` and intensities are summed per
-    digitizer index. Keeps 100% of the ion current, yields three to four
-    times as many points per frame, and is the only mode whose result is
-    exactly the mobility marginal of the per-scan data.
+    digitizer index. Keeps 100% of the ion current, yields 1.5 to 3 times as
+    many points per frame, equals Bruker's own quasi-profile export
+    (``tims_extract_profile_for_frame``) and ``Frames.SummedIntensities``
+    exactly, and is the only mode whose result is the mobility marginal
+    of the per-scan data.
 
 Frame ids are the 1-based ``Frames.Id`` of the SQLite database throughout;
 the SDK takes them as-is.

--- a/thyra/readers/bruker/timstof/sdk/sdk_functions.py
+++ b/thyra/readers/bruker/timstof/sdk/sdk_functions.py
@@ -7,7 +7,8 @@ TDF (TIMS engaged) frames are read over the **full mobility ramp**. A TIMS
 frame is one pixel, its scans are the mobility dimension, and the scan
 number maps monotonically onto 1/K0. The one spectrum the reader yields per
 pixel therefore has to collapse every scan of the frame, and there are two
-correct ways to do that (see :data:`TDF_SPECTRUM_MODES`):
+correct ways to do that (see :data:`TDF_SPECTRUM_MODES`); ``scan_sum`` is
+the default, ``vendor_centroid`` the opt-in:
 
 ``vendor_centroid``
     Bruker's own frame-level centroid extraction
@@ -61,7 +62,10 @@ logger = logging.getLogger(__name__)
 #: reader yields per pixel. See the module docstring for what each means.
 TdfSpectrumMode = Literal["vendor_centroid", "scan_sum"]
 TDF_SPECTRUM_MODES: Tuple[str, ...] = ("vendor_centroid", "scan_sum")
-DEFAULT_TDF_SPECTRUM: str = "vendor_centroid"
+#: ``scan_sum`` since the default was decided on measurement (see
+#: ``docs/design-decisions.md`` D1): it is the instrument's own record and
+#: equals Bruker's per-frame total; the centroid is the opt-in.
+DEFAULT_TDF_SPECTRUM: str = "scan_sum"
 
 # The callback the SDK's frame-level centroid extraction hands its result
 # to: (precursor id, number of peaks, m/z values, area values). Declared

--- a/thyra/readers/bruker/timstof/sdk/sdk_functions.py
+++ b/thyra/readers/bruker/timstof/sdk/sdk_functions.py
@@ -48,7 +48,7 @@ from ctypes import (
     c_void_p,
     create_string_buffer,
 )
-from typing import Dict, Literal, Optional, Tuple
+from typing import Any, Dict, Literal, Optional, Tuple
 
 import numpy as np
 from numpy.typing import NDArray
@@ -57,6 +57,23 @@ from .....utils.bruker_exceptions import SDKError
 from .dll_manager import DLLManager
 
 logger = logging.getLogger(__name__)
+
+
+def sum_scans_per_index(
+    inverse: NDArray[Any], intensities: NDArray[Any], n_unique: int
+) -> NDArray[np.float64]:
+    """The ``scan_sum`` collapse: every pair's intensity summed per unique index.
+
+    ``inverse`` is ``np.unique(indices, return_inverse=True)``'s second
+    answer. One expression, shared by the spectrum reader and the frame
+    record (``thyra.core.frames``), so the two cannot sum differently.
+    """
+    return np.bincount(
+        np.asarray(inverse).ravel(),
+        weights=np.asarray(intensities).astype(np.float64),
+        minlength=int(n_unique),
+    )
+
 
 #: How a TDF frame's TIMS scans are collapsed into the one spectrum the
 #: reader yields per pixel. See the module docstring for what each means.
@@ -633,11 +650,7 @@ class SDKFunctions:
             return np.array([], dtype=np.float64), np.array([], dtype=np.float64)
 
         unique_indices, inverse = np.unique(indices, return_inverse=True)
-        summed = np.bincount(
-            inverse.ravel(),
-            weights=intensities.astype(np.float64),
-            minlength=unique_indices.size,
-        )
+        summed = sum_scans_per_index(inverse, intensities, unique_indices.size)
         # Unique indices are ascending and the calibration is monotonic, so
         # the m/z array comes out sorted without a second pass.
         mzs = self._convert_indices_to_mz(

--- a/thyra/readers/bruker/timstof/timstof_reader.py
+++ b/thyra/readers/bruker/timstof/timstof_reader.py
@@ -46,7 +46,12 @@ from ..base_bruker_reader import BrukerBaseMSIReader
 from ..folder_structure import BrukerFolderStructure, BrukerFormat
 from ..mis_parser import parse_mis_file
 from .sdk.dll_manager import DLLManager
-from .sdk.sdk_functions import DEFAULT_TDF_SPECTRUM, TDF_SPECTRUM_MODES, SDKFunctions
+from .sdk.sdk_functions import (
+    DEFAULT_TDF_SPECTRUM,
+    TDF_SPECTRUM_MODES,
+    SDKFunctions,
+    sum_scans_per_index,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -208,6 +213,114 @@ def _get_frame_count(db_path: Path) -> int:
         return 0
 
 
+class TdfFrameScans:
+    """One TDF frame's raw scan read, with every view of it derived on demand.
+
+    The :class:`~thyra.core.frames.FrameScans` record of the Bruker
+    reader: one ``tims_read_scans_v2`` over the full ramp at construction,
+    ``tims_index_to_mz`` on the frame's unique indices the first time any
+    view needs m/z, and the three views computed by the very helpers the
+    reader's iterators use, so a converter fed from records sees what its
+    own pass would have read.
+    """
+
+    __slots__ = (
+        "coords",
+        "frame_id",
+        "indices",
+        "intensities",
+        "scans",
+        "unique_indices",
+        "inverse",
+        "_reader",
+        "_unique_mz",
+    )
+
+    def __init__(
+        self, reader: "BrukerReader", frame_id: int, coords: Tuple[int, int, int]
+    ) -> None:
+        """Read the frame's scans once; every view is derived from them."""
+        self.coords = coords
+        self.frame_id = int(frame_id)
+        self._reader = reader
+        self.indices, self.intensities, self.scans = reader.sdk.read_tdf_scans(
+            reader.handle,
+            frame_id,
+            0,
+            reader._frame_num_scans(frame_id),
+            reader._num_peaks_cache.get(frame_id),
+        )
+        if self.indices.size:
+            unique_indices, inverse = np.unique(self.indices, return_inverse=True)
+            self.unique_indices = unique_indices
+            self.inverse = np.asarray(inverse).ravel()
+        else:
+            self.unique_indices = np.zeros(0, dtype=self.indices.dtype)
+            self.inverse = np.zeros(0, dtype=np.int64)
+        self._unique_mz: Optional[NDArray[np.float64]] = None
+
+    @property
+    def unique_mz(self) -> NDArray[np.float64]:
+        """m/z of each unique digitizer index, ascending; converted once."""
+        if self._unique_mz is None:
+            self._unique_mz = self._reader.sdk.index_to_mz(
+                self._reader.handle,
+                self.frame_id,
+                self.unique_indices.astype(np.float64),
+            )
+        return self._unique_mz
+
+    def spectrum(
+        self,
+    ) -> Optional[Tuple[NDArray[np.float64], NDArray[np.float64]]]:
+        """The summed spectrum as :meth:`BrukerReader.iter_spectra` yields it."""
+        reader = self._reader
+        try:
+            if reader.tdf_spectrum == "vendor_centroid":
+                # Bruker's own picker over the same ramp: a second library
+                # call, which is the price of that mode; the raw read still
+                # serves every other view.
+                mzs, intensities = reader._read_frame_spectrum(self.frame_id)
+            else:
+                if self.indices.size == 0:
+                    return None
+                mzs = self.unique_mz
+                intensities = sum_scans_per_index(
+                    self.inverse, self.intensities, self.unique_indices.size
+                )
+            mzs, intensities = reader._apply_intensity_filter(mzs, intensities)
+        except Exception as e:
+            logger.warning(f"Error reading spectrum for frame {self.frame_id}: {e}")
+            return None
+        if mzs.size > 0 and intensities.size > 0:
+            return mzs, intensities
+        return None
+
+    def mobility_points(
+        self,
+    ) -> Optional[Tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]]]:
+        """The point cloud as :meth:`BrukerReader.iter_mobility_spectra` yields it."""
+        reader = self._reader
+        try:
+            values, n_axis = reader._mobility_values()
+            return reader._mobility_points_from(self, values, n_axis)
+        except Exception as e:
+            logger.warning(
+                f"Error reading mobility scans for frame {self.frame_id}: {e}"
+            )
+            return None
+
+    def precursor_spectra(
+        self,
+    ) -> List[Tuple[int, NDArray[np.float64], NDArray[np.float64]]]:
+        """The fragment spectra as :meth:`BrukerReader.iter_precursor_spectra` yields them."""
+        context = self._reader._precursor_context()
+        if context is None:
+            return []
+        scan_map, n_windows = context
+        return self._reader._precursor_spectra_from(self, scan_map, n_windows)
+
+
 @register_reader("bruker")
 class BrukerReader(BrukerBaseMSIReader):
     """Bruker reader for TSF/TDF data formats.
@@ -327,6 +440,9 @@ class BrukerReader(BrukerBaseMSIReader):
         self._fragmentation: Optional[FragmentationSchedule] = None
         self._fragmentation_read: bool = False
         self._mobility_scan_overflow_warned: bool = False
+        # (scan -> window map, window count) for the frame records' precursor
+        # view; built once per reader, like iter_precursor_spectra's own.
+        self._precursor_scan_map_cache: Optional[Tuple[NDArray[np.int64], int]] = None
         self._closed: bool = False  # Track if resources have been closed
 
         # Preload the per-frame NumPeaks (buffer sizing) and, for TDF, the
@@ -1188,55 +1304,65 @@ class BrukerReader(BrukerBaseMSIReader):
                 "Reading mobility spectra needs the Bruker library; the reader "
                 "was opened in metadata-only mode"
             )
-        axis = self.get_mobility_axis()
-        if axis is None or axis.values is None:
-            raise SDKError("The per-scan 1/K0 axis is not available")
-        values = axis.values
-        n_axis = int(values.size)
+        values, n_axis = self._mobility_values()
 
         for frame_id, coords in self._iter_frames():
             try:
-                indices, raw_intensities, scans = self.sdk.read_tdf_scans(
-                    self.handle,
-                    frame_id,
-                    0,
-                    self._frame_num_scans(frame_id),
-                    self._num_peaks_cache.get(frame_id),
-                )
-                if indices.size == 0:
-                    continue
-                unique_indices, inverse = np.unique(indices, return_inverse=True)
-                unique_mz = self.sdk.index_to_mz(
-                    self.handle, frame_id, unique_indices.astype(np.float64)
-                )
-                mzs = unique_mz[np.asarray(inverse).ravel()]
-                if (
-                    int(scans.max()) >= n_axis
-                    and not self._mobility_scan_overflow_warned
-                ):
-                    self._mobility_scan_overflow_warned = True
-                    logger.warning(
-                        "Frame %d has scan numbers beyond the %d-scan mobility "
-                        "axis; they are clipped to the last scan's 1/K0",
-                        frame_id,
-                        n_axis,
-                    )
-                mobility = np.take(values, scans, mode="clip")
-                intensities = raw_intensities.astype(np.float64)
+                frame = TdfFrameScans(self, frame_id, coords)
+                points = self._mobility_points_from(frame, values, n_axis)
             except Exception as e:
                 logger.warning(
                     f"Error reading mobility scans for frame {frame_id}: {e}"
                 )
                 continue
-            if self._intensity_threshold is not None:
-                keep = intensities >= self._intensity_threshold
-                mzs, mobility, intensities = (
-                    mzs[keep],
-                    mobility[keep],
-                    intensities[keep],
-                )
-            if mzs.size > 0:
-                yield coords, mzs, mobility, intensities
+            if points is not None:
+                yield coords, points[0], points[1], points[2]
+
+    def _mobility_values(self) -> Tuple[NDArray[np.float64], int]:
+        """The per-scan 1/K0 values and their count, for the point cloud."""
+        axis = self.get_mobility_axis()
+        if axis is None or axis.values is None:
+            raise SDKError("The per-scan 1/K0 axis is not available")
+        return axis.values, int(axis.values.size)
+
+    def _mobility_points_from(
+        self,
+        frame: "TdfFrameScans",
+        values: NDArray[np.float64],
+        n_axis: int,
+    ) -> Optional[Tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]]]:
+        """One frame's ``(m/z, 1/K0, intensity)`` points from its raw read.
+
+        The one derivation behind :meth:`iter_mobility_spectra` and the
+        frame record's ``mobility_points``: ``tims_index_to_mz`` on the
+        frame's unique indices only, the scan number of each pair turned
+        into ``values[scan]``. ``None`` when the frame holds no points
+        (or none above the intensity threshold).
+        """
+        if frame.indices.size == 0:
+            return None
+        mzs = frame.unique_mz[frame.inverse]
+        scans = frame.scans
+        if int(scans.max()) >= n_axis and not self._mobility_scan_overflow_warned:
+            self._mobility_scan_overflow_warned = True
+            logger.warning(
+                "Frame %d has scan numbers beyond the %d-scan mobility "
+                "axis; they are clipped to the last scan's 1/K0",
+                frame.frame_id,
+                n_axis,
+            )
+        mobility = np.take(values, scans, mode="clip")
+        intensities = frame.intensities.astype(np.float64)
+        if self._intensity_threshold is not None:
+            keep = intensities >= self._intensity_threshold
+            mzs, mobility, intensities = (
+                mzs[keep],
+                mobility[keep],
+                intensities[keep],
+            )
+        if mzs.size == 0:
+            return None
+        return mzs, mobility, intensities
 
     def _precursor_scan_map(
         self, windows: Tuple[IsolationWindow, ...]
@@ -1324,51 +1450,111 @@ class BrukerReader(BrukerBaseMSIReader):
         n_windows = len(schedule.windows)
         for frame_id, coords in self._iter_frames():
             try:
-                indices, raw_intensities, scans = self.sdk.read_tdf_scans(
-                    self.handle,
-                    frame_id,
-                    0,
-                    self._frame_num_scans(frame_id),
-                    self._num_peaks_cache.get(frame_id),
-                )
+                frame = TdfFrameScans(self, frame_id, coords)
             except Exception as e:
                 logger.warning(
                     f"Error reading scans for frame {frame_id}: {e}",
                 )
                 continue
-            if indices.size == 0:
-                continue
-            unique_indices, inverse = np.unique(indices, return_inverse=True)
-            unique_mz = self.sdk.index_to_mz(
-                self.handle, frame_id, unique_indices.astype(np.float64)
+            for window_index, mzs, intensities in self._precursor_spectra_from(
+                frame, scan_map, n_windows
+            ):
+                yield coords, window_index, mzs, intensities
+
+    def _precursor_context(self) -> Optional[Tuple[NDArray[np.int64], int]]:
+        """``(scan -> window map, window count)``, or ``None`` when not separable.
+
+        The frame record's precursor view uses this where
+        :meth:`iter_precursor_spectra` would have raised: a record of a
+        frame that cannot be split simply has no precursor spectra.
+        """
+        if self.file_type != "tdf":
+            return None
+        schedule = self.get_fragmentation()
+        if schedule is None or not schedule.windows:
+            return None
+        if not all(w.is_mobility_resolved for w in schedule.windows):
+            return None
+        if self._precursor_scan_map_cache is None:
+            self._precursor_scan_map_cache = (
+                self._precursor_scan_map(schedule.windows),
+                len(schedule.windows),
             )
-            inverse = np.asarray(inverse).ravel()
-            intensities = raw_intensities.astype(np.float64)
-            window_of_point = np.take(scan_map, scans, mode="clip")
-            isolated = window_of_point >= 0
-            n_unique = int(unique_indices.size)
-            # Sum over each window's scans per digitizer index, every
-            # window at once: the mobility dimension is collapsed inside
-            # the window, the way iter_spectra collapses it over the whole
-            # ramp. One bincount over (window, index) keys instead of one
-            # pass over the frame per window.
-            sums = np.bincount(
-                window_of_point[isolated] * n_unique + inverse[isolated],
-                weights=intensities[isolated],
-                minlength=n_windows * n_unique,
-            ).reshape(n_windows, n_unique)
-            for window_index in np.flatnonzero(sums.any(axis=1)).tolist():
-                mzs, window_intensities = self._apply_intensity_filter(
-                    unique_mz, sums[window_index]
-                )
-                nonzero = np.flatnonzero(window_intensities)
-                if nonzero.size:
-                    yield (
-                        coords,
-                        window_index,
-                        mzs[nonzero],
-                        window_intensities[nonzero],
-                    )
+        return self._precursor_scan_map_cache
+
+    def _precursor_spectra_from(
+        self,
+        frame: "TdfFrameScans",
+        scan_map: NDArray[np.int64],
+        n_windows: int,
+    ) -> List[Tuple[int, NDArray[np.float64], NDArray[np.float64]]]:
+        """One frame's fragment spectra, one per precursor with points.
+
+        The one derivation behind :meth:`iter_precursor_spectra` and the
+        frame record's ``precursor_spectra``. Sums over each window's
+        scans per digitizer index, every window at once: the mobility
+        dimension is collapsed inside the window, the way the summed
+        spectrum collapses it over the whole ramp. One bincount over
+        (window, index) keys instead of one pass over the frame per
+        window.
+        """
+        if frame.indices.size == 0:
+            return []
+        unique_mz = frame.unique_mz
+        inverse = frame.inverse
+        intensities = frame.intensities.astype(np.float64)
+        window_of_point = np.take(scan_map, frame.scans, mode="clip")
+        isolated = window_of_point >= 0
+        n_unique = int(frame.unique_indices.size)
+        sums = np.bincount(
+            window_of_point[isolated] * n_unique + inverse[isolated],
+            weights=intensities[isolated],
+            minlength=n_windows * n_unique,
+        ).reshape(n_windows, n_unique)
+        out: List[Tuple[int, NDArray[np.float64], NDArray[np.float64]]] = []
+        for window_index in np.flatnonzero(sums.any(axis=1)).tolist():
+            mzs, window_intensities = self._apply_intensity_filter(
+                unique_mz, sums[window_index]
+            )
+            nonzero = np.flatnonzero(window_intensities)
+            if nonzero.size:
+                out.append((window_index, mzs[nonzero], window_intensities[nonzero]))
+        return out
+
+    # ------------------------------------------------------------------
+    # One read per frame for every table (design decision D5)
+    # ------------------------------------------------------------------
+
+    @property
+    def has_frame_scans(self) -> bool:
+        """True for a TDF file read through the library: one raw read serves every table."""
+        return (
+            self.file_type == "tdf"
+            and getattr(self, "sdk", None) is not None
+            and bool(self.handle)
+        )
+
+    def iter_frame_scans(
+        self, batch_size: Optional[int] = None
+    ) -> Generator["TdfFrameScans", None, None]:
+        """Every frame as a :class:`TdfFrameScans`: one ``tims_read_scans_v2`` each.
+
+        Same frames, same order and same coordinates as
+        :meth:`iter_spectra`; a frame whose read fails is logged and
+        skipped, as the iterators skip it. See
+        :mod:`thyra.core.frames`.
+        """
+        if not self.has_frame_scans:
+            raise NotImplementedError(
+                "Frame records need a TDF file read through the Bruker library"
+            )
+        for frame_id, coords in self._iter_frames():
+            try:
+                frame = TdfFrameScans(self, frame_id, coords)
+            except Exception as e:
+                logger.warning(f"Error reading scans for frame {frame_id}: {e}")
+                continue
+            yield frame
 
     def _get_maldi_frame_ids(self) -> Optional[List[int]]:
         """Get sorted frame IDs from MaldiFrameInfo table.

--- a/thyra/readers/bruker/timstof/timstof_reader.py
+++ b/thyra/readers/bruker/timstof/timstof_reader.py
@@ -261,11 +261,12 @@ class BrukerReader(BrukerBaseMSIReader):
                 step 2 doesn't need the Bruker SDK to be installed.
             tdf_spectrum: How a TDF (TIMS engaged) frame's mobility scans
                 are collapsed into the one spectrum yielded per pixel.
-                ``"vendor_centroid"`` (default) is Bruker's frame-level
-                centroid extraction over the full ramp, the same peak
-                picker behind the TSF line spectrum; ``"scan_sum"`` sums
-                every scan per digitizer index and keeps all of the ion
-                current. Ignored for TSF. See
+                ``"scan_sum"`` (default) sums every scan per digitizer
+                index and keeps all of the ion current, which is also
+                Bruker's own per-frame total; ``"vendor_centroid"`` is
+                Bruker's frame-level centroid extraction over the full
+                ramp, the same peak picker behind the TSF line spectrum.
+                Ignored for TSF. See
                 :mod:`thyra.readers.bruker.timstof.sdk.sdk_functions`.
             **kwargs: Additional arguments
         """

--- a/thyra/readers/waters/masslynx_lib.py
+++ b/thyra/readers/waters/masslynx_lib.py
@@ -86,6 +86,12 @@ class ScanInfoData:
     rt: float
     laser_x_pos: float  # in mm from DLL
     laser_y_pos: float  # in mm from DLL
+    #: The quadrupole isolation window and collision energy of an MS/MS
+    #: scan, as MassLynx reports them; 0.0 when the scan is MS1. Defaulted
+    #: so a scan record built without them (older callers, tests) is intact.
+    quad_isolation_start: float = 0.0
+    quad_isolation_end: float = 0.0
+    collision_energy: float = 0.0
 
     @property
     def has_position(self) -> bool:
@@ -375,6 +381,9 @@ class MassLynxLib:
             rt=info.rt,
             laser_x_pos=info.laserXPos,
             laser_y_pos=info.laserYPos,
+            quad_isolation_start=info.quadIsolationStart,
+            quad_isolation_end=info.quadIsolationEnd,
+            collision_energy=info.collisionEnergy,
         )
 
     def read_spectrum(

--- a/thyra/readers/waters/waters_reader.py
+++ b/thyra/readers/waters/waters_reader.py
@@ -9,7 +9,7 @@ reconstructed from laser X/Y positions stored in each scan's metadata.
 import ctypes
 import logging
 from pathlib import Path
-from typing import Dict, Generator, List, Optional, Tuple
+from typing import Any, Dict, Generator, List, Optional, Tuple
 
 import numpy as np
 from numpy.typing import NDArray
@@ -17,13 +17,21 @@ from tqdm import tqdm
 
 from ...core.base_extractor import MetadataExtractor
 from ...core.base_reader import BaseMSIReader
+from ...core.msms import (
+    COLLISION_INDUCED_DISSOCIATION_ACCESSION,
+    FragmentationSchedule,
+    IsolationWindow,
+)
 from ...core.registry import register_reader
 from ...metadata.extractors.waters_extractor import WatersMetadataExtractor
 from .imaging_grid import ImagingGrid, build_imaging_grid
 from .instrument import WatersInstrument, identify_waters_instrument
-from .masslynx_lib import FunctionType, MassLynxLib
+from .masslynx_lib import FunctionType, MassLynxLib, ScanInfoData
 
 logger = logging.getLogger(__name__)
+
+#: What the fragmentation schedule names as its origin.
+FRAGMENTATION_SOURCE = "waters_masslynx"
 
 
 @register_reader("waters")
@@ -38,7 +46,17 @@ class WatersReader(BaseMSIReader):
     2. Opens the .raw directory and verifies it contains imaging data
     3. Classifies acquisition functions (MS, IMS, MRM, lockmass)
     4. Reconstructs the imaging pixel grid from laser coordinates
-    5. Iterates MS spectra yielding (coords, mzs, intensities) tuples
+    5. Keeps the MS1 functions only when the file also holds MS/MS ones
+    6. Iterates MS spectra yielding (coords, mzs, intensities) tuples
+
+    Every MS function shares the one laser grid, so two functions yield
+    two spectra at the same pixel. Summing an MS1 and an MS2 spectrum into
+    one pixel would make a spectrum of nothing, which is why the level
+    filter in step 5 exists: an MSe or data-dependent acquisition converts
+    to its MS1 image, and the functions left out are recorded in the
+    Waters-specific metadata block. A file with no MS1 function converts
+    its MS/MS functions instead and says so through
+    :meth:`get_fragmentation`.
     """
 
     def __init__(
@@ -93,6 +111,9 @@ class WatersReader(BaseMSIReader):
         self._imaging_grid: Optional[ImagingGrid] = None
         self._function_types: Optional[Dict[int, FunctionType]] = None
         self._ms_functions: Optional[List[int]] = None
+        #: MS functions left out of the conversion because the file also
+        #: holds MS1 ones: function index -> what they were.
+        self._excluded_functions: Dict[int, Dict[str, Any]] = {}
         self._common_mass_axis_cache: Optional[NDArray[np.float64]] = None
         self._use_centroid = use_centroid
         self._closed = False
@@ -175,6 +196,11 @@ class WatersReader(BaseMSIReader):
             self._ml, self._handle, self._function_types
         )
 
+        # One MS level per store: keep the MS1 functions when there are any
+        self._ms_functions = self._select_functions_by_ms_level(
+            self._ms_functions, self._imaging_grid
+        )
+
         # Verify the grid has more than one position (otherwise not really imaging)
         if (
             self._imaging_grid.pixel_count_x <= 1
@@ -189,6 +215,144 @@ class WatersReader(BaseMSIReader):
             f"Initialized Waters reader: {self.data_path.name}, "
             f"{len(self._ms_functions)} MS functions, "
             f"grid {self._imaging_grid.pixel_count_x}x{self._imaging_grid.pixel_count_y}"
+        )
+
+    # ------------------------------------------------------------------
+    # MS level: which functions become the stored spectrum
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _positioned_scans(func: int, grid: "ImagingGrid") -> List["ScanInfoData"]:
+        """The scan records of one function that carry a laser position."""
+        return [
+            info
+            for (f, _scan), info in sorted(grid.scan_map.items())
+            if f == func and info.has_position
+        ]
+
+    @classmethod
+    def _function_ms_level(cls, func: int, grid: "ImagingGrid") -> int:
+        """The MS level MassLynx reports for a function's scans.
+
+        Read off the first positioned scan: MassLynx sets the level per
+        function, so one scan speaks for all of them. A function without a
+        positioned scan contributes no pixel and is treated as MS1 so that
+        it is never the reason an MS1 image is refused.
+        """
+        scans = cls._positioned_scans(func, grid)
+        return max(1, int(scans[0].ms_level)) if scans else 1
+
+    def _select_functions_by_ms_level(
+        self, ms_functions: List[int], grid: "ImagingGrid"
+    ) -> List[int]:
+        """Keep the MS1 functions when the file has any, else all of them.
+
+        Records what was left out in :attr:`_excluded_functions` so the
+        store can say the acquisition fragmented something even though
+        the stored spectra are intact-ion spectra.
+        """
+        levels = {f: self._function_ms_level(f, grid) for f in ms_functions}
+        ms1 = [f for f in ms_functions if levels[f] == 1]
+        if not ms1 or len(ms1) == len(ms_functions):
+            self._excluded_functions = {}
+            if len(ms_functions) > 1:
+                logger.warning(
+                    "%d MS functions (%s) share one laser grid; their spectra "
+                    "are summed per pixel.",
+                    len(ms_functions),
+                    ", ".join(str(f) for f in ms_functions),
+                )
+            return list(ms_functions)
+
+        self._excluded_functions = {}
+        for f in ms_functions:
+            if levels[f] == 1:
+                continue
+            precursors = self._function_precursors(f, grid)
+            self._excluded_functions[f] = {
+                "ms_level": levels[f],
+                "precursor_mz": (
+                    precursors[0]
+                    if len(precursors) == 1
+                    else (precursors if precursors else None)
+                ),
+                "n_scans": len(self._positioned_scans(f, grid)),
+            }
+        logger.warning(
+            "Functions %s are MS level %s and share the laser grid with the "
+            "MS1 function(s) %s. Only the MS1 spectra are converted; the "
+            "others are recorded in the Waters metadata block as "
+            "'excluded_functions'.",
+            ", ".join(str(f) for f in self._excluded_functions),
+            "/".join(
+                sorted({str(v["ms_level"]) for v in self._excluded_functions.values()})
+            ),
+            ", ".join(str(f) for f in ms1),
+        )
+        return ms1
+
+    @classmethod
+    def _function_precursors(cls, func: int, grid: "ImagingGrid") -> List[float]:
+        """The distinct precursor m/z values a function's scans report, ascending."""
+        values = {
+            round(float(info.precursor_mz), 4)
+            for info in cls._positioned_scans(func, grid)
+            if info.precursor_mz > 0
+        }
+        return sorted(values)
+
+    def get_fragmentation(self) -> Optional[FragmentationSchedule]:
+        """What the stored spectra are: MS1, or the fragment spectra of what.
+
+        MS level 1 whenever an MS1 function was converted, including the
+        MSe and data-dependent files whose MS/MS functions were left out
+        (those are in the Waters metadata block, not here, because this
+        describes the spectra in the store). When the file holds MS/MS
+        functions only, the schedule is their precursors: one isolation
+        window per function whose precursor is constant, and
+        ``constant_across_pixels`` false as soon as any function's
+        precursor changes from scan to scan.
+        """
+        _ml, _handle, grid, _types, ms_functions = self._require_initialized()
+        levels = {f: self._function_ms_level(f, grid) for f in ms_functions}
+        top = max(levels.values(), default=1)
+        if top <= 1:
+            return FragmentationSchedule(ms_level=1, source=FRAGMENTATION_SOURCE)
+
+        windows: List[IsolationWindow] = []
+        constant = True
+        for f in ms_functions:
+            precursors = self._function_precursors(f, grid)
+            if len(precursors) != 1:
+                constant = False
+                continue
+            windows.append(self._isolation_window(f, precursors[0], grid))
+        return FragmentationSchedule(
+            ms_level=top,
+            windows=tuple(windows),
+            constant_across_pixels=constant,
+            dissociation_accession=(
+                COLLISION_INDUCED_DISSOCIATION_ACCESSION if windows else None
+            ),
+            source=FRAGMENTATION_SOURCE,
+        )
+
+    @classmethod
+    def _isolation_window(
+        cls, func: int, target: float, grid: "ImagingGrid"
+    ) -> IsolationWindow:
+        """One function's isolation window from its first positioned scan."""
+        info = cls._positioned_scans(func, grid)[0]
+        lower = upper = None
+        start, end = float(info.quad_isolation_start), float(info.quad_isolation_end)
+        if 0.0 < start <= target <= end:
+            lower, upper = target - start, end - target
+        energy = float(info.collision_energy)
+        return IsolationWindow(
+            target=target,
+            lower_offset=lower,
+            upper_offset=upper,
+            collision_energy=energy if energy > 0 else None,
         )
 
     def _require_initialized(
@@ -247,6 +411,7 @@ class WatersReader(BaseMSIReader):
             ms_functions=ms_functions,
             instrument=self._instrument,
             use_centroid=self._use_centroid,
+            excluded_functions=self._excluded_functions,
         )
 
     def get_common_mass_axis(self) -> NDArray[np.float64]:


### PR DESCRIPTION
## What

Implements the design decisions recorded on the new `docs/design-decisions.md` page, plus the page itself. Four commits:

1. **docs + fix(waters)** -- the decisions page (D1-D8, each with reason, objections and measurements); the TDF vendor centroid described as measured (peak areas, 87-96% of the current, no "single-count noise"); the Waters reader converts MS level 1 functions only and records the MS/MS ones (D7).
2. **feat(defaults)** -- TDF default `--tdf-spectrum scan_sum` (D1); `--msms-table` on by default, refused with a reason elsewhere (D2); the grid's fixed 20M feature ceiling becomes a free-memory projection at 330 B/feature (D4); a raw-axis refusal for the MS/MS table was implemented and withdrawn the same day, recorded on the page (D6).
3. **feat(converters)** -- one raw read per frame per pass serves every table on the streaming route (D5): the Bruker TDF reader hands frames over as records; the summed table's count and scatter passes feed the heatmap, grid and MS/MS sinks.
4. **docs(decisions)** -- the Waters MRT profile default from #207 placed on the record side of D1.

## Why scan_sum

Measured on two acquisitions: Thyra's `scan_sum` equals Bruker's own quasi-profile export and `Frames.SummedIntensities` exactly; the vendor centroid keeps 87.5% / 96.4% of that. On TSF the line intensity is the peak height and the profile is a baseline-laden ADC trace, so TSF stays on the line spectrum. Whole slide (26,087 px): 282M -> 893M non-zeros, 1.36 -> 2.50 GB, 438 -> 528 s. Existing stores are told apart by `msi_metadata.processing[0].parameters.tdf_spectrum`.

## Verification

- Byte-identical A/B against stores written by the previous commit on five configurations (400-frame slide with/without the grid on both write routes; 713-px PASEF split on both routes): every array, var, obs, uns block, index dtypes included.
- New unit tests: Waters MS levels, MS/MS defaults, memory guard, fused passes (fused == unfused, reads twice, never the iterators).
- 2326 unit tests, 31 synthetic TDF integration tests through the real library, pre-commit clean, complexity 0 violations, on the branch rebased onto v3.18.0.
- Timings warm: 400 frames + grid 32 -> 21 s; 713-px split 12 -> 9 s; whole slide default 528 -> 454 s; whole slide grid at 40k bins 858 s.

## Notes

- Minor release: schema unchanged, old numbers one flag away.
- D7 is untested on real Waters MSe/DDA imaging data (none available); synthetic scan records only.
