### PR TITLE
fix(waters): the laser positions decide which functions hold the image

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -425,7 +425,9 @@ thyra synapt_run.raw output.zarr --waters-spectrum profile
     it in a new *function*. It will not centroid the last of them, so a
     centroid conversion leaves that chunk out and logs how many pixels
     (16.6% of one Synapt G1 run) and this flag. Reading the trace converts
-    every chunk, because then they all come back the same way. See
+    every chunk, because then they all come back the same way -- pass
+    `--streaming true` with it, since the profile store for that run is
+    estimated at 74 GB against 241 MB. See
     [Which functions hold the image](supported-formats.md#which-functions-hold-the-image).
 
 ---

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -420,6 +420,14 @@ thyra synapt_run.raw output.zarr --waters-spectrum profile
     nothing the profile resolves, which is why only the MRT defaults to it;
     see [Supported Formats](supported-formats.md#waters-masslynx).
 
+!!! note "The other reason to pass `profile`"
+    A long imaging run outgrows one `_FUNC*.DAT` file, and MassLynx continues
+    it in a new *function*. It will not centroid the last of them, so a
+    centroid conversion leaves that chunk out and logs how many pixels
+    (16.6% of one Synapt G1 run) and this flag. Reading the trace converts
+    every chunk, because then they all come back the same way. See
+    [Which functions hold the image](supported-formats.md#which-functions-hold-the-image).
+
 ---
 
 ## Other

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -336,32 +336,211 @@ accident.
 
 ---
 
-## D7. Waters: the summed table takes MS level 1 only
+## D7. Waters: which functions hold the image
 
-**Status:** Implemented 2026-09-07, as a correctness fix.
+**Status:** Implemented 2026-09-07, then **restated the same day against
+real files, which contradicted its premise.** The first version is kept
+below because the correction is the point.
 
-**What was found.** The Waters reader classifies acquisition functions and
-then yields every scan of every MS-classified function as a pixel spectrum,
-keyed by laser coordinate. A two-function acquisition, MSe low and high
-energy or a data-dependent run, therefore emits two spectra at the same
-coordinate, one MS1 and one MS2. The per-scan MS level and precursor m/z
-that MassLynx reports are parsed and then ignored. What the converter does
-with the duplicate coordinate is not verified, and no Waters MS/MS imaging
-file was available to test on; either outcome, overwrite or sum, is wrong.
+### What the first version decided, and why it was wrong
 
-**Decision.** Convert the MS level 1 functions only, and list the others,
-with their level, precursor m/z and scan count, under `excluded_functions`
-in the Waters-specific metadata block. The versioned `fragmentation` block
-describes the spectra in the store, so it says MS1 for such a file; a file
-with MS/MS functions only converts them and reports their precursors there,
-as the Bruker path does. A demultiplexed Waters table waits until a
-scheduled Waters acquisition exists to look at.
+The Waters reader classifies acquisition functions and then yields every
+scan of every MS-classified function as a pixel spectrum, keyed by laser
+coordinate. A two-function acquisition -- MSe low and high energy, or a
+data-dependent run -- would therefore emit two spectra at the same
+coordinate, one MS1 and one MS2, and the per-scan MS level MassLynx reports
+was parsed and then ignored. Summing an intact-ion and a fragment spectrum
+into one pixel makes a spectrum of nothing, so the fix was to convert the
+functions MassLynx labelled MS level 1 and record the rest under
+`excluded_functions`. No Waters MS/MS imaging file was available; the
+objection *no test data* was answered with "the filter is on a field already
+parsed and is testable with a synthetic scan record".
 
-**Objections considered.**
+That answer was wrong, and the entry said so itself without noticing: a
+synthetic record can only confirm that the code reads the field it was
+written to read. It cannot say what the field **means**.
 
-- *No test data.* The filter is on a field already parsed and is testable
-  with a synthetic scan record. The fix does not depend on the MS/MS table
-  work.
+### What the real files say
+
+7,486 Waters `.raw` directories were found on the lab share (the six Waters
+instrument folders under `V:\Instruments`, plus `V:\Users\Cuypers_Eva`);
+1,396 hold more than one `_FUNC*.DAT`, and the multi-function ones were
+opened. **Every multi-function MALDI imaging run is a single-function raster
+that MassLynx split across functions**, because it caps a `_FUNC*.DAT` file
+at about 1.6 GB and opens a new *function* when a long run reaches it. In
+each of those files:
+
+- `_extern.inf` declares exactly **one** acquisition function -- "MALDI TOF
+  MS FUNCTION", or "MALDI MOBILITY TOF MS FUNCTION" on the G2-Si -- however
+  many functions the file holds. `_FUNCTNS.INF` carries one 416-byte record
+  per stored chunk (10,400 bytes for the 25-function file).
+- The chunks **tile** the stage and the run: consecutive, non-overlapping y
+  bands and retention-time ranges, and **zero** shared pixels between any
+  two functions. Their positioned scans sum exactly to the file's distinct
+  laser positions (7,682 on `180814_EVO_Fresh_image.raw`, which is also
+  exactly its 167 x 46 grid).
+- MassLynx reports MS level 1 for the first chunk, 2 for the middle ones and
+  **0** for the last, and `getLockmassFunction` names that last chunk as the
+  file's lockmass function (it returns -1 only when the file has one
+  function). `isMsFunction` is 1 for every chunk, including the one it calls
+  lockmass, and **no chunk carries a precursor m/z**.
+
+So on these files the level filter dropped every chunk after the first, and
+the lockmass classification -- which predates this decision -- dropped the
+last one on top of that. Measured, pixels converted against pixels in the
+file:
+
+| File | Instrument | Functions | v3.19.0 | In the file |
+|---|---|---|---|---|
+| `20140509_ZF_No13.raw` | Synapt G1 | 25 | 1,657 | 37,033 |
+| `20140513_ZF_No16.raw` | Synapt G1 | 11 | 2,496 | 21,732 |
+| `20141003 MTB_04.raw` | Synapt G1 | 8 | 1,700 | 12,972 |
+| `140903_trypsin_vs_no.raw` | Synapt G1 | 5 | 2,284 | 9,223 |
+| `180814_EVO_Fresh_image.raw` | Synapt G1 | 3 | 3,200 | 7,682 |
+| `20201209_BCtumor_left Analyte 2.raw` | Synapt G2-Si | 4 | 15,790 | 61,107 |
+| `20201223_BCTumor_Eva MDA_468.raw` | Synapt G2-Si | 3 | 5,837 | 17,550 |
+| `20201218_MDA468_slide20201208 Analyte 5.raw` | Synapt G2-Si | 2 | 7,355 | 8,547 |
+
+The two-function G2-Si run is the mildest case and still loses 14 percent of
+the image; the 25-function one keeps 4.5 percent of it. Nothing in the store
+said so: the reader logged a warning about "MS level 2" functions and the
+conversion looked healthy.
+
+**One real multi-function acquisition was found**, and it is what makes the
+rule below decidable rather than a guess:
+`Xevo DESI\Pierre\DESI_PIMAX.PRO\Data\20191107_fastDDA_neg_002.raw`. Its
+`_extern.inf` declares **16** functions -- one "TOF FAST DDA FUNCTION" and
+15 "TOF SURVEY FUNCTION"s -- against the one function the chunked files
+declare. Function 0 is MS1 with no precursor; functions 1 to 15 are level 2
+and report a *different* precursor per scan, 28 distinct values each. And
+every one of the 16 lands on the **same** position. So the two cases
+separate cleanly on the positions: a chunked raster tiles them, a real
+parallel acquisition repeats them.
+
+(That file grids to 1x1, because the reader builds the grid from laser
+coordinates and a DESI stage records none. That is a separate gap, tracked
+outside this entry; it is not what D7 is about.)
+
+### Decision
+
+Decide from the **laser positions**, the same measurement the pixel grid is
+already built from.
+
+- A function landing on pixels no earlier function covers **extends the
+  raster** and is converted, whatever level MassLynx reports for it and
+  whether or not MassLynx calls it the lockmass function. Only ever widens a
+  file that already has an MS-classified function, so a run with no MS
+  function is still refused.
+- Functions **competing for the same pixels** were acquired in parallel.
+  Only one of them can be the pixel's spectrum, so among those the MS1 ones
+  win when the group has any, and the rest are listed with their level,
+  precursor m/z, scan count and the reason they stayed out under
+  `excluded_functions`. That is the original decision, kept -- scoped to the
+  functions it was actually about.
+
+`format_specific.function_types` keeps MassLynx's own classification next to
+`format_specific.ms_functions`, so a rescued chunk is visible in the store.
+
+### The catch: the tail chunk cannot be centroided
+
+The library will not centroid the function `getLockmassFunction` names.
+Measured on `180814_EVO_Fresh_image.raw`, sampling scans from each chunk:
+
+| Function | `setCentroid(1)` | `setCentroid(0)` | `isRawSpectrumContinuum` |
+|---|---|---|---|
+| 0 (MS) | 7,408 points, TIC 3.35e4 | 82,876 points | continuum |
+| 1 (MS, "level 2") | 8,508 points, TIC 3.60e4 | 91,274 points | continuum |
+| 2 (named lockmass) | **112,594 points, TIC 1.11e5** | 112,594 points | continuum |
+
+All three are acquired as continuum, and the request is honoured for the
+first two and ignored for the third: it returns the same profile trace
+either way. `ScanInfo.isProfile` reports this faithfully (0, 0, 1), since it
+is read after `setCentroid`. There is no per-function centroid entry point
+in the library to work around it.
+
+Converting that chunk into a store of centroids therefore lays a band of
+profile rows across the top of the image. It was converted that way once, by
+accident, and the TIC image shows it: rows 0 to 37 average 3.1e4 to 3.7e4 and
+rows 39 to 45 -- exactly the rescued chunk -- average 8.6e4 to 9.3e4, a
+sharp 2.3x step at the chunk boundary and not a feature of the sample.
+
+So the rule takes the representation into account: while the run is read as
+centroids, a chunk the library will not centroid **stays out**, and
+`excluded_functions` records it with its scan count, the pixels it would
+have added and the reason. Reading the run as the profile trace
+(`--waters-spectrum profile`, and the default on an MRT) converts every
+chunk, because then all of them come back the same way. The warning names
+the cost and the flag:
+
+    Function(s) 2 hold 1274 pixels (16.6% of the image) that no other
+    function covers, but MassLynx names them the lockmass function and will
+    not centroid them. They stay out rather than put profile rows in a table
+    of centroids: pass --waters-spectrum profile to convert the whole image.
+
+The alternative -- forcing the whole run to the profile trace whenever a
+chunk cannot be centroided -- would keep the image whole automatically, but
+it silently overrides D1's measured choice for a whole vendor and costs
+about ten times the non-zeros on every chunked file, of which this share
+holds 1,396. Better to convert what is consistent, say what is missing, and
+leave the trade to the one flag that already exists.
+
+The `fragmentation` block follows the **precursor**, not the level: a
+converted function holds fragment spectra when MassLynx reports a precursor
+m/z for it. A reported level with no precursor behind it is the chunk
+artefact above, and reads as MS1.
+
+**Verified on real data** (2026-09-07):
+
+| Check | Result |
+|---|---|
+| `180814_EVO_Fresh_image.raw`, 3 chunks, converted whole | 7,682 pixels, no duplicate coordinates, `ms_functions [0, 1, 2]`, `function_types["2"] == "LOCKMASS"`, `fragmentation` MS1 |
+| `20170818_08.raw`, a real single-precursor MS/MS run | `fragmentation` MS level 2, one window at m/z 377.4, collision energy 35.0, CID; converter declines a demultiplexed table because one precursor needs none |
+| every file in the table above | pixels converted equal the file's distinct laser positions, and no two converted functions share a pixel |
+
+### Objections considered
+
+- *The level is what MassLynx says; the chunking is its bug to report, not
+  ours to work around.* It is not a bug that can be worked around later:
+  there is no other field that separates a chunk from a high-energy
+  function, and the level is wrong in both directions at once (0 for a
+  chunk that holds image data, 2 for one that holds MS1 data). The
+  positions are a direct measurement of the thing the rule is about --
+  whether two spectra land on the same pixel -- so they are the better
+  signal even if MassLynx were fixed tomorrow.
+- *A lockmass function could legitimately carry laser positions, and would
+  now be converted.* A reference function is acquired **alongside** the
+  image, so its scans land on pixels the MS function already covers and it
+  is excluded by the same rule. The one real parallel lockmass function
+  found (`050517_BILE ACIDS 01.raw`) sits at a single constant position for
+  the whole run, which no raster chunk does.
+- *Two functions covering complementary mass ranges at one pixel should be
+  summed, not filtered.* They still are: functions competing for a pixel and
+  reporting the same level are all kept and summed, exactly as before. Only
+  a mixed-level group is filtered.
+
+**Known limit.** A raster chunk is recognised by covering new pixels, so a
+chunked acquisition whose stage revisits a position -- a re-scan of the same
+area in a later function -- would have that function read as a parallel one
+and excluded. No such file was found, and the acquisition would be
+ambiguous anyway: the store holds one spectrum per pixel.
+
+### No Waters demultiplexed table yet
+
+The second half of the original entry -- "a demultiplexed Waters table waits
+until a scheduled Waters acquisition exists to look at" -- still waits. Of
+506 Waters `.raw` directories surveyed, **113 declare a "MALDI TOF MSMS
+FUNCTION"**, and every one of them has exactly **one** function isolating
+**one** precursor, 224 KB to 3.9 MB, 9 to 60 scans on five or fewer distinct
+positions: spot acquisitions, not images. A Waters demultiplexer needs a
+file whose MS/MS functions each isolate a *different* constant precursor
+over one raster, and no such file exists here, so it was not built.
+
+What those files do establish, which the synthetic tests could not: MassLynx
+reports the precursor faithfully when there is one (377.4, 482.0, 476.16,
+each matching `Set Mass` in `_extern.inf`) together with a real collision
+energy (35.0, and a 6 -> 30 eV ramp on one), so `precursor_mz` is the field
+to trust. `quadIsolationStart`/`End` stay 0.0 even on these, so the
+isolation window has no offsets from this API and only a target.
 
 ---
 

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -387,24 +387,26 @@ each of those files:
 
 So on these files the level filter dropped every chunk after the first, and
 the lockmass classification -- which predates this decision -- dropped the
-last one on top of that. Measured, pixels converted against pixels in the
-file:
+last one on top of that. Pixels converted, against the pixels the file
+holds:
 
-| File | Instrument | Functions | v3.19.0 | In the file |
-|---|---|---|---|---|
-| `20140509_ZF_No13.raw` | Synapt G1 | 25 | 1,657 | 37,033 |
-| `20140513_ZF_No16.raw` | Synapt G1 | 11 | 2,496 | 21,732 |
-| `20141003 MTB_04.raw` | Synapt G1 | 8 | 1,700 | 12,972 |
-| `140903_trypsin_vs_no.raw` | Synapt G1 | 5 | 2,284 | 9,223 |
-| `180814_EVO_Fresh_image.raw` | Synapt G1 | 3 | 3,200 | 7,682 |
-| `20201209_BCtumor_left Analyte 2.raw` | Synapt G2-Si | 4 | 15,790 | 61,107 |
-| `20201223_BCTumor_Eva MDA_468.raw` | Synapt G2-Si | 3 | 5,837 | 17,550 |
-| `20201218_MDA468_slide20201208 Analyte 5.raw` | Synapt G2-Si | 2 | 7,355 | 8,547 |
+| File | Instrument | Functions | v3.19.0 | Now (centroid) | In the file |
+|---|---|---|---|---|---|
+| `20140509_ZF_No13.raw` | Synapt G1 | 25 | 1,657 | 36,633 | 37,033 |
+| `20140513_ZF_No16.raw` | Synapt G1 | 11 | 2,496 | 20,438 | 21,788 |
+| `20141003 MTB_04.raw` | Synapt G1 | 8 | 1,700 | 12,110 | 12,972 |
+| `140903_trypsin_vs_no.raw` | Synapt G1 | 5 | 2,284 | 8,843 | 9,221 |
+| `180814_EVO_Fresh_image.raw` | Synapt G1 | 3 | 3,200 | 6,408 | 7,682 |
+| `20201209_BCtumor_left Analyte 2.raw` | Synapt G2-Si | 4 | 15,790 | 49,096 | 61,108 |
+| `20201223_BCTumor_Eva MDA_468.raw` | Synapt G2-Si | 3 | 5,837 | 11,413 | 17,550 |
+| `20201218_MDA468_slide20201208 Analyte 5.raw` | Synapt G2-Si | 2 | 7,355 | 7,355 | 8,547 |
 
-The two-function G2-Si run is the mildest case and still loses 14 percent of
-the image; the 25-function one keeps 4.5 percent of it. Nothing in the store
+The two-function G2-Si run is the mildest case and still lost 14 percent of
+the image; the 25-function one kept 4.5 percent of it. Nothing in the store
 said so: the reader logged a warning about "MS level 2" functions and the
-conversion looked healthy.
+conversion looked healthy. The middle column is what the rule below converts
+by default; the gap that remains is one chunk per file, and the next section
+is why.
 
 **One real multi-function acquisition was found**, and it is what makes the
 rule below decidable rather than a guess:
@@ -468,21 +470,30 @@ So the rule takes the representation into account: while the run is read as
 centroids, a chunk the library will not centroid **stays out**, and
 `excluded_functions` records it with its scan count, the pixels it would
 have added and the reason. Reading the run as the profile trace
-(`--waters-spectrum profile`, and the default on an MRT) converts every
+(`--waters-spectrum profile`, and the default on an MRT) selects every
 chunk, because then all of them come back the same way. The warning names
-the cost and the flag:
+the cost and the flags:
 
     Function(s) 2 hold 1274 pixels (16.6% of the image) that no other
     function covers, but MassLynx names them the lockmass function and will
     not centroid them. They stay out rather than put profile rows in a table
-    of centroids: pass --waters-spectrum profile to convert the whole image.
+    of centroids: pass --waters-spectrum profile --streaming true to convert
+    the whole image.
+
+`--streaming true` is in that sentence because the profile store is large
+and `--streaming auto` does not notice: its estimate assumes 10,000 peaks
+per spectrum whatever the source, which is 0.57 GB for this run, while the
+streaming converter's own estimate once running is **74.1 GB** (7,682
+pixels x 2,590,447 bins). Left on `auto` the conversion stays in memory and
+dies at 72 percent asking for a 24.5 GiB array on a 128 GB machine. That
+estimate is a general defect, tracked separately.
 
 The alternative -- forcing the whole run to the profile trace whenever a
 chunk cannot be centroided -- would keep the image whole automatically, but
-it silently overrides D1's measured choice for a whole vendor and costs
-about ten times the non-zeros on every chunked file, of which this share
+it silently overrides D1's measured choice for a whole vendor and turns a
+241 MB store into a 74 GB one, on every chunked file, of which this share
 holds 1,396. Better to convert what is consistent, say what is missing, and
-leave the trade to the one flag that already exists.
+leave the trade to the flags that already exist.
 
 The `fragmentation` block follows the **precursor**, not the level: a
 converted function holds fragment spectra when MassLynx reports a precursor
@@ -493,9 +504,11 @@ artefact above, and reads as MS1.
 
 | Check | Result |
 |---|---|
-| `180814_EVO_Fresh_image.raw`, 3 chunks, converted whole | 7,682 pixels, no duplicate coordinates, `ms_functions [0, 1, 2]`, `function_types["2"] == "LOCKMASS"`, `fragmentation` MS1 |
-| `20170818_08.raw`, a real single-precursor MS/MS run | `fragmentation` MS level 2, one window at m/z 377.4, collision energy 35.0, CID; converter declines a demultiplexed table because one precursor needs none |
-| every file in the table above | pixels converted equal the file's distinct laser positions, and no two converted functions share a pixel |
+| `180814_EVO_Fresh_image.raw` converted, default centroid | 6,408 pixels against v3.19.0's 3,200, no duplicate coordinates, no empty pixel, `ms_functions [0, 1]`, `excluded_functions["2"]` carrying `n_unique_pixels 1274` and its reason, `fragmentation` MS1. The TIC image is continuous across the chunk boundary at row 19 |
+| the same run with `--waters-spectrum profile` | all three chunks selected: 7,683 spectra on all 7,682 pixels, one representation. Needs `--streaming true`; see above |
+| `20170818_08.raw`, a real single-precursor MS/MS run | `fragmentation` MS level 2, one window at m/z 377.4, collision energy 35.0, CID; the converter declines a demultiplexed table because one precursor needs none |
+| `20191107_fastDDA_neg_002.raw`, the real DDA run | functions 1 to 15 recorded under `excluded_functions` with their per-scan precursors, function 0 converted, `fragmentation` MS1 |
+| every file in the table above | no two converted functions share a pixel, and converted plus recorded pixels equal the file's distinct laser positions |
 
 ### Objections considered
 
@@ -528,8 +541,8 @@ ambiguous anyway: the store holds one spectrum per pixel.
 
 The second half of the original entry -- "a demultiplexed Waters table waits
 until a scheduled Waters acquisition exists to look at" -- still waits. Of
-506 Waters `.raw` directories surveyed, **113 declare a "MALDI TOF MSMS
-FUNCTION"**, and every one of them has exactly **one** function isolating
+the 506 methods whose `_extern.inf` was read, **113 declare a "MALDI TOF
+MSMS FUNCTION"**, and every one of them has exactly **one** function isolating
 **one** precursor, 224 KB to 3.9 MB, 9 to 60 scans on five or fewer distinct
 positions: spot acquisitions, not images. A Waters demultiplexer needs a
 file whose MS/MS functions each isolate a *different* constant precursor

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -505,7 +505,7 @@ artefact above, and reads as MS1.
 | Check | Result |
 |---|---|
 | `180814_EVO_Fresh_image.raw` converted, default centroid | 6,408 pixels against v3.19.0's 3,200, no duplicate coordinates, no empty pixel, `ms_functions [0, 1]`, `excluded_functions["2"]` carrying `n_unique_pixels 1274` and its reason, `fragmentation` MS1. The TIC image is continuous across the chunk boundary at row 19 |
-| the same run with `--waters-spectrum profile` | all three chunks selected: 7,683 spectra on all 7,682 pixels, one representation. Needs `--streaming true`; see above |
+| the same run with `--waters-spectrum profile --streaming true --resample-bins 60000` | all three chunks, **7,682 pixels** -- the whole 167 x 46 raster, no duplicate coordinate, no empty pixel -- and the TIC image is continuous across both chunk boundaries, so the band above was the representation and nothing else. 109M non-zeros, 870 MB. The axis was coarsened only to keep the store off a full disk; the default axis is the 74.1 GB estimate above |
 | `20170818_08.raw`, a real single-precursor MS/MS run | `fragmentation` MS level 2, one window at m/z 377.4, collision energy 35.0, CID; the converter declines a demultiplexed table because one precursor needs none |
 | `20191107_fastDDA_neg_002.raw`, the real DDA run | functions 1 to 15 recorded under `excluded_functions` with their per-scan precursors, function 0 converted, `fragmentation` MS1 |
 | every file in the table above | no two converted functions share a pixel, and converted plus recorded pixels equal the file's distinct laser positions |

--- a/docs/metadata-schema.md
+++ b/docs/metadata-schema.md
@@ -129,11 +129,13 @@ which means "not reported", not "MS1". `windows` is stored as a JSON string
 mzPeak's, so an archive and a store describe a precursor the same way; see
 [Output Format](output-format.md#fragmentation-msms) for the array block
 beside it and for what `merges_precursors` means for the stored spectrum.
-Waters `.raw` fills it too, from the MS level MassLynx reports per scan: a
-file with MS/MS functions only reports their precursors here, and a file
-that also holds MS1 functions converts those alone, reports MS1, and lists
-the MS/MS functions it left out under `excluded_functions` in the
-Waters-specific block (see [Supported Formats](supported-formats.md#waters-masslynx)).
+Waters `.raw` fills it too, from the precursor m/z MassLynx reports per scan:
+a file whose converted functions carry one reports it here, and a file that
+also holds MS1 functions converts those alone, reports MS1, and lists the
+MS/MS functions it left out under `excluded_functions` in the Waters-specific
+block. The MS level MassLynx reports is not used on its own, because on a
+raster it split across functions the level is a chunk artefact (see
+[Supported Formats](supported-formats.md#which-functions-hold-the-image)).
 `resolved_table` names the demultiplexed sibling table when one was written,
 mirroring `ion_mobility.resolved_table`, so both kinds of sibling are
 discoverable from this block alone.

--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -319,14 +319,18 @@ the image at about 3x the neighbouring TIC, so while a run is read as
 centroids that chunk stays out, and `excluded_functions` records its scan
 count, the pixels it would have added and the reason. `--waters-spectrum
 profile` converts every chunk, because then they all come back the same way.
-The log names the cost and the flag:
+The log names the cost and the flags:
 
 ```
 Function(s) 2 hold 1274 pixels (16.6% of the image) that no other function
 covers, but MassLynx names them the lockmass function and will not centroid
 them. They stay out rather than put profile rows in a table of centroids:
-pass --waters-spectrum profile to convert the whole image.
+pass --waters-spectrum profile --streaming true to convert the whole image.
 ```
+
+Pass `--streaming true` with it: the profile store for that run is estimated
+at 74 GB against 241 MB for the centroid one, and `--streaming auto` does not
+notice, so the conversion otherwise runs out of memory.
 
 A file whose converted functions carry a precursor m/z holds fragment
 spectra and reports them through `ms_analysis.fragmentation`, exactly as a

--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -213,9 +213,9 @@ position log supplies the pixel grid. No SDK required.
 
 A `.raw` **directory** of `_FUNC*.DAT` files, read through the MassLynxRaw and
 MLReader native libraries (bundled for Windows and Linux). The pixel grid is
-reconstructed from the laser X/Y position recorded on each scan, and only MS
-functions are converted -- lockmass, MRM and ion-mobility functions are
-classified and skipped.
+reconstructed from the laser X/Y position recorded on each scan; MRM and
+ion-mobility functions are classified and skipped, and which of the rest hold
+the image is decided from those same positions (below).
 
 ### Which representation is read
 
@@ -282,15 +282,56 @@ at the cost of an axis that differs from run to run.
 (`profile spectrum` or `centroid spectrum`), `format_specific.spectrum_source`
 says which MassLynx representation it came from, and `format_specific.is_mrt`
 with `instrument_decided_by` record the instrument decision.
-**One MS level per store.** Every MS function shares the one laser grid, so
-a two-function acquisition (MSe low and high energy, or a data-dependent
-run) records an MS1 and an MS/MS spectrum at the same pixel. Thyra converts
-the MS1 function(s) only and lists the others, with their MS level and
-precursor m/z, under `excluded_functions` in the Waters-specific metadata
-block; summing an intact-ion and a fragment spectrum into one pixel would
-make a spectrum of nothing. A file with MS/MS functions only converts them
-and reports their precursors through `ms_analysis.fragmentation`, exactly as
-a Bruker MS/MS acquisition does (see [Design Decisions](design-decisions.md#d7-waters-the-summed-table-takes-ms-level-1-only)).
+### Which functions hold the image
+
+A Waters *function* is not necessarily one acquisition function. MassLynx
+caps a `_FUNC*.DAT` file at about 1.6 GB and opens a **new function** when a
+long imaging run reaches it, so one raster commonly arrives as several
+functions that tile the stage. It reports MS level 1 for the first of them,
+2 for the middle ones and 0 for the last, and `getLockmassFunction` names
+that last one as the file's lockmass function -- none of which is true. Nine
+real imaging runs from two instruments and five users were checked and every
+multi-function one was a chunked single-function raster; see the
+[D7 entry](design-decisions.md#d7-waters-which-functions-hold-the-image).
+
+Thyra therefore decides from the laser positions, the same measurement the
+pixel grid is built from:
+
+- A function landing on pixels no earlier function covers **extends the
+  raster** and is converted, whatever level MassLynx reports and whether or
+  not MassLynx calls it the lockmass function.
+- Functions **competing for the same pixels** were acquired in parallel:
+  MSe low and high energy, a data-dependent run, a co-acquired lockmass
+  reference. Only one of them can be the pixel's spectrum, and summing an
+  intact-ion and a fragment spectrum into one pixel would make a spectrum of
+  nothing, so the MS1 ones win where the file has any. The rest are listed,
+  with their MS level and precursor m/z, under `excluded_functions` in the
+  Waters-specific metadata block.
+
+`format_specific.function_types` keeps MassLynx's own classification next to
+`format_specific.ms_functions`, so a rescued chunk is visible in the store.
+
+**One catch.** The library will not centroid the function it names the
+lockmass function -- the request is honoured for every other function and
+ignored for that one, which returns its profile trace either way. Putting it
+into a store of centroids would lay a band of profile rows across the top of
+the image at about 3x the neighbouring TIC, so while a run is read as
+centroids that chunk stays out, and `excluded_functions` records its scan
+count, the pixels it would have added and the reason. `--waters-spectrum
+profile` converts every chunk, because then they all come back the same way.
+The log names the cost and the flag:
+
+```
+Function(s) 2 hold 1274 pixels (16.6% of the image) that no other function
+covers, but MassLynx names them the lockmass function and will not centroid
+them. They stay out rather than put profile rows in a table of centroids:
+pass --waters-spectrum profile to convert the whole image.
+```
+
+A file whose converted functions carry a precursor m/z holds fragment
+spectra and reports them through `ms_analysis.fragmentation`, exactly as a
+Bruker MS/MS acquisition does. A reported MS level with no precursor behind
+it does not: that is the chunk artefact above.
 
 ## PHI SmartSoft-TOF (ToF-SIMS)
 

--- a/tests/unit/readers/test_waters_reader.py
+++ b/tests/unit/readers/test_waters_reader.py
@@ -10,13 +10,13 @@ from thyra.readers.waters.masslynx_lib import FunctionType, ScanInfoData
 from thyra.readers.waters.waters_reader import WatersReader
 
 
-def _make_scan_info(x_mm=0.1, y_mm=0.2, ms_level=1, has_pos=True):
+def _make_scan_info(x_mm=0.1, y_mm=0.2, ms_level=1, has_pos=True, is_profile=0):
     """Helper to create a ScanInfoData with given laser position."""
     return ScanInfoData(
         ms_level=ms_level,
         polarity=0,
         drift_scan_count=0,
-        is_profile=0,
+        is_profile=is_profile,
         precursor_mz=0.0,
         rt=1.0,
         laser_x_pos=x_mm if has_pos else -1.0,
@@ -489,19 +489,66 @@ def _two_function_grid(levels, precursors=None):
     )
 
 
-def _open_reader(mock_ml_cls, mock_build_grid, mock_waters_data, grid, n_funcs):
+def _chunked_grid(levels, scans_per_function=3, profile_functions=()):
+    """A raster MassLynx split across functions, as the real files are.
+
+    Function ``f`` records ``scans_per_function`` scans on pixels no other
+    function visits, so the functions tile the stage instead of competing
+    for it. ``levels`` maps function index -> the MS level MassLynx reports,
+    which on a real chunked file is 1 for the first chunk, 2 for the middle
+    ones and 0 for the last.
+    """
+    scan_map = {}
+    x_index_map = {}
+    for column, (func, scan) in enumerate(
+        (f, s) for f in sorted(levels) for s in range(scans_per_function)
+    ):
+        x_mm = (column + 1) / 10.0
+        x_index_map[round(x_mm * 1000.0, 2)] = column
+        scan_map[(func, scan)] = _make_scan_info(
+            x_mm,
+            0.05,
+            ms_level=levels[func],
+            is_profile=1 if func in profile_functions else 0,
+        )
+    return ImagingGrid(
+        x_index_map=x_index_map,
+        y_index_map={50.0: 0},
+        pixel_count_x=len(x_index_map),
+        pixel_count_y=1,
+        pixel_size_x=100.0,
+        pixel_size_y=100.0,
+        lateral_width=100.0 * (len(x_index_map) - 1),
+        lateral_height=0.0,
+        scan_map=scan_map,
+    )
+
+
+def _open_reader(
+    mock_ml_cls,
+    mock_build_grid,
+    mock_waters_data,
+    grid,
+    n_funcs,
+    types=None,
+    scans_per_function=3,
+    use_centroid=True,
+):
     mock_ml = MagicMock()
     mock_ml_cls.get_instance.return_value = mock_ml
     mock_ml.is_imaging_file.return_value = True
     mock_ml.get_number_of_functions.return_value = n_funcs
-    mock_ml.classify_function.return_value = FunctionType.MS
-    mock_ml.get_number_of_scans_in_function.return_value = 3
+    if types is None:
+        mock_ml.classify_function.return_value = FunctionType.MS
+    else:
+        mock_ml.classify_function.side_effect = lambda _h, f: types[f]
+    mock_ml.get_number_of_scans_in_function.return_value = scans_per_function
     mock_ml.read_spectrum.return_value = (
         np.array([100.0, 200.0]),
         np.array([1.0, 2.0]),
     )
     mock_build_grid.return_value = grid
-    return WatersReader(mock_waters_data), mock_ml
+    return WatersReader(mock_waters_data, use_centroid=use_centroid), mock_ml
 
 
 class TestWatersReaderMsLevels:
@@ -585,4 +632,166 @@ class TestWatersReaderMsLevels:
         assert len(spectra) == 6
         assert {call.args[1] for call in mock_ml.read_spectrum.call_args_list} == {0, 1}
         assert reader.get_fragmentation().ms_level == 1
+        reader.close()
+
+
+class TestWatersReaderChunkedRaster:
+    """One raster split across functions: every chunk is part of the image.
+
+    MassLynx caps a ``_FUNC*.DAT`` at about 1.6 GB and opens a new function
+    when a long imaging run reaches it. On the real files the chunks come
+    back as MS level 1, then 2, then 0, the last one is what
+    ``getLockmassFunction`` names, and none of them carries a precursor --
+    so neither the level nor the lockmass index can decide what to convert.
+    The laser positions can: chunks tile the stage, parallel functions
+    repeat it.
+    """
+
+    @patch("thyra.readers.waters.waters_reader.MassLynxLib")
+    @patch("thyra.readers.waters.waters_reader.build_imaging_grid")
+    def test_every_chunk_of_a_split_raster_is_converted(
+        self, mock_build_grid, mock_ml_cls, mock_waters_data
+    ):
+        grid = _chunked_grid({0: 1, 1: 2, 2: 0})
+        reader, mock_ml = _open_reader(
+            mock_ml_cls,
+            mock_build_grid,
+            mock_waters_data,
+            grid,
+            3,
+            types={0: FunctionType.MS, 1: FunctionType.MS, 2: FunctionType.LOCKMASS},
+        )
+        spectra = list(reader.iter_spectra())
+
+        # Nine pixels, one spectrum each, read from all three functions
+        assert len(spectra) == 9
+        assert len({c for c, _, _ in spectra}) == 9
+        assert {call.args[1] for call in mock_ml.read_spectrum.call_args_list} == {
+            0,
+            1,
+            2,
+        }
+        assert reader._ms_functions == [0, 1, 2]
+        assert reader._excluded_functions == {}
+        reader.close()
+
+    @patch("thyra.readers.waters.waters_reader.MassLynxLib")
+    @patch("thyra.readers.waters.waters_reader.build_imaging_grid")
+    def test_a_level_two_chunk_is_not_a_fragmentation_schedule(
+        self, mock_build_grid, mock_ml_cls, mock_waters_data
+    ):
+        grid = _chunked_grid({0: 1, 1: 2, 2: 0})
+        reader, _ = _open_reader(
+            mock_ml_cls,
+            mock_build_grid,
+            mock_waters_data,
+            grid,
+            3,
+            types={0: FunctionType.MS, 1: FunctionType.MS, 2: FunctionType.LOCKMASS},
+        )
+        schedule = reader.get_fragmentation()
+        assert schedule.ms_level == 1 and not schedule.is_msms
+        assert schedule.windows == ()
+
+        block = reader._create_metadata_extractor()._extract_waters_specific()
+        # The block keeps MassLynx's own classification next to what was
+        # converted, so the rescue is visible in the store.
+        assert block["ms_functions"] == [0, 1, 2]
+        assert block["function_types"]["2"] == "LOCKMASS"
+        reader.close()
+
+    @patch("thyra.readers.waters.waters_reader.MassLynxLib")
+    @patch("thyra.readers.waters.waters_reader.build_imaging_grid")
+    def test_a_lockmass_function_on_the_image_pixels_stays_out(
+        self, mock_build_grid, mock_ml_cls, mock_waters_data
+    ):
+        # A reference function acquired alongside the image covers no pixel
+        # the MS function does not already cover, so it is not rescued.
+        grid = _two_function_grid({0: 1, 1: 0})
+        reader, mock_ml = _open_reader(
+            mock_ml_cls,
+            mock_build_grid,
+            mock_waters_data,
+            grid,
+            2,
+            types={0: FunctionType.MS, 1: FunctionType.LOCKMASS},
+        )
+        reader._ensure_initialized()
+        assert reader._ms_functions == [0]
+        assert len(list(reader.iter_spectra())) == 3
+        assert {call.args[1] for call in mock_ml.read_spectrum.call_args_list} == {0}
+        reader.close()
+
+    @patch("thyra.readers.waters.waters_reader.MassLynxLib")
+    @patch("thyra.readers.waters.waters_reader.build_imaging_grid")
+    def test_a_chunked_mse_run_keeps_the_ms1_function_of_every_chunk(
+        self, mock_build_grid, mock_ml_cls, mock_waters_data
+    ):
+        # Two chunks, each an MSe pair: functions 0/1 on one set of pixels,
+        # functions 2/3 on the next.
+        grid = _chunked_grid({0: 1, 2: 1})
+        for func, twin in ((0, 1), (2, 3)):
+            for (f, scan), info in list(grid.scan_map.items()):
+                if f != func:
+                    continue
+                grid.scan_map[(twin, scan)] = ScanInfoData(
+                    **{**info.__dict__, "ms_level": 2, "precursor_mz": 0.0}
+                )
+        reader, mock_ml = _open_reader(
+            mock_ml_cls, mock_build_grid, mock_waters_data, grid, 4
+        )
+        reader._ensure_initialized()
+        assert reader._ms_functions == [0, 2]
+        assert sorted(reader._excluded_functions) == [1, 3]
+        assert len(list(reader.iter_spectra())) == 6
+        assert reader.get_fragmentation().ms_level == 1
+        reader.close()
+
+    @patch("thyra.readers.waters.waters_reader.MassLynxLib")
+    @patch("thyra.readers.waters.waters_reader.build_imaging_grid")
+    def test_a_chunk_masslynx_will_not_centroid_stays_out_of_a_centroid_store(
+        self, mock_build_grid, mock_ml_cls, mock_waters_data
+    ):
+        # MassLynx's centroider skips the function it names the lockmass
+        # function, so that chunk comes back as profile whatever was asked.
+        # Converting it anyway would band the top of the image.
+        grid = _chunked_grid({0: 1, 1: 2, 2: 0}, profile_functions={2})
+        reader, mock_ml = _open_reader(
+            mock_ml_cls,
+            mock_build_grid,
+            mock_waters_data,
+            grid,
+            3,
+            types={0: FunctionType.MS, 1: FunctionType.MS, 2: FunctionType.LOCKMASS},
+        )
+        assert len(list(reader.iter_spectra())) == 6
+        assert reader._ms_functions == [0, 1]
+        assert {call.args[1] for call in mock_ml.read_spectrum.call_args_list} == {0, 1}
+
+        left_out = reader._excluded_functions[2]
+        assert left_out["n_scans"] == 3
+        assert left_out["n_unique_pixels"] == 3
+        assert left_out["reason"] == "MassLynx will not centroid this function"
+        reader.close()
+
+    @patch("thyra.readers.waters.waters_reader.MassLynxLib")
+    @patch("thyra.readers.waters.waters_reader.build_imaging_grid")
+    def test_the_profile_read_converts_that_chunk_too(
+        self, mock_build_grid, mock_ml_cls, mock_waters_data
+    ):
+        # Reading the trace asks for no centroiding, so every chunk comes
+        # back the same way and the whole image can be converted.
+        grid = _chunked_grid({0: 1, 1: 2, 2: 0}, profile_functions={0, 1, 2})
+        reader, _ = _open_reader(
+            mock_ml_cls,
+            mock_build_grid,
+            mock_waters_data,
+            grid,
+            3,
+            types={0: FunctionType.MS, 1: FunctionType.MS, 2: FunctionType.LOCKMASS},
+            use_centroid=False,
+        )
+        assert len(list(reader.iter_spectra())) == 9
+        assert reader._ms_functions == [0, 1, 2]
+        assert reader._excluded_functions == {}
         reader.close()

--- a/thyra/readers/waters/waters_reader.py
+++ b/thyra/readers/waters/waters_reader.py
@@ -9,7 +9,7 @@ reconstructed from laser X/Y positions stored in each scan's metadata.
 import ctypes
 import logging
 from pathlib import Path
-from typing import Any, Dict, Generator, List, Optional, Tuple
+from typing import Any, Dict, Generator, List, Optional, Set, Tuple
 
 import numpy as np
 from numpy.typing import NDArray
@@ -46,17 +46,34 @@ class WatersReader(BaseMSIReader):
     2. Opens the .raw directory and verifies it contains imaging data
     3. Classifies acquisition functions (MS, IMS, MRM, lockmass)
     4. Reconstructs the imaging pixel grid from laser coordinates
-    5. Keeps the MS1 functions only when the file also holds MS/MS ones
-    6. Iterates MS spectra yielding (coords, mzs, intensities) tuples
+    5. Works out which functions hold the image, from the laser positions
+    6. Iterates their spectra yielding (coords, mzs, intensities) tuples
 
-    Every MS function shares the one laser grid, so two functions yield
-    two spectra at the same pixel. Summing an MS1 and an MS2 spectrum into
-    one pixel would make a spectrum of nothing, which is why the level
-    filter in step 5 exists: an MSe or data-dependent acquisition converts
-    to its MS1 image, and the functions left out are recorded in the
-    Waters-specific metadata block. A file with no MS1 function converts
-    its MS/MS functions instead and says so through
-    :meth:`get_fragmentation`.
+    Step 5 exists because a Waters function is not necessarily one
+    acquisition function. MassLynx caps a ``_FUNC*.DAT`` file at about
+    1.6 GB and opens a new *function* when a long imaging run reaches it,
+    so one raster arrives as several functions that tile the stage: they
+    never share a pixel. It also names the last of them as the file's
+    lockmass function, and reports MS level 1 for the first chunk, 2 for
+    the middle ones and 0 for the last. None of that survived contact with
+    real files (see :doc:`the D7 entry </design-decisions>`), so the reader
+    decides from the laser positions instead, which are the same
+    measurement the pixel grid is built from:
+
+    * A function landing on pixels no earlier function covers **extends the
+      raster** and is converted, whatever level MassLynx reports for it --
+      including the chunk MassLynx calls the lockmass function, except while
+      the run is read as centroids, which that one function's spectra cannot
+      be (see :meth:`_raster_candidates`).
+    * Functions competing for the same pixels are a parallel acquisition --
+      MSe low and high energy, a data-dependent run, a co-acquired lockmass
+      reference. Summing an MS1 and an MS2 spectrum into one pixel would
+      make a spectrum of nothing, so among those the MS1 functions win when
+      the file has any, and the rest are recorded under
+      ``excluded_functions`` in the Waters-specific metadata block.
+
+    A file whose converted functions carry a precursor m/z holds fragment
+    spectra and says so through :meth:`get_fragmentation`.
     """
 
     def __init__(
@@ -111,9 +128,11 @@ class WatersReader(BaseMSIReader):
         self._imaging_grid: Optional[ImagingGrid] = None
         self._function_types: Optional[Dict[int, FunctionType]] = None
         self._ms_functions: Optional[List[int]] = None
-        #: MS functions left out of the conversion because the file also
-        #: holds MS1 ones: function index -> what they were.
+        #: Functions not converted: function index -> what they held and
+        #: why they stayed out.
         self._excluded_functions: Dict[int, Dict[str, Any]] = {}
+        #: Raster chunks MassLynx refuses to centroid: index -> pixels lost.
+        self._uncentroidable_functions: Dict[int, int] = {}
         self._common_mass_axis_cache: Optional[NDArray[np.float64]] = None
         self._use_centroid = use_centroid
         self._closed = False
@@ -179,9 +198,10 @@ class WatersReader(BaseMSIReader):
             logger.debug(f"Function {f}: {ft.name}")
 
         # Filter to MS functions only (skip lockmass, MRM, IMS, NOT_MS)
-        self._ms_functions = [
+        ms_functions = [
             f for f, ft in self._function_types.items() if ft == FunctionType.MS
         ]
+        self._ms_functions = ms_functions
 
         if not self._ms_functions:
             self._ml.close_file(self._handle)
@@ -196,9 +216,15 @@ class WatersReader(BaseMSIReader):
             self._ml, self._handle, self._function_types
         )
 
-        # One MS level per store: keep the MS1 functions when there are any
-        self._ms_functions = self._select_functions_by_ms_level(
-            self._ms_functions, self._imaging_grid
+        # Which functions hold the image: the raster chunks MassLynx named
+        # lockmass belong to it, the parallel functions do not. The first
+        # step also records the chunks that had to stay out, so it has to
+        # run before the second.
+        candidates = self._raster_candidates(
+            ms_functions, self._function_types, self._imaging_grid
+        )
+        self._ms_functions = self._select_converted_functions(
+            candidates, self._imaging_grid
         )
 
         # Verify the grid has more than one position (otherwise not really imaging)
@@ -218,7 +244,7 @@ class WatersReader(BaseMSIReader):
         )
 
     # ------------------------------------------------------------------
-    # MS level: which functions become the stored spectrum
+    # Which functions become the stored spectrum
     # ------------------------------------------------------------------
 
     @staticmethod
@@ -229,6 +255,90 @@ class WatersReader(BaseMSIReader):
             for (f, _scan), info in sorted(grid.scan_map.items())
             if f == func and info.has_position
         ]
+
+    @classmethod
+    def _function_pixels(
+        cls, func: int, grid: "ImagingGrid"
+    ) -> Set[Tuple[int, int, int]]:
+        """The pixels one function's positioned scans land on."""
+        pixels = (
+            grid.get_coordinates(info) for info in cls._positioned_scans(func, grid)
+        )
+        return {c for c in pixels if c is not None}
+
+    @classmethod
+    def _comes_back_centroided(cls, func: int, grid: "ImagingGrid") -> bool:
+        """Whether MassLynx honours the centroid request for this function.
+
+        ``ScanInfo.isProfile`` is read after ``setCentroid``, so it reports
+        what ``getDataPoints`` will hand back rather than how the run was
+        acquired. It does not always agree with the request: the library's
+        centroider skips the function ``getLockmassFunction`` names, which
+        on a chunked imaging file is the last chunk of the raster.
+        """
+        scans = cls._positioned_scans(func, grid)
+        return bool(scans) and not scans[0].is_profile
+
+    def _raster_candidates(
+        self,
+        ms_functions: List[int],
+        function_types: Dict[int, FunctionType],
+        grid: "ImagingGrid",
+    ) -> List[int]:
+        """The MS functions, plus any lockmass function that extends the raster.
+
+        MassLynx names the last function of a chunked imaging file as the
+        file's lockmass function even though it is the tail of the raster.
+        A function it calls lockmass belongs to the image when it covers
+        pixels no MS function covers; a real reference function is acquired
+        alongside the image and so covers nothing new. Only ever widens a
+        file that already has an MS function, so a run with no MS function
+        at all is still refused.
+
+        The catch is that the same library will not centroid that function.
+        Rescuing it into a store of centroids would put a band of profile
+        rows across the top of the image -- measured at 3.3x the neighbouring
+        rows' TIC -- so while the run is being read as centroids it stays
+        out, and :attr:`_excluded_functions` records how many pixels that
+        costs. Reading the run as the profile trace converts the whole image.
+        """
+        covered: Set[Tuple[int, int, int]] = set()
+        for f in ms_functions:
+            covered |= self._function_pixels(f, grid)
+
+        extra, uncentroidable = [], []
+        for f, ft in sorted(function_types.items()):
+            if ft is not FunctionType.LOCKMASS:
+                continue
+            new_pixels = self._function_pixels(f, grid) - covered
+            if not new_pixels:
+                continue
+            if self._use_centroid and not self._comes_back_centroided(f, grid):
+                uncentroidable.append((f, len(new_pixels)))
+            else:
+                extra.append(f)
+
+        if uncentroidable:
+            lost = sum(n for _f, n in uncentroidable)
+            logger.warning(
+                "Function(s) %s hold %d pixels (%.1f%% of the image) that no "
+                "other function covers, but MassLynx names them the lockmass "
+                "function and will not centroid them. They stay out rather "
+                "than put profile rows in a table of centroids: pass "
+                "--waters-spectrum profile to convert the whole image.",
+                ", ".join(str(f) for f, _n in uncentroidable),
+                lost,
+                100.0 * lost / max(len(covered) + lost, 1),
+            )
+        if extra:
+            logger.warning(
+                "MassLynx names function(s) %s the lockmass function, but they "
+                "cover pixels no MS function covers, so they are the tail of a "
+                "raster MassLynx split across functions. Converting them too.",
+                ", ".join(str(f) for f in extra),
+            )
+        self._uncentroidable_functions = dict(uncentroidable)
+        return sorted(set(ms_functions) | set(extra))
 
     @classmethod
     def _function_ms_level(cls, func: int, grid: "ImagingGrid") -> int:
@@ -242,51 +352,95 @@ class WatersReader(BaseMSIReader):
         scans = cls._positioned_scans(func, grid)
         return max(1, int(scans[0].ms_level)) if scans else 1
 
-    def _select_functions_by_ms_level(
+    @classmethod
+    def _pixel_groups(
+        cls, ms_functions: List[int], grid: "ImagingGrid"
+    ) -> List[List[int]]:
+        """Group the functions that compete for the same pixels.
+
+        Functions in one group were acquired in parallel and only one of
+        them can be the pixel's spectrum. Separate groups tile the stage --
+        they are the chunks MassLynx makes when a raster outgrows one
+        ``_FUNC*.DAT`` file -- and every one of them is part of the image.
+        """
+        groups: List[Tuple[Set[Tuple[int, int, int]], List[int]]] = []
+        for f in ms_functions:
+            pixels = cls._function_pixels(f, grid)
+            for covered, members in groups:
+                if covered & pixels:
+                    covered |= pixels
+                    members.append(f)
+                    break
+            else:
+                groups.append((pixels, [f]))
+        return [members for _covered, members in groups]
+
+    def _select_converted_functions(
         self, ms_functions: List[int], grid: "ImagingGrid"
     ) -> List[int]:
-        """Keep the MS1 functions when the file has any, else all of them.
+        """Keep every raster chunk, and one MS level per pixel within each.
 
-        Records what was left out in :attr:`_excluded_functions` so the
-        store can say the acquisition fragmented something even though
-        the stored spectra are intact-ion spectra.
+        Chunks of one raster are all converted. Where functions do compete
+        for a pixel, the MS1 ones win when the group has any; the rest are
+        recorded in :attr:`_excluded_functions` so the store can say the
+        acquisition fragmented something even though the stored spectra are
+        intact-ion spectra.
         """
-        levels = {f: self._function_ms_level(f, grid) for f in ms_functions}
-        ms1 = [f for f in ms_functions if levels[f] == 1]
-        if not ms1 or len(ms1) == len(ms_functions):
-            self._excluded_functions = {}
-            if len(ms_functions) > 1:
-                logger.warning(
-                    "%d MS functions (%s) share one laser grid; their spectra "
-                    "are summed per pixel.",
-                    len(ms_functions),
-                    ", ".join(str(f) for f in ms_functions),
-                )
-            return list(ms_functions)
+        self._excluded_functions = {
+            f: {
+                **self._function_summary(f, grid),
+                "n_unique_pixels": n_pixels,
+                "reason": "MassLynx will not centroid this function",
+            }
+            for f, n_pixels in self._uncentroidable_functions.items()
+        }
+        kept: List[int] = []
+        for group in self._pixel_groups(ms_functions, grid):
+            kept.extend(self._select_within_group(group, grid))
+        return sorted(kept)
 
-        self._excluded_functions = {}
-        for f in ms_functions:
+    def _function_summary(self, func: int, grid: "ImagingGrid") -> Dict[str, Any]:
+        """What a function that was not converted held."""
+        precursors = self._function_precursors(func, grid)
+        return {
+            "ms_level": self._function_ms_level(func, grid),
+            "precursor_mz": (
+                precursors[0]
+                if len(precursors) == 1
+                else (precursors if precursors else None)
+            ),
+            "n_scans": len(self._positioned_scans(func, grid)),
+        }
+
+    def _select_within_group(self, group: List[int], grid: "ImagingGrid") -> List[int]:
+        """Which of a set of functions competing for one pixel set is stored."""
+        levels = {f: self._function_ms_level(f, grid) for f in group}
+        ms1 = [f for f in group if levels[f] == 1]
+        if not ms1 or len(ms1) == len(group):
+            if len(group) > 1:
+                logger.warning(
+                    "%d MS functions (%s) cover the same pixels; their spectra "
+                    "are summed per pixel.",
+                    len(group),
+                    ", ".join(str(f) for f in group),
+                )
+            return list(group)
+
+        for f in group:
             if levels[f] == 1:
                 continue
-            precursors = self._function_precursors(f, grid)
             self._excluded_functions[f] = {
-                "ms_level": levels[f],
-                "precursor_mz": (
-                    precursors[0]
-                    if len(precursors) == 1
-                    else (precursors if precursors else None)
-                ),
-                "n_scans": len(self._positioned_scans(f, grid)),
+                **self._function_summary(f, grid),
+                "reason": "covers the same pixels as an MS1 function",
             }
+        excluded = [f for f in group if levels[f] != 1]
         logger.warning(
-            "Functions %s are MS level %s and share the laser grid with the "
+            "Functions %s are MS level %s and cover the same pixels as the "
             "MS1 function(s) %s. Only the MS1 spectra are converted; the "
             "others are recorded in the Waters metadata block as "
             "'excluded_functions'.",
-            ", ".join(str(f) for f in self._excluded_functions),
-            "/".join(
-                sorted({str(v["ms_level"]) for v in self._excluded_functions.values()})
-            ),
+            ", ".join(str(f) for f in excluded),
+            "/".join(sorted({str(levels[f]) for f in excluded})),
             ", ".join(str(f) for f in ms1),
         )
         return ms1
@@ -304,32 +458,38 @@ class WatersReader(BaseMSIReader):
     def get_fragmentation(self) -> Optional[FragmentationSchedule]:
         """What the stored spectra are: MS1, or the fragment spectra of what.
 
-        MS level 1 whenever an MS1 function was converted, including the
-        MSe and data-dependent files whose MS/MS functions were left out
-        (those are in the Waters metadata block, not here, because this
-        describes the spectra in the store). When the file holds MS/MS
-        functions only, the schedule is their precursors: one isolation
-        window per function whose precursor is constant, and
-        ``constant_across_pixels`` false as soon as any function's
-        precursor changes from scan to scan.
+        A converted function holds fragment spectra when MassLynx reports a
+        precursor m/z for it. The reported MS level alone is not evidence:
+        on every real multi-function imaging file measured, the chunks of
+        one raster come back as level 1, then 2, then 0, with no precursor
+        anywhere (see the D7 entry of the decisions page). So an MSe or
+        data-dependent file, whose MS/MS functions were left out, reads as
+        MS1 here -- what they were is in the Waters metadata block, since
+        this describes the spectra in the store -- and so does a chunked
+        MS1 raster. A file whose converted functions do carry precursors
+        reports them: one isolation window per distinct precursor, and
+        ``constant_across_pixels`` false as soon as a function's precursor
+        changes from scan to scan.
         """
         _ml, _handle, grid, _types, ms_functions = self._require_initialized()
-        levels = {f: self._function_ms_level(f, grid) for f in ms_functions}
-        top = max(levels.values(), default=1)
-        if top <= 1:
+        precursors = {f: self._function_precursors(f, grid) for f in ms_functions}
+        fragment_functions = [f for f in ms_functions if precursors[f]]
+        if not fragment_functions:
             return FragmentationSchedule(ms_level=1, source=FRAGMENTATION_SOURCE)
 
-        windows: List[IsolationWindow] = []
+        windows: Dict[float, IsolationWindow] = {}
         constant = True
-        for f in ms_functions:
-            precursors = self._function_precursors(f, grid)
-            if len(precursors) != 1:
+        for f in fragment_functions:
+            if len(precursors[f]) != 1:
                 constant = False
                 continue
-            windows.append(self._isolation_window(f, precursors[0], grid))
+            target = precursors[f][0]
+            windows.setdefault(target, self._isolation_window(f, target, grid))
         return FragmentationSchedule(
-            ms_level=top,
-            windows=tuple(windows),
+            ms_level=max(
+                [2] + [self._function_ms_level(f, grid) for f in fragment_functions]
+            ),
+            windows=tuple(windows[target] for target in sorted(windows)),
             constant_across_pixels=constant,
             dissociation_accession=(
                 COLLISION_INDUCED_DISSOCIATION_ACCESSION if windows else None

--- a/thyra/readers/waters/waters_reader.py
+++ b/thyra/readers/waters/waters_reader.py
@@ -325,7 +325,8 @@ class WatersReader(BaseMSIReader):
                 "other function covers, but MassLynx names them the lockmass "
                 "function and will not centroid them. They stay out rather "
                 "than put profile rows in a table of centroids: pass "
-                "--waters-spectrum profile to convert the whole image.",
+                "--waters-spectrum profile --streaming true to convert the "
+                "whole image.",
                 ", ".join(str(f) for f, _n in uncentroidable),
                 lost,
                 100.0 * lost / max(len(covered) + lost, 1),


### PR DESCRIPTION
## What this fixes

A Waters *function* is not necessarily one acquisition function. MassLynx caps a `_FUNC*.DAT` file at about 1.6 GB and opens a **new function** when a long imaging run reaches it, so one raster arrives as several functions that tile the stage. It reports MS level 1 for the first chunk, 2 for the middle ones and 0 for the last, and `getLockmassFunction` names that last chunk as the file's lockmass function.

D7 shipped in v3.19.0 on the premise that a level-2 function is a fragment function. It was tested on synthetic scan records only, and the follow-up asked for real data. Every multi-function Waters imaging run on the lab share contradicts it: `_extern.inf` declares **one** acquisition function, the chunks tile in retention time and y with **zero** shared pixels, and none carries a precursor. So the level filter dropped every chunk after the first, and the lockmass classification dropped the last one on top:

| File | Instrument | fns | v3.19.0 | this PR (centroid) | in the file |
|---|---|---|---|---|---|
| `20140509_ZF_No13.raw` | Synapt G1 | 25 | 1,657 | 36,633 | 37,033 |
| `20140513_ZF_No16.raw` | Synapt G1 | 11 | 2,496 | 20,438 | 21,788 |
| `20141003 MTB_04.raw` | Synapt G1 | 8 | 1,700 | 12,110 | 12,972 |
| `140903_trypsin_vs_no.raw` | Synapt G1 | 5 | 2,284 | 8,843 | 9,221 |
| `180814_EVO_Fresh_image.raw` | Synapt G1 | 3 | 3,200 | 6,408 | 7,682 |
| `20201209_BCtumor_left Analyte 2.raw` | Synapt G2-Si | 4 | 15,790 | 49,096 | 61,108 |
| `20201223_BCTumor_Eva MDA_468.raw` | Synapt G2-Si | 3 | 5,837 | 11,413 | 17,550 |
| `20201218_MDA468_slide20201208 Analyte 5.raw` | Synapt G2-Si | 2 | 7,355 | 7,355 | 8,547 |

7,486 Waters `.raw` directories were found on the share; 1,396 hold more than one `_FUNC*.DAT`.

## The rule

Decide from the **laser positions**, the same measurement the pixel grid is already built from.

- A function landing on pixels **no earlier function covers** extends the raster and is converted, whatever level MassLynx reports and whether or not MassLynx calls it the lockmass function. Only ever widens a file that already has an MS function, so `No MS functions found` still fires.
- Functions **competing for the same pixels** were acquired in parallel, so the MS1 ones still win and the rest are recorded under `excluded_functions`, now with the reason. That is D7's original decision, kept — scoped to the functions it was actually about.

This is decidable rather than a guess because one real multi-function acquisition was found: `Xevo DESI/…/20191107_fastDDA_neg_002.raw`, whose `_extern.inf` declares 16 functions (one `TOF FAST DDA FUNCTION` + 15 surveys), `isDdaFile` returns 1, and all 16 land on the **same** position. A chunked raster tiles the positions; a parallel acquisition repeats them.

`get_fragmentation` follows the **precursor** rather than the level for the same reason — a reported level with no precursor behind it is the chunk artefact.

## The catch, caught by the TIC image

The library will not centroid the function `getLockmassFunction` names: on `180814_EVO_Fresh_image.raw` it returns 112,594 points either way, against 7,408 for its centroided neighbour, TIC 3.3x. Converting it into a store of centroids laid a band of profile rows across the top of the image (rows 39–45 averaging 8.6e4 against 3.1–3.7e4 below). So while a run is read as centroids that chunk **stays out**, `excluded_functions` records its scan count, the pixels it would have added and the reason, and the warning names the cost and the flags.

## Verified on real data

| Check | Result |
|---|---|
| `180814_EVO_Fresh_image.raw`, default (centroid) | 6,408 pixels against 3,200; no duplicate coordinate, no empty pixel; `excluded_functions["2"]` carries `n_unique_pixels 1274` and its reason; TIC image continuous across the chunk boundary |
| the same run, `--waters-spectrum profile --streaming true` | 7,682 pixels — the whole 167×46 raster — and the TIC image continuous across **both** boundaries, so the band was the representation and nothing else |
| `20170818_08.raw`, a real single-precursor MS/MS run | `fragmentation` MS level 2, window at m/z 377.4, CE 35.0, CID; the converter declines a demultiplexed table because one precursor needs none |
| `20191107_fastDDA_neg_002.raw` | functions 1–15 recorded with their per-scan precursors, function 0 converted, `fragmentation` MS1 |

`tests/unit` 2,332 passed / 3 skipped; `test_waters_reader.py` 31 (6 new); flake8 including the complexity gate clean; pre-commit clean.

## Not in this PR

- **No Waters demultiplexer.** Of the 113 files whose method declares a `MALDI TOF MSMS FUNCTION`, every one has exactly one function isolating one precursor, 224 KB–3.9 MB, 9–60 scans on ≤5 positions — spot acquisitions, not images. Part 2 of that follow-up has nothing to be built against, so `demultiplex_refusal` is untouched.
- **Xevo DESI runs grid to 1×1** (no laser coordinates) — separate gap, own task.
- **`--streaming auto` under-estimates profile datasets 130x** (`n_pixels * 10000 * 8`), which is why the profile route OOMs on the default axis — separate gap, own task.

Docs: D7 rewritten in `docs/design-decisions.md` keeping its first version so the correction is legible, plus `supported-formats.md`, `cli.md`, `metadata-schema.md`.
