### PR TITLE
The MS/MS table beyond the one dataset it was built on

### DIFF
--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -151,17 +151,145 @@ analysis-layer convention to defer to.
 **Objections considered.**
 
 - *It has run on one dataset: 713 pixels, 15 precursors, one schedule
-  shape.* True, and stated as a limit. The assembly engine underneath is
-  the one verified on the 26k-pixel mobility grid, and the MS/MS count span
-  is tiny, so scale is not where it would fail. A different schedule shape
-  is, and no such file exists to test on. That is a reason to document the
-  limit, not to ship the mixture by default.
+  shape.* True when it shipped, and stated as a limit. Answered on
+  2026-09-07 by four more acquisitions, below: a second schedule of 13
+  precursors in the other polarity, sharing no precursor with the first,
+  found by walking the lab share. The assembly engine underneath is the one
+  verified on the 26k-pixel mobility grid, and the MS/MS count span is
+  tiny, so scale is not where it would fail; the schedule shape was, and
+  now there are two of them measured plus a third made by deleting a window
+  from a copy.
 - *A default-on writes an element the user did not ask for and consumers
   must recognise.* The sibling is discriminated by its `uns` block exactly
   as the mobility sibling already is, and the summed table remains the
   primary element.
 
-**Known limits.** Tested to 713 pixels, 15 precursors, one schedule shape.
+### What five more acquisitions showed (2026-09-07)
+
+Every file in `TIMS-test-data\01_tiny_msms_315px`, and the two negative-mode
+images the share search below turned up, converted with the defaults and
+`--no-optical` on both write routes (`--streaming true` and `false`). The
+two routes agreed exactly on every table they wrote -- same `var` labels,
+same `obs`, and the same CSR `indices`, `indptr` and `data` arrays -- so
+only one set of numbers is given:
+
+| acquisition | pixels | `MsMsType` | precursor table | tables written | windows | `current_ratio` | MS/MS `var` |
+|---|---|---|---|---|---|---|---|
+| `220425_MSMS_pos_brain1.d` | 713 | 8 | `PasefFrameMsMsInfo`, 10,695 rows | summed + `_msms` | 15 | 1.0 (per pixel 1.0 to 1.0) | 713 x 264,006, 302,460 nnz |
+| `220425_MSMS_pos_brain1_2.d` | 668 | 8 | `PasefFrameMsMsInfo`, 10,020 rows | summed + `_msms` | 15 | 1.0 (per pixel 1.0 to 1.0) | 668 x 284,235, 335,840 nnz |
+| `220425_MSMS_neg.d` | 487 | 8 | `PasefFrameMsMsInfo`, 6,331 rows | summed + `_msms` | 13 | 1.0 (per pixel 1.0 to 1.0) | 487 x 162,829, 169,079 nnz |
+| `220425_MSMS_neg_test.d` | 519 | 8 | `PasefFrameMsMsInfo`, 6,747 rows | summed + `_msms` | 13 | 1.0 (per pixel 1.0 to 1.0) | 519 x 93,926, 96,046 nnz |
+| `220425_MSMS_pos.d` | 315 | 2 | `FrameMsMsInfo`, 315 rows | summed only | 1 | -- | -- |
+
+Conversion took 6 to 19 s per file per route. The summed axis is 599,146
+bins on the positive files and 635,610 on the negative ones, which acquired
+to m/z 1200 rather than 1000 -- the default grid follows the acquisition
+range, so **two runs share an axis only when they share that range.**
+
+**The refusal on `220425_MSMS_pos.d` is the right answer.** Its 315 frames
+are all `MsMsType = 2`, single-precursor MS/MS, and it has no
+`PasefFrameMsMsInfo` at all: `FrameMsMsInfo` carries one row per frame,
+every one of them `TriggerMass` 1046.54 at `IsolationWidth` 1.5 and
+`CollisionEnergy` 57.327. The whole mobility ramp of every frame fragments
+that one precursor, so the summed table already *is* its fragment spectrum
+and there is nothing to separate. This is the acquisition the "one
+precursor" refusal was written for, met for the first time.
+
+**Two pixel sets of one method align on the labels.** `brain1` and
+`brain1_2` share 38,453 of their 264,006 and 284,235 feature labels, and
+every shared label agrees on `precursor_mz`, `mz`, `mz_index` *and*
+`precursor_index`; `anndata.concat` gives 1,381 x 509,788 with per-pixel
+totals preserved and no column holding two precursors. `precursor_mobility`
+does **not** agree between those two: they carry their own TIMS
+calibration and the same window comes out up to 4.0e-3 apart in 1/K0. The
+two negative-mode runs, acquired back to back, agree on it *bitwise*. So
+the coordinate is reproducible when the calibration is and not otherwise,
+which is why aligning on `(precursor_mz, precursor_mobility)` means
+matching the pair rather than comparing it with `==`.
+
+**A second schedule, acquired as such.** The negative-mode pair isolates 13
+precursors from 519.182 to 1179.731 -- a list with **nothing in common**
+with the positive-mode 15 from 313.275 to 936.578. Concatenating a negative
+store with a positive one shares **zero** labels, which is the whole point:
+two unrelated acquisitions must not merge. Had the labels been named after
+the rank, the two would have shared **5,262** labels and *every one of them*
+would have named two different precursors -- `p0_mz31749` is 519.182 in one
+and 313.275 in the other -- and the different mass axes would not have
+saved it, because both axes start at m/z 50 and their low bins line up. The
+two negative runs, which do share a schedule, share 7,155 labels and agree
+on every column of `var` including the rank.
+
+**And a third shape, made from the data at hand.** A copy of `brain1_2`
+with the lowest-m/z window (313.275) deleted from all 668 frames -- from
+every frame, so `constant_across_pixels` still holds and only the shape
+changes. The result is 14 precursors, each one rank lower than in `brain1`:
+353.32 is `precursor_index` 1 there and 0 here. The alignment survives it.
+36,912 labels are shared and all of them agree on `precursor_mz`, `mz` and
+`mz_index`; `precursor_index` does not, and
+`anndata.concat(join="inner", merge="unique")` drops that column while
+keeping the other three -- anndata itself finding the rank disagrees. The
+15,741 labels of the deleted precursor are `brain1`-only and the reduced
+sample contributes exactly 0 to them; a rank-named scheme would have merged
+all 27,145 labels the two stores would then have shared.
+
+**And the current block says what was removed.** The reduced copy's summed
+table is untouched, so its split now misses exactly the deleted window's
+ion current: `current_ratio` 0.9717425865942857 against
+1 - 0.028257413405714304 = 0.9717425865942857, equal to the last digit.
+
+### The share census
+
+Every `analysis.tdf` under `V:\Instruments` and `V:\Users` was opened
+read-only and asked what it is: **1,021** of them, plus the nine in the
+local corpus. `V:\Instruments\TimsTOF` holds 25 -- most `.d` folders there
+are TSF, TIMS off -- and the other twenty instrument directories hold none.
+Of the 1,021, 230 are imaging acquisitions (they have `MaldiFrameInfo`) and
+95 carry `PasefFrameMsMsInfo`, but only **six are both**, and those six are
+the four positive-mode files above (two of them duplicate copies) plus the
+two negative-mode ones. Every other PASEF file on the share is an LC run
+with no MALDI geometry at all, so the converter stops there long before the
+tables -- a clean conversion failure, not a crash.
+
+Their *schedules* are still worth reading, and reading them exercised two
+refusals no real file had reached before.
+
+- **Data-dependent PASEF.** `V:\Users\Cillero-Pastor_Berta\Pereira_Betzabeth\TIMS TOF 2 PRO\20260313`
+  holds fourteen DDA runs on a timsTOF Pro 2. One
+  (`260313_BP_26_DDA_S2-G10_1_741.d`) has 1,840 survey and 9,912 fragment
+  frames and **14,952 distinct isolation windows, each in 1 to 8 frames**;
+  across the share the count reaches 90,915. The precursors are chosen per
+  frame, so there is no global feature axis, and the windows overlap on the
+  ramp as well. Refused on the first of those, which is the right one: the
+  overlap is a consequence of the design, the varying schedule *is* the
+  design.
+- **diaPASEF.** 654 files interleave survey and DIA fragment frames -- 1,786
+  and about 28,566 of them in one -- with their windows in
+  `DiaFrameMsMsWindows`.
+
+**Reading a diaPASEF one found a refusal that lied.**
+`DiaFrameMsMsWindows` is not one of the two tables the TDF reader looks in,
+so such a file yields a schedule with an empty window list, and
+`constant_across_pixels` false because the frame types are mixed.
+`demultiplex_refusal` asked the window count before the constancy and
+answered *"the acquisition isolates a single precursor"* about a run that
+isolates 32. It now asks the conditions in order of what each says about
+the acquisition -- not MS/MS, then not constant, then no precursor
+recorded, then one precursor, then overlapping -- so that file is refused
+as non-constant, which is true, and an empty window list has a reason of
+its own. The `INFO` line about a `current_ratio` off 1 was likewise
+attributing every deviation to `vendor_centroid`; a schedule whose windows
+do not cover every scan carrying current is the other direction, as the
+reduced copy above measures.
+
+**Known limits.** Tested on four MALDI PASEF images across **two
+independently acquired schedules** -- 15 precursors in positive mode over
+m/z 50-1000, 13 in negative over 50-1200 -- at 487 to 713 pixels, plus a
+third shape made by deleting one window from a copy, the single-precursor
+refusal on a real `MsMsType = 2` acquisition, and the varying-schedule
+refusal on real DDA-PASEF. All four come from the same instrument and the
+same method family, and none exceeds 713 pixels: the assembly engine
+underneath is the one verified on the 26k-pixel mobility grid, but this
+table has not itself been run at that scale.
 
 ---
 

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -558,23 +558,51 @@ applies to every other table.
     `precursor_index` is a position in **one store's** precursor axis and
     means nothing outside it: two samples whose schedules differ in length
     give the same index to different precursors. Align on
-    `(precursor_mz, precursor_mobility)`. The `var` index labels are named
+    `(precursor_mz, precursor_mobility)` -- by matching the pair, never by
+    comparing it with `==`: two runs acquired back to back agreed on the
+    1/K0 bitwise, while two of the same method on different days came out
+    up to 4.0e-3 apart, because each file carries its own TIMS calibration.
+    The `var` index labels are named
     after the precursor's m/z for the same reason -- `p936.578_mz1732`,
     never `p14_mz1732` -- so `anndata.concat` cannot silently merge two
-    unrelated precursors. The table carries no `mobility`
+    unrelated precursors. Measured on two real acquisitions in opposite
+    polarities, 15 precursors against 13 with none in common: **zero**
+    labels shared, against **5,262** a rank-named scheme would have shared,
+    every one of them naming two different precursors. Differing mass axes
+    do not save you there -- both started at m/z 50, so the low `mz_index`
+    values line up. Concatenate with `join="inner"` to keep
+    a `var` at all: on an outer join every column missing from one side
+    makes `merge="unique"` drop the whole column, while on an inner join it
+    keeps `precursor_mz`, `mz` and `mz_index` and drops exactly
+    `precursor_index` and `precursor_mobility` -- anndata finding, on its
+    own, which of the four travel between stores. The table carries no
+    `mobility`
 column: the scan range is how the precursors are *separated*, not what
 they are *indexed by*, and a table matching both discriminators would tell
 a consumer nothing about which kind it holds.
 
 The split is a filter on the scan number, never an estimate, so Thyra
 refuses rather than approximates and says at `INFO` which condition
-failed:
+failed. They are asked in this order, which is by how much each says about
+the acquisition rather than by how cheap it is to check:
 
 | refused when | because |
 |---|---|
 | the schedule varies from pixel to pixel | the precursors are not a global feature axis |
-| the isolation windows overlap, or carry no scan range | they cannot be separated by mobility alone |
+| the source records no precursor for the fragment frames | there is nothing to separate them by |
 | there is one precursor | the summed table already *is* its fragment spectrum |
+| the isolation windows overlap, or carry no scan range | they cannot be separated by mobility alone |
+
+The order matters because the last three are facts about what the source
+recorded and the first is a fact about the method. A diaPASEF file puts its
+windows in `DiaFrameMsMsWindows`, which the TDF reader does not read, so it
+arrives with no windows at all *and* survey frames mixed in among the
+fragment ones -- and reporting a count first would describe a run isolating
+32 precursors as one isolating a single precursor. A data-dependent
+(DDA) PASEF run trips the first row and the last at once -- one measured
+holds 14,952 distinct windows, each in one to eight frames, overlapping on
+the ramp -- and the varying schedule is the design while the overlap is
+only its consequence.
 
 A refusal writes no sibling table, is never an exception and never touches
 the summed table. Bruker TDF is the only source that reports what the
@@ -615,6 +643,21 @@ already holds for the TIC image.
       two passes, fed from the same frame read, so the split adds no read
       of the source. The largest acquisition this has run on is still 713
       pixels with 15 precursors; `var` grows with the occupied pairs.
+    - **Two acquired schedules have been tested, from one instrument.** 15
+      precursors in positive mode and 13 in negative sharing none of them,
+      over four images of 487 to 713 pixels, plus a third shape made by
+      deleting one window from a copy, the single-precursor refusal on a
+      real `MsMsType = 2` acquisition and the varying-schedule refusal on
+      real DDA-PASEF (see
+      [Design Decisions](design-decisions.md#d2-the-msms-table-is-written-by-default-when-the-schedule-qualifies)).
+      All four come from the same instrument and method family, and none
+      exceeds 713 pixels.
+    - **A label means the same bin only when the axes match.** `mz_index`
+      is a column of *that store's* mass axis, and the default resampling
+      grid follows the acquisition range, so two runs share an axis only
+      when they share that range -- 599,146 bins to m/z 1000 against
+      635,610 to 1200 on the two measured. Check `var["mz"]`, not just the
+      label, before reading across stores.
 
 !!! note "Relation to other MS/MS imaging representations"
     The open formats solve this at the raw layer by never merging: an

--- a/tests/integration/test_bruker_tdf_synthetic.py
+++ b/tests/integration/test_bruker_tdf_synthetic.py
@@ -9,6 +9,12 @@ A second group runs only against a real acquisition named by
 ``THYRA_BRUKER_TDF_DATASET`` and checks the reader against the database's own
 per-frame ``SummedIntensities``, and the stored mass-mobility heatmap against
 the stored mean spectrum.
+
+A third runs against a real *PASEF* acquisition named by
+``THYRA_BRUKER_PASEF_DATASET`` -- a ``.d`` whose ``PasefFrameMsMsInfo``
+schedules at least three precursors -- and checks the demultiplexed table
+on both write routes, plus how it aligns with a copy of itself whose
+schedule is one window shorter.
 """
 
 from __future__ import annotations
@@ -938,3 +944,312 @@ class TestRealAcquisition:
 
         ratio = grid.X.nnz / summed.X.nnz
         assert 1.2 <= ratio <= 5, f"unexpected non-zero ratio {ratio:.2f}"
+
+
+# ----------------------------------------------------------------------
+# The demultiplexed table on a real PASEF acquisition, and across two
+# stores whose schedules differ in shape
+# ----------------------------------------------------------------------
+
+PASEF_DATASET = os.environ.get("THYRA_BRUKER_PASEF_DATASET")
+
+#: Frames each conversion below covers. Enough pixels that every scheduled
+#: window still carries signal, few enough that three conversions of an
+#: arbitrarily large acquisition stay quick.
+_PASEF_FRAMES = 64
+
+#: What the CLI passes when nothing overrides it. Without it a TDF's raw
+#: axis is the union of the digitizer indices the frames happen to hold,
+#: which is not the same axis for two different pixel sets -- and a shared
+#: axis is what makes a feature label mean the same bin in both stores.
+_CLI_RESAMPLING = {"method": "auto", "axis_type": "auto", "reference_mz": 1000.0}
+
+
+def _flat_copy(source: Path, target: Path, n_frames: int) -> Path:
+    """A copy of a ``.d``'s top-level files, capped to ``n_frames`` pixels.
+
+    Only ``analysis.tdf`` is copied; every other file is hard-linked, so
+    capping a large acquisition costs nothing. The method subdirectory is
+    left behind on purpose: the SDK opens the database and its binary
+    without it, and its nested backups are deep enough to pass the Windows
+    path limit once a pytest temporary directory is prefixed to them.
+    """
+    target.mkdir(parents=True)
+    for entry in source.iterdir():
+        if not entry.is_file():
+            continue
+        if entry.name == "analysis.tdf":
+            shutil.copy2(entry, target / entry.name)
+            continue
+        try:
+            os.link(entry, target / entry.name)
+        except OSError:
+            shutil.copy2(entry, target / entry.name)
+    with sqlite3.connect(target / "analysis.tdf") as conn:
+        conn.execute(
+            "DELETE FROM MaldiFrameInfo WHERE Frame NOT IN "
+            "(SELECT Frame FROM MaldiFrameInfo ORDER BY Frame LIMIT ?)",
+            (int(n_frames),),
+        )
+    return target
+
+
+def _drop_lowest_window(source: Path) -> float:
+    """Delete the lowest-m/z isolation window, from every frame; return its m/z.
+
+    From *every* frame, so the schedule stays constant across pixels and
+    what changes is only its shape: one window fewer, and every remaining
+    precursor one rank lower than it is in the full acquisition.
+    """
+    with sqlite3.connect(source / "analysis.tdf") as conn:
+        mz = conn.execute("SELECT MIN(IsolationMz) FROM PasefFrameMsMsInfo").fetchone()[
+            0
+        ]
+        conn.execute("DELETE FROM PasefFrameMsMsInfo WHERE IsolationMz = ?", (mz,))
+        remaining = conn.execute(
+            "SELECT COUNT(DISTINCT IsolationMz) FROM PasefFrameMsMsInfo"
+        ).fetchone()
+    assert remaining[0] >= 2, "the reduced schedule must still hold two precursors"
+    return float(mz)
+
+
+def _convert_pasef(source: Path, out: Path, streaming: bool) -> Path:
+    """The acquisition converted the way the CLI converts it by default."""
+    from thyra.convert import convert_msi
+
+    assert convert_msi(
+        str(source),
+        str(out),
+        dataset_id="real",
+        include_optical=False,
+        streaming=streaming,
+        resampling_config=dict(_CLI_RESAMPLING),
+    )
+    return out
+
+
+@pytest.fixture(scope="module")
+def pasef_stores(tmp_path_factory):
+    """The three conversions the PASEF class runs on, built once.
+
+    The full acquisition on both write routes, and the same frames with one
+    isolation window deleted from every one of them.
+    """
+    pytest.importorskip("spatialdata")
+    source = Path(PASEF_DATASET)  # type: ignore[arg-type]
+    _open("scan_sum", source).close()
+    root = tmp_path_factory.mktemp("pasef")
+    full = _flat_copy(source, root / "full.d", _PASEF_FRAMES)
+    reduced = _flat_copy(source, root / "reduced.d", _PASEF_FRAMES)
+    return {
+        "dropped_mz": _drop_lowest_window(reduced),
+        "streaming": _convert_pasef(full, root / "streaming.zarr", True),
+        "buffered": _convert_pasef(full, root / "buffered.zarr", False),
+        "reduced": _convert_pasef(reduced, root / "reduced.zarr", True),
+    }
+
+
+@pytest.mark.skipif(
+    not PASEF_DATASET,
+    reason="Set THYRA_BRUKER_PASEF_DATASET to a Bruker PASEF .d directory to run",
+)
+class TestRealPasefAcquisition:
+    """The demultiplexed table on a real scheduled PASEF acquisition.
+
+    Two questions the synthetic fixture cannot answer. First, whether the
+    two write routes agree on real frames: the streaming one feeds the
+    accumulator from the summed table's own passes, the buffered one drives
+    it over ``iter_precursor_spectra``, and a difference between them would
+    be a difference in what the store holds. Second, whether two stores
+    whose schedules differ in *shape* align -- the copy below has one
+    isolation window deleted from every frame, which moves every remaining
+    precursor one rank down, so a positional feature label would
+    concatenate unrelated precursors onto each other without an error.
+    """
+
+    @staticmethod
+    def _msms(store: Path):
+        return _read_table(store, "real_z0_msms")
+
+    def test_both_routes_write_the_same_demultiplexed_table(self, pasef_stores):
+        """The route is a performance choice; it must not be a data choice."""
+        streaming = self._msms(pasef_stores["streaming"])
+        buffered = self._msms(pasef_stores["buffered"])
+
+        assert streaming.shape == buffered.shape
+        assert list(streaming.var.index) == list(buffered.var.index)
+        assert list(streaming.obs.index) == list(buffered.obs.index)
+        for column in ("precursor_mz", "mz", "precursor_index", "mz_index"):
+            np.testing.assert_array_equal(
+                streaming.var[column].to_numpy(),
+                buffered.var[column].to_numpy(),
+                err_msg=column,
+            )
+        np.testing.assert_array_equal(_rows(streaming), _rows(buffered))
+
+    def test_the_split_adds_back_up_to_the_summed_table_exactly(self, pasef_stores):
+        """Under the default ``scan_sum`` the two tables hold one ion current."""
+        for route in ("streaming", "buffered"):
+            summed = _read_table(pasef_stores[route], "real_z0")
+            msms = self._msms(pasef_stores[route])
+            block = msms.uns["demultiplexed_current"]
+
+            assert block["summed_table"] == "real_z0"
+            for key in (
+                "current_ratio",
+                "current_ratio_pixel_min",
+                "current_ratio_pixel_max",
+            ):
+                assert float(block[key]) == pytest.approx(1.0, abs=1e-12), (route, key)
+            per_pixel = np.asarray(msms.X.sum(axis=1)).ravel()
+            np.testing.assert_allclose(
+                per_pixel, np.asarray(summed.X.sum(axis=1)).ravel(), rtol=1e-12
+            )
+            assert per_pixel.sum() > 0
+
+    def test_the_precursor_axis_is_the_databases_own_window_list(self, pasef_stores):
+        summed = _read_table(pasef_stores["streaming"], "real_z0")
+        schedule = summed.uns["msms_schedule"]
+        con = sqlite3.connect(
+            f"file:{(Path(PASEF_DATASET) / 'analysis.tdf').as_posix()}"
+            "?mode=ro&immutable=1",
+            uri=True,
+        )
+        targets = [
+            row[0]
+            for row in con.execute(
+                "SELECT DISTINCT IsolationMz FROM PasefFrameMsMsInfo "
+                "ORDER BY IsolationMz"
+            )
+        ]
+        con.close()
+
+        assert schedule["resolved_table"] == "real_z0_msms"
+        assert int(schedule["n_windows"]) == len(targets)
+        np.testing.assert_allclose(
+            np.asarray(schedule["isolation_window_target"], dtype=float), targets
+        )
+        var = self._msms(pasef_stores["streaming"]).var
+        assert var["precursor_index"].nunique() == len(targets)
+        assert np.all(np.diff(var["precursor_index"].to_numpy()) >= 0)
+        assert np.all(np.isfinite(var["precursor_mobility"].to_numpy()))
+
+    def test_one_window_fewer_still_aligns_on_the_labels(self, pasef_stores):
+        """The alignment the labels exist for, on a schedule of another shape."""
+        import anndata
+
+        full = self._msms(pasef_stores["streaming"])
+        reduced = self._msms(pasef_stores["reduced"])
+        dropped = pasef_stores["dropped_mz"]
+
+        # The premise: the reduced store gives every precursor a lower rank.
+        assert reduced.var["precursor_index"].nunique() == (
+            full.var["precursor_index"].nunique() - 1
+        )
+        assert not np.any(np.isclose(reduced.var["precursor_mz"].to_numpy(), dropped))
+        second = sorted(set(full.var["precursor_mz"]))[1]
+        rank_in = {
+            "full": full.var.loc[
+                full.var["precursor_mz"] == second, "precursor_index"
+            ].iloc[0],
+            "reduced": reduced.var.loc[
+                reduced.var["precursor_mz"] == second, "precursor_index"
+            ].iloc[0],
+        }
+        assert (int(rank_in["full"]), int(rank_in["reduced"])) == (1, 0)
+
+        # Every label both stores carry still names the same precursor and
+        # the same bin of the shared mass axis.
+        shared = full.var.index.intersection(reduced.var.index)
+        assert shared.size > 0
+        for column in ("precursor_mz", "mz", "mz_index"):
+            np.testing.assert_array_equal(
+                full.var.loc[shared, column].to_numpy(),
+                reduced.var.loc[shared, column].to_numpy(),
+                err_msg=column,
+            )
+
+        joined = anndata.concat(
+            {"full": full, "reduced": reduced},
+            axis=0,
+            join="inner",
+            label="sample",
+            index_unique="-",
+            merge="unique",
+        )
+        assert joined.n_obs == full.n_obs + reduced.n_obs
+        assert list(joined.var.index) == list(shared)
+        # anndata itself finds that the rank disagrees and drops it, while
+        # the columns intrinsic to the precursor survive.
+        assert "precursor_mz" in joined.var.columns
+        assert "mz_index" in joined.var.columns
+        assert "precursor_index" not in joined.var.columns
+        assert not np.any(np.isclose(joined.var["precursor_mz"].to_numpy(), dropped))
+
+    def test_the_dropped_precursor_is_absent_rather_than_reassigned(self, pasef_stores):
+        import anndata
+
+        full = self._msms(pasef_stores["streaming"])
+        reduced = self._msms(pasef_stores["reduced"])
+        labels = full.var.index[
+            np.isclose(full.var["precursor_mz"].to_numpy(), pasef_stores["dropped_mz"])
+        ]
+
+        joined = anndata.concat(
+            {"full": full, "reduced": reduced},
+            axis=0,
+            join="outer",
+            label="sample",
+            index_unique="-",
+        )
+        rows = (joined.obs["sample"] == "reduced").to_numpy()
+        block = joined[rows, joined.var.index.isin(labels)].X
+
+        assert labels.size > 0
+        assert (
+            np.abs(block.toarray() if hasattr(block, "toarray") else block).sum() == 0
+        )
+
+    def test_a_rank_named_label_would_have_merged_two_precursors(self, pasef_stores):
+        """Why the label is named after the precursor's m/z, on real data."""
+        import pandas as pd
+
+        def ranked(table):
+            return pd.Series(
+                table.var["precursor_mz"].to_numpy(),
+                index=[
+                    f"p{p}_mz{m}"
+                    for p, m in zip(table.var["precursor_index"], table.var["mz_index"])
+                ],
+            )
+
+        left = ranked(self._msms(pasef_stores["streaming"]))
+        right = ranked(self._msms(pasef_stores["reduced"]))
+        shared = left.index.intersection(right.index)
+
+        assert shared.size > 0
+        collisions = int(
+            (left.loc[shared].to_numpy() != right.loc[shared].to_numpy()).sum()
+        )
+        assert (
+            collisions == shared.size
+        ), "every shared rank label must name two different precursors here"
+
+    def test_the_removed_windows_current_is_exactly_the_deficit(self, pasef_stores):
+        """What ``demultiplexed_current`` measures, checked by arithmetic.
+
+        The reduced copy's summed table is untouched -- the frames are the
+        same -- so the split now misses exactly the ion current of the
+        window that was deleted from the schedule, and the ratio says so.
+        """
+        full = self._msms(pasef_stores["streaming"])
+        reduced = self._msms(pasef_stores["reduced"])
+        block = np.isclose(
+            full.var["precursor_mz"].to_numpy(), pasef_stores["dropped_mz"]
+        )
+
+        share = float(full.X[:, block].sum()) / float(full.X.sum())
+        assert 0.0 < share < 1.0
+        assert float(
+            reduced.uns["demultiplexed_current"]["current_ratio"]
+        ) == pytest.approx(1.0 - share, rel=1e-9)

--- a/tests/unit/converters/test_msms_table.py
+++ b/tests/unit/converters/test_msms_table.py
@@ -255,12 +255,39 @@ class TestRefusals:
         assert "single precursor" in demultiplex_refusal(schedule)
         assert _build(_reader(schedule=schedule)) is None
 
+    def test_a_source_that_records_no_precursor_at_all(self):
+        """Not "one precursor": none, which is a different thing to say.
+
+        A diaPASEF acquisition puts its windows in ``DiaFrameMsMsWindows``,
+        which the TDF reader does not read, so the schedule it builds is
+        MS/MS with an empty window list. Measured on a real one (32 DIA
+        windows, 1786 survey and 28566 fragment frames): before the
+        conditions were ordered as they are now, this reported "isolates a
+        single precursor" about a run that isolates 32.
+        """
+        schedule = FragmentationSchedule(ms_level=2, windows=())
+        assert "no precursor" in demultiplex_refusal(schedule)
+
     def test_a_schedule_that_varies_per_pixel(self):
         schedule = FragmentationSchedule(
             ms_level=2, windows=WINDOWS, constant_across_pixels=False
         )
         assert "not constant across pixels" in demultiplex_refusal(schedule)
         assert _build(_reader(schedule=schedule)) is None
+
+    def test_survey_and_fragment_frames_are_refused_as_non_constant(self):
+        """The mixed-``MsMsType`` case, which has no schedule per pixel.
+
+        The reader sets ``constant_across_pixels`` false as soon as a file
+        holds survey frames as well as fragment ones, whatever the
+        precursor tables say -- and that fact outranks the window count,
+        which for such a file says nothing about the method.
+        """
+        schedule = FragmentationSchedule(
+            ms_level=2, windows=(), constant_across_pixels=False
+        )
+        assert "not constant across pixels" in demultiplex_refusal(schedule)
+        assert _build(_reader(schedule=schedule, spectra=[])) is None
 
     def test_overlapping_windows(self):
         overlapping = (
@@ -337,3 +364,204 @@ class TestIsomerPrecursors:
         assert list(table.var["precursor_mz"].unique()) == [313.275, 936.578]
         assert table.var["precursor_mz"].is_monotonic_increasing
         assert table.var.index.is_unique
+
+
+class TestAlignmentAcrossScheduleShapes:
+    """Two samples whose schedules differ in length must still align.
+
+    The synthetic form of the check run on real data: a copy of an
+    acquisition with one isolation window removed from every frame gives
+    every remaining precursor a lower rank than it has in the full one, so
+    a positional label would concatenate the wrong precursors onto each
+    other -- silently, since a rank collides with a rank. The labels are
+    named after the precursor's m/z precisely so that cannot happen.
+    """
+
+    FULL = (
+        IsolationWindow(313.275, 0.5, 0.5, 34.3, scan_begin=150, scan_end=200),
+        IsolationWindow(500.0, 0.5, 0.5, 40.0, scan_begin=90, scan_end=140),
+        IsolationWindow(936.578, 0.5, 0.5, 49.6, scan_begin=20, scan_end=60),
+    )
+    FULL_SPECTRA = [
+        ((0, 0, 0), 0, [100.0, 300.0], [10.0, 20.0]),
+        ((0, 0, 0), 1, [200.0, 400.0], [30.0, 40.0]),
+        ((0, 0, 0), 2, [200.0], [50.0]),
+        ((1, 0, 0), 1, [400.0], [60.0]),
+    ]
+    #: The same acquisition with the lowest-m/z window gone: the reader
+    #: reports two windows, so what was window 1 is now window 0.
+    REDUCED_SPECTRA = [
+        (coords, window - 1, mzs, intensities)
+        for coords, window, mzs, intensities in FULL_SPECTRA
+        if window > 0
+    ]
+
+    def _full(self):
+        schedule = FragmentationSchedule(ms_level=2, windows=self.FULL)
+        return _build(_reader(schedule=schedule, spectra=self.FULL_SPECTRA))
+
+    def _reduced(self):
+        schedule = FragmentationSchedule(ms_level=2, windows=self.FULL[1:])
+        return _build(_reader(schedule=schedule, spectra=self.REDUCED_SPECTRA))
+
+    def test_the_remaining_precursors_all_shift_one_rank_down(self):
+        """The premise: what makes a positional label wrong here."""
+        full, reduced = self._full().var, self._reduced().var
+
+        assert full.loc[full["precursor_mz"] == 500.0, "precursor_index"].unique() == [
+            1
+        ]
+        assert reduced.loc[
+            reduced["precursor_mz"] == 500.0, "precursor_index"
+        ].unique() == [0]
+        assert 313.275 not in set(reduced["precursor_mz"])
+
+    def test_every_shared_label_still_names_the_same_precursor_and_bin(self):
+        full, reduced = self._full().var, self._reduced().var
+        shared = full.index.intersection(reduced.index)
+
+        assert list(shared) == ["p500_mz1", "p500_mz3", "p936.578_mz1"]
+        np.testing.assert_array_equal(
+            full.loc[shared, "precursor_mz"].to_numpy(),
+            reduced.loc[shared, "precursor_mz"].to_numpy(),
+        )
+        np.testing.assert_array_equal(
+            full.loc[shared, "mz_index"].to_numpy(),
+            reduced.loc[shared, "mz_index"].to_numpy(),
+        )
+
+    def test_concat_merges_no_two_precursors_and_drops_the_rank(self):
+        """`merge="unique"` is anndata itself finding the rank disagrees."""
+        import anndata
+
+        full, reduced = self._full(), self._reduced()
+        joined = anndata.concat(
+            {"full": full, "reduced": reduced},
+            axis=0,
+            join="inner",
+            label="sample",
+            index_unique="-",
+            merge="unique",
+        )
+
+        assert list(joined.var.index) == ["p500_mz1", "p500_mz3", "p936.578_mz1"]
+        # The intrinsic columns survive because both stores agree on them;
+        # precursor_index does not, because the rank means different things.
+        assert "precursor_mz" in joined.var.columns
+        assert "mz_index" in joined.var.columns
+        assert "precursor_index" not in joined.var.columns
+        np.testing.assert_array_equal(
+            joined.var["precursor_mz"].to_numpy(), [500.0, 500.0, 936.578]
+        )
+
+    def test_the_dropped_precursor_is_absent_rather_than_reassigned(self):
+        import anndata
+
+        full, reduced = self._full(), self._reduced()
+        joined = anndata.concat(
+            {"full": full, "reduced": reduced},
+            axis=0,
+            join="outer",
+            label="sample",
+            index_unique="-",
+        )
+        dropped = [label for label in full.var.index if label.startswith("p313.275_")]
+        rows = (joined.obs["sample"] == "reduced").to_numpy()
+        block = joined[rows, joined.var.index.isin(dropped)]
+
+        assert dropped == ["p313.275_mz0", "p313.275_mz2"]
+        assert np.abs(_dense(block)).sum() == 0.0
+
+    def test_a_rank_named_label_would_have_merged_two_precursors(self):
+        """Why the label is not `p{rank}_mz{i}`, stated as an assertion."""
+        full, reduced = self._full().var, self._reduced().var
+
+        def ranked(var):
+            return pd.Series(
+                var["precursor_mz"].to_numpy(),
+                index=[
+                    f"p{p}_mz{m}"
+                    for p, m in zip(var["precursor_index"], var["mz_index"])
+                ],
+            )
+
+        left, right = ranked(full), ranked(reduced)
+        shared = left.index.intersection(right.index)
+
+        assert list(shared) == ["p1_mz1"]
+        # The same label, two unrelated precursors: 500.0 in one sample and
+        # 936.578 in the other would have been summed into one column.
+        assert left.loc["p1_mz1"] == 500.0
+        assert right.loc["p1_mz1"] == 936.578
+
+
+class TestTwoUnrelatedSchedules:
+    """Two acquisitions with nothing in common must concatenate to nothing shared.
+
+    The negative-mode counterpart of a targeted run isolates a different
+    list of precursors from the positive-mode one, so no column of either
+    store describes anything in the other. Measured on the two real pairs
+    (13 windows over m/z 50-1200 against 15 over 50-1000): **zero** shared
+    labels, but 5,262 shared *rank*-named ones, every one of which names
+    two different precursors -- and that collision survives the two runs
+    having different mass axes, because both axes start at m/z 50 and the
+    low bins line up.
+    """
+
+    NEGATIVE = (
+        IsolationWindow(519.182, scan_begin=20, scan_end=60),
+        IsolationWindow(720.469, scan_begin=90, scan_end=140),
+    )
+    SPECTRA = [
+        ((0, 0, 0), 0, [100.0, 300.0], [10.0, 20.0]),
+        ((0, 0, 0), 1, [200.0], [30.0]),
+    ]
+
+    def _other(self):
+        schedule = FragmentationSchedule(ms_level=2, windows=self.NEGATIVE)
+        return _build(_reader(schedule=schedule, spectra=self.SPECTRA))
+
+    def test_no_label_is_shared(self):
+        one, other = _build().var, self._other().var
+
+        assert set(one["precursor_mz"]).isdisjoint(set(other["precursor_mz"]))
+        assert one.index.intersection(other.index).empty
+
+    def test_a_rank_named_label_would_have_shared_several(self):
+        """The same columns under a positional name, to show what is avoided."""
+        one, other = _build().var, self._other().var
+
+        def ranked(var):
+            return pd.Series(
+                var["precursor_mz"].to_numpy(),
+                index=[
+                    f"p{p}_mz{m}"
+                    for p, m in zip(var["precursor_index"], var["mz_index"])
+                ],
+            )
+
+        left, right = ranked(one), ranked(other)
+        shared = left.index.intersection(right.index)
+
+        assert shared.size > 0
+        assert all(
+            left.loc[label] != right.loc[label] for label in shared
+        ), "a rank label must name two different precursors here"
+
+    def test_an_outer_concat_keeps_them_apart(self):
+        import anndata
+
+        one, other = _build(), self._other()
+        joined = anndata.concat(
+            {"one": one, "other": other},
+            axis=0,
+            join="outer",
+            label="sample",
+            index_unique="-",
+        )
+
+        assert joined.n_vars == one.n_vars + other.n_vars
+        # Every column belongs to exactly one sample, so nothing was summed.
+        rows = (joined.obs["sample"] == "one").to_numpy()
+        for mask, table in ((rows, one), (~rows, other)):
+            assert _dense(joined[mask]).sum() == pytest.approx(_dense(table).sum())

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -1904,9 +1904,10 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         if abs(float(block["current_ratio"]) - 1.0) > _MARGINAL_TOLERANCE:
             logger.info(
                 "The demultiplexed table holds %.4fx the summed table's ion "
-                "current (per pixel %.4f to %.4f). They agree exactly only "
-                "under --tdf-spectrum scan_sum; the vendor centroid discards "
-                "counts the raw scans keep.",
+                "current (per pixel %.4f to %.4f). Above 1 under an explicit "
+                "--tdf-spectrum vendor_centroid, which discards counts the "
+                "raw scans keep; below 1 when the schedule's windows do not "
+                "cover every scan that carries current.",
                 block["current_ratio"],
                 block["current_ratio_pixel_min"],
                 block["current_ratio_pixel_max"],

--- a/thyra/converters/spatialdata/msms_table.py
+++ b/thyra/converters/spatialdata/msms_table.py
@@ -101,18 +101,31 @@ def demultiplex_refusal(schedule: Optional[FragmentationSchedule]) -> Optional[s
     split an approximation rather than a filter, so the answer is to
     refuse and say which one failed -- never to apportion ion current
     between precursors that cannot be told apart.
+
+    The conditions are asked in order of how much they say about the
+    acquisition, not in order of how cheap they are to check. A schedule
+    that varies is a fact about the method; an empty or one-entry window
+    list is a fact about what the source recorded, and reporting either of
+    those first would describe a run whose precursors Thyra simply cannot
+    read -- a diaPASEF file with survey and fragment frames interleaved,
+    say -- as one that isolated a single precursor.
     """
     if schedule is None or not schedule.is_msms:
         return "the acquisition is not MS/MS"
-    if len(schedule.windows) < 2:
-        return (
-            "the acquisition isolates a single precursor, so the summed table "
-            "is already its fragment spectrum"
-        )
     if not schedule.constant_across_pixels:
         return (
             "the precursor schedule is not constant across pixels, so the "
             "precursors are not a global feature axis"
+        )
+    if not schedule.windows:
+        return (
+            "the source records no precursor for the fragment frames, so "
+            "there is nothing to separate them by"
+        )
+    if len(schedule.windows) < 2:
+        return (
+            "the acquisition isolates a single precursor, so the summed table "
+            "is already its fragment spectrum"
         )
     if windows_overlap(schedule.windows):
         return (


### PR DESCRIPTION
The demultiplexed MS/MS table shipped in v3.19.0 having run on
one dataset. This takes it to four MALDI PASEF images across two
independently acquired schedules, explains every refusal it produces on the
lab share's other TDFs, and fixes one that was saying something false.

## What was measured

All three files of `TIMS-test-data\01_tiny_msms_315px`, plus the two
negative-mode images the share search turned up, converted with the
defaults and `--no-optical` on both write routes. **The two routes agreed
exactly** on every table -- same `var` labels, same `obs`, same CSR
`indices`, `indptr` and `data`.

| acquisition | pixels | windows | tables | `current_ratio` | MS/MS `var` |
|---|---|---|---|---|---|
| `220425_MSMS_pos_brain1.d` | 713 | 15 | summed + `_msms` | 1.0 | 713 x 264,006 |
| `220425_MSMS_pos_brain1_2.d` | 668 | 15 | summed + `_msms` | 1.0 | 668 x 284,235 |
| `220425_MSMS_neg.d` | 487 | 13 | summed + `_msms` | 1.0 | 487 x 162,829 |
| `220425_MSMS_neg_test.d` | 519 | 13 | summed + `_msms` | 1.0 | 519 x 93,926 |
| `220425_MSMS_pos.d` | 315 | 1 | summed only | -- | refused |

`220425_MSMS_pos.d` is a single-precursor MRM image -- `MsMsType = 2` on all
315 frames, no `PasefFrameMsMsInfo`, one `FrameMsMsInfo` row per frame all
at TriggerMass 1046.54. It is the acquisition the "one precursor" refusal
was written for, met for the first time.

## A second schedule, acquired as such

Walking every `analysis.tdf` under `V:\Instruments` and `V:\Users` (1,021 of
them) found the negative-mode counterpart of the acquisition the table was
built on: 13 precursors from 519.182 to 1179.731, sharing **none** with the
positive-mode 15. That is the "different schedule shape" the D2 limit named,
and it exists after all.

Concatenating a negative store with a positive one shares **zero** labels,
which is the point. A rank-named scheme would have shared **5,262**, and
every one of them names two different precursors -- `p0_mz31749` is 519.182
in one and 313.275 in the other. The two runs having different mass axes
(635,610 bins to m/z 1200 against 599,146 to 1000) would not have saved it,
because both start at m/z 50 and their low bins line up.

A third shape comes from deleting one window from all 668 frames of a copy
of `brain1_2`: 14 precursors, every rank one lower, 36,912 shared labels
that still agree on `precursor_mz`/`mz`/`mz_index` while
`merge="unique"` drops `precursor_index`. Its `current_ratio`
0.9717425865942857 is 1 minus the removed window's 0.028257413405714304
share of the current, to the last digit.

## The fix

`demultiplex_refusal` asked the window count before the constancy, so a real
diaPASEF file -- windows in `DiaFrameMsMsWindows`, a table the TDF reader
does not read, survey and fragment frames interleaved -- was refused with
*"the acquisition isolates a single precursor"* about a run isolating 32.
The refusal was right, its reason was not. The conditions now run in order
of what each says about the acquisition, and an empty window list has a
reason of its own. The same file is now refused as non-constant, which is
true. The `INFO` line about a `current_ratio` off 1 also blamed
`vendor_centroid` for every deviation; a schedule not covering every scan
carrying current is the other direction.

## Two corrections to what the docs told a consumer

- **Align on `(precursor_mz, precursor_mobility)` by matching, not `==`.**
  The two negative runs agree on the 1/K0 bitwise; the two positive ones,
  acquired apart, differ by up to 4.0e-3, because each file carries its own
  TIMS calibration.
- **Concatenate with `join="inner"`.** On an outer join `merge="unique"`
  drops every `var` column; on an inner one it keeps `precursor_mz`, `mz`
  and `mz_index` and drops exactly the ones that do not travel.

Also recorded: `mz_index` means the same bin only when two stores share a
mass axis, and the default grid follows the acquisition range.

## Tests

`TestRealPasefAcquisition`, gated on `THYRA_BRUKER_PASEF_DATASET` beside the
existing `THYRA_BRUKER_TDF_DATASET`. Green on all three real PASEF
acquisitions. The synthetic halves -- the reduced schedule, two disjoint
schedules, and the two refusals the diaPASEF file exposed -- are unit tests.

Unit suite 2336 passed / 3 skipped. Synthetic integration 31 passed / 10
skipped. Pre-commit clean, complexity violations 0.
