### PR TITLE
perf(tdf): map a frame's unique m/z once and gather by its inverse

### DIFF
--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -229,9 +229,27 @@ table that is routine on a workstation is fatal on a laptop.
   measured and documented, and a guess wrong by a factor of two still
   refuses at half of free memory.
 
-**Known limits.** The whole slide at the default axis lands 5.5 percent over
-the present fixed ceiling and is refused after one fused read; with
-`--resample-bins 40000` it converts.
+**Measured on the whole slide** (2026-09-07, 26,087 pixels at the default
+138,629-bin axis, `--mobility-grid --no-optical`, warm, no optical image).
+The conversion the fixed ceiling refused now runs: 21,101,151 occupied
+`(m/z bin, mobility channel)` pairs, 1,627,659,585 non-zeros through 18.19 GB
+of scratch, 239 of 256 channels occupied, a marginal of exactly 1.0 in every
+pixel, an 8.0 GB store (2.5 GB summed, 5.6 GB grid). The guard neither warned
+nor refused, which is what a projection of 6.5 GB against 90 GB free should
+do.
+
+The constant held: peak private bytes were 6.38 GB, which over 21,101,151
+features is **302 bytes per feature**, 8 percent under the 330 the guard
+projects with and measured the way that number was, as the whole process's
+private peak over the feature count. The `var` frame's own step is narrower
+-- private sat at 2.49 GB through both passes and both column sorts and rose
+to 6.38 GB over three seconds while the frame was built, so 184 bytes per
+feature is what the frame alone costs -- and the guard is conservative under
+either reading, on a grid 1.6 times the one the constant was measured on. It
+stays at 330.
+
+**Known limits.** The `var` frame is still the peak (D8), and the grid at the
+default axis is 5.6 GB of store for a slide whose summed table is 2.5 GB.
 
 ---
 
@@ -243,7 +261,8 @@ about 4 percent of wall time; the whole-slide logs from the D1 measurement
 then showed the mobility heatmap's own pass at 201 s of a 528 s conversion
 under `scan_sum` and 272 s of 438 s under the vendor centroid. The extra
 reads were 38 to 62 percent of a default conversion, not 4, and the reopen
-condition was met on the same afternoon.
+condition was met on the same afternoon. The mapping this left as the next
+lever was taken the same week, by the frame's own unique indices; see below.
 
 **Decision.** A Bruker TDF reader hands each frame over once, as a record
 of its raw scan read, from which the summed spectrum, the mobility point
@@ -285,10 +304,59 @@ pass, which grew from about 120 s to 266 s: what was saved is the read and
 the index-to-m/z conversion of every frame, about 55 s, plus the second
 scatter-side read. What remains is the mapping of every raw point onto the
 mass axis, 51,000 points per frame on this slide, which the heatmap and
-the grid need and the summed spectrum does not. That mapping is the next
-lever, not another read: the points of a frame share about 30,000 unique
-digitizer indices, and mapping those once and gathering would give the
-same bins for two fifths of the work. Not done here.
+the grid need and the summed spectrum does not. That mapping was the next
+lever, not another read, and it was taken the same week.
+
+**The mapping, by the frame's unique indices** (implemented 2026-09-07). A
+TDF frame is read as digitizer indices, and the reader already converts the
+unique ones: measured on this slide, 28,560 unique of 49,070 points, 58
+percent. Both halves of the mapping -- nearest bin, and in range or not --
+are elementwise in the m/z, so mapping the unique values and gathering by
+the frame's own inverse gives the same bins, the same mask and the same drop
+count for 58 percent of the binary searches. The record offers that view as
+`mobility_points_indexed`, the fused passes prefer it, and a record that
+does not offer it is mapped point by point as before; the iterators and the
+standalone passes are untouched.
+
+**Measured** (2026-09-07, the same slide, warm, local disk, no optical
+image; each pair one session, v3.19.0 against the branch):
+
+| whole 26,087-pixel slide | v3.19.0 | indexed mapping |
+|---|---|---|
+| default, wall | 420 s | 343 s |
+| default, pass 1 (maps every point, for the heatmap) | 250 s | 171 s |
+| default, pass 2 (no mobility sink) | 137 s | 139 s |
+| `--mobility-grid` at the default axis, wall | 1,201 s | 724 s |
+| grid, pass 1 (heatmap and discovery) | 401 s | 237 s |
+| grid, pass 2 (grid scatter) | 627 s | 357 s |
+
+The pass that maps points is a third faster, and where both passes map, the
+conversion is 40 percent faster; the default's second pass, which has no
+mobility sink to map for, is unchanged, which is the control. Taking 42
+percent of the searches out of the default's mapping pass took 79 s off it,
+which puts the searches at roughly 190 s of that pass's 250 and roughly 110 s
+of its 171 now -- still the largest single item in it, and the gather and
+the mask that remain are proportional to the points however few searches
+they cost.
+
+Identity was checked the way the fused passes were: stores written by
+v3.19.0 and by the branch, compared array by array (X data, indices and
+indptr with dtypes, `var`, `obs` and `uns`), on the 400-frame slice with and
+without the grid and on the 713-pixel PASEF set, and then on the whole slide
+in both configurations by hashing every array of every table in chunks.
+Identical throughout, the heatmap's `counts` included.
+
+**Cold cache on the lab share** (2026-09-07, the deferral D5 left open).
+The same slide copied to the SMB share, default conversion, branch code, the
+file pushed out of the machine's standby list before the first run so the
+read is genuinely cold: 365 s cold against 342 s warm, pass 1 178 s against
+170 s, pass 2 143 s against 138 s. The first read of a never-read file costs
+about 5 percent of the pass; a conversion's second pass is warm either way,
+since the first pulls the acquisition into the cache. The share is not the
+bottleneck the deferral suspected -- on this machine a cold network read is
+within seconds of a warm local one (171 s for the same pass), so the mapping
+and not the read is what a conversion of this shape spends its time on,
+wherever the file lives.
 
 **Objections considered.**
 
@@ -300,6 +368,15 @@ same bins for two fifths of the work. Not done here.
   raw scans.* Correct; in that mode the record asks the library for the
   centroid as a second call per frame, and the raw read still serves the
   sinks. That mode is the opt-in.
+- *The record contract grew a method for one reader's convenience.* The
+  indexed view is reached with `getattr` and a record that does not offer
+  it is mapped point by point, which the stub records in the tests pin. It
+  is a view of the read every record already has, not a new obligation.
+- *Mapping every unique value maps ones that are then dropped as out of
+  range.* It does, and it costs a few searches more on a frame whose points
+  overhang the axis -- 8,328 points of 1.65 billion on this slide. The
+  alternative, masking before mapping, would need the mask expanded to the
+  points first, which is the work the factoring exists to avoid.
 
 **Known limits.** Only the Bruker TDF reader hands frames over as records;
 every other source keeps its iterators and its standalone passes, which for

--- a/tests/integration/test_bruker_tdf_synthetic.py
+++ b/tests/integration/test_bruker_tdf_synthetic.py
@@ -195,6 +195,28 @@ class TestSyntheticFixture:
                 seen.append(frame["frame"])
         assert sorted(seen) == [f["frame"] for f in expected["frames"]]
 
+    def test_the_indexed_points_are_the_flat_points_factored(self, expected):
+        # The record's two views of the same read: the indexed one leaves
+        # the m/z as (distinct values, index of each point), which is what
+        # the fused passes map by. unique_mz[inverse] must be the flat
+        # view's m/z, value for value, or a sibling table would bin
+        # points differently depending on which view it asked for.
+        with _open("scan_sum") as reader:
+            n = 0
+            for frame in reader.iter_frame_scans():
+                flat = frame.mobility_points()
+                indexed = frame.mobility_points_indexed()
+                assert (flat is None) == (indexed is None)
+                if flat is None:
+                    continue
+                unique_mz, inverse, mobility, intensities = indexed
+                np.testing.assert_array_equal(unique_mz[inverse], flat[0])
+                np.testing.assert_array_equal(mobility, flat[1])
+                np.testing.assert_array_equal(intensities, flat[2])
+                assert unique_mz.size <= flat[0].size
+                n += 1
+        assert n == len(expected["frames"])
+
     def test_mobility_cloud_sums_to_the_scan_sum_spectrum(self, expected):
         with _open("scan_sum") as reader:
             summed = {c: (m, i) for c, m, i in reader.iter_spectra()}

--- a/tests/unit/converters/test_fused_passes.py
+++ b/tests/unit/converters/test_fused_passes.py
@@ -88,6 +88,22 @@ class _Frame:
         return _precursors(self._p)
 
 
+class _IndexedFrame(_Frame):
+    """A record that offers the indexed view, as the Bruker TDF record does.
+
+    Its flat view raises, so a sink reached through it would fail the
+    conversion: whatever the store holds came through the indexed view.
+    """
+
+    def mobility_points(self):
+        raise AssertionError("the indexed view was offered and not taken")
+
+    def mobility_points_indexed(self):
+        mzs, mobility, intensities = _cloud(self._p)
+        unique, inverse = np.unique(mzs, return_inverse=True)
+        return unique, np.asarray(inverse).ravel(), mobility, intensities
+
+
 class _StubExtractor(MetadataExtractor):
     def __init__(self):
         super().__init__(data_source=None)
@@ -198,6 +214,15 @@ class UnfusedStubReader(FusedStubReader):
     frame_scans = False
 
 
+class IndexedStubReader(FusedStubReader):
+    """The same source whose records hand their points over indexed."""
+
+    def iter_frame_scans(self, batch_size: Optional[int] = None) -> Generator:
+        self.frame_passes += 1
+        for p, (x, y) in enumerate(PIXELS):
+            yield _IndexedFrame(p, (x, y, 0))
+
+
 RESAMPLED = {
     "method": "nearest_neighbor",
     "axis_type": "constant",
@@ -276,6 +301,32 @@ class TestFusedPasses:
         # Heatmap + discovery fused into one, then the grid's scatter.
         assert unfused.mobility_passes == 2
         assert unfused.precursor_passes == 2
+
+    def test_the_indexed_view_gives_the_same_store(self, tmp_path):
+        # The record offering (unique m/z, inverse) instead of the points'
+        # m/z changes how many binary searches the mapping does, nothing
+        # else. Its flat view raises, so the conversion completing is
+        # itself the proof that the indexed one was preferred.
+        a = _read(_convert(FusedStubReader(), tmp_path / "flat.zarr"))
+        b = _read(_convert(IndexedStubReader(), tmp_path / "indexed.zarr"))
+
+        assert set(a.tables) == set(b.tables)
+        for key in a.tables:
+            ta, tb = a.tables[key], b.tables[key]
+            np.testing.assert_array_equal(_dense(ta), _dense(tb))
+            assert list(ta.var.index) == list(tb.var.index)
+            assert list(ta.obs.index) == list(tb.obs.index)
+        np.testing.assert_array_equal(
+            np.asarray(a.tables["stub_z0"].uns["mobility_heatmap"]["counts"]),
+            np.asarray(b.tables["stub_z0"].uns["mobility_heatmap"]["counts"]),
+        )
+
+    def test_a_record_without_the_indexed_view_still_converts(self, tmp_path):
+        # The fallback is not incidental: a record that cannot factor its
+        # m/z (every source but the TDF one) offers no such method.
+        assert not hasattr(_Frame(0, (0, 0, 0)), "mobility_points_indexed")
+        sdata = _read(_convert(FusedStubReader(), tmp_path / "flat_only.zarr"))
+        assert "mobility_heatmap" in sdata.tables["stub_z0"].uns
 
     def test_the_marginals_are_exact_either_way(self, tmp_path):
         for reader, name in ((FusedStubReader(), "f"), (UnfusedStubReader(), "u")):

--- a/tests/unit/converters/test_mobility_heatmap.py
+++ b/tests/unit/converters/test_mobility_heatmap.py
@@ -19,6 +19,8 @@ from thyra.converters.spatialdata.mobility_heatmap import (
     HEATMAP_MZ_BINS,
     MobilityHeatmap,
     build_mobility_heatmap,
+    map_indexed_points_to_axis,
+    map_points_to_axis,
     mobility_bin_edges,
     mz_bin_edges,
 )
@@ -176,6 +178,114 @@ class TestAccumulator:
         assert counts[0].sum() == 2.0  # entries 0..2
         assert counts[1].sum() == 1.0  # entries 3..5
         assert counts[3].sum() == 1.0  # entry 9
+
+
+class TestIndexedMapping:
+    """``map_indexed_points_to_axis`` is the flat mapping, gathered.
+
+    A TDF frame reports its points as digitizer indices, so its m/z
+    values repeat; mapping the distinct ones and gathering must give what
+    mapping every point gives, bins, masked arrays and drop count alike.
+    """
+
+    AXIS = np.array([100.0, 110.0, 120.0, 130.0])
+
+    def _both(self, mzs, mobility, intensities):
+        """Map one point cloud both ways: point by point, and factored."""
+        flat = map_points_to_axis(
+            self.AXIS,
+            np.asarray(mzs, dtype=np.float64),
+            np.asarray(mobility, dtype=np.float64),
+            np.asarray(intensities, dtype=np.float64),
+        )
+        unique, inverse = np.unique(
+            np.asarray(mzs, dtype=np.float64), return_inverse=True
+        )
+        indexed = map_indexed_points_to_axis(
+            self.AXIS,
+            unique,
+            np.asarray(inverse).ravel(),
+            np.asarray(mobility, dtype=np.float64),
+            np.asarray(intensities, dtype=np.float64),
+        )
+        return flat, indexed
+
+    @staticmethod
+    def _same(flat, indexed):
+        np.testing.assert_array_equal(indexed[0], flat[0])
+        np.testing.assert_array_equal(indexed[1], flat[1])
+        np.testing.assert_array_equal(indexed[2], flat[2])
+        assert indexed[3] == flat[3]
+        assert indexed[0].dtype == flat[0].dtype == np.int64
+
+    def test_repeated_mz_values_map_to_the_same_bins(self):
+        mzs = [100.0, 121.0, 100.0, 130.0, 121.0, 104.9, 121.0]
+        mobility = np.linspace(1.5, 1.1, len(mzs))
+        intensities = np.arange(1.0, len(mzs) + 1.0)
+        flat, indexed = self._both(mzs, mobility, intensities)
+        self._same(flat, indexed)
+        assert flat[3] == 0 and flat[0].size == len(mzs)
+
+    def test_out_of_range_points_are_dropped_the_same_way(self):
+        # Below the axis, above it, and repeats of both.
+        mzs = [99.9, 100.0, 140.0, 121.0, 99.9, 140.0, 130.0]
+        mobility = np.linspace(1.5, 1.1, len(mzs))
+        intensities = np.arange(1.0, len(mzs) + 1.0)
+        flat, indexed = self._both(mzs, mobility, intensities)
+        self._same(flat, indexed)
+        assert flat[3] == 4 and flat[0].size == 3
+
+    def test_every_point_out_of_range(self):
+        flat, indexed = self._both(
+            [10.0, 10.0, 500.0], [1.5, 1.4, 1.3], [1.0, 2.0, 3.0]
+        )
+        self._same(flat, indexed)
+        assert flat[0].size == 0 and flat[3] == 3
+
+    def test_a_frame_with_no_points(self):
+        empty = np.zeros(0, dtype=np.float64)
+        flat = map_points_to_axis(self.AXIS, empty, empty, empty)
+        indexed = map_indexed_points_to_axis(
+            self.AXIS, empty, np.zeros(0, dtype=np.int64), empty, empty
+        )
+        self._same(flat, indexed)
+
+    def test_ties_go_right_through_the_gather_too(self):
+        # 105.0 is exactly between two entries; the flat mapping takes the
+        # right one, and the gathered mapping is the same mapping.
+        flat, indexed = self._both([105.0, 105.0], [1.5, 1.4], [1.0, 2.0])
+        self._same(flat, indexed)
+        np.testing.assert_array_equal(flat[0], [1, 1])
+
+    def test_the_unique_values_are_mapped_once(self, monkeypatch):
+        calls = []
+        original = mh._nn_map_to_bins
+
+        def counted(axis, mzs):
+            calls.append(np.asarray(mzs).size)
+            return original(axis, mzs)
+
+        monkeypatch.setattr(mh, "_nn_map_to_bins", counted)
+        mzs = np.array([100.0, 121.0] * 50)
+        map_indexed_points_to_axis(
+            self.AXIS,
+            *np.unique(mzs, return_inverse=True),
+            np.ones(mzs.size),
+            np.ones(mzs.size),
+        )
+        assert calls == [2]
+
+    def test_an_accumulator_fed_either_way_agrees(self):
+        mzs = np.array([100.0, 121.0, 100.0, 140.0, 130.0, 121.0])
+        mobility = np.linspace(1.5, 1.1, mzs.size)
+        intensities = np.arange(1.0, mzs.size + 1.0)
+        flat, indexed = self._both(mzs, mobility, intensities)
+        a = MobilityHeatmap(self.AXIS, (1.1, 1.5))
+        b = MobilityHeatmap(self.AXIS, (1.1, 1.5))
+        a.add_mapped(None, *flat)
+        b.add_mapped(None, *indexed)
+        np.testing.assert_array_equal(a.finalize()["counts"], b.finalize()["counts"])
+        assert a.n_out_of_range == b.n_out_of_range == 1
 
 
 # ----------------------------------------------------------------------

--- a/thyra/converters/spatialdata/fused_passes.py
+++ b/thyra/converters/spatialdata/fused_passes.py
@@ -15,11 +15,15 @@ frame with the row the frame is getting; everything the sinks see goes
 through the same mapping and the same accumulators the standalone passes
 use (``map_points_to_axis``, ``GridDiscovery``, ``MsmsAccumulator``), so
 the tables come out identical to the ones the standalone passes build.
+A record that offers its points indexed by their distinct m/z values is
+mapped by ``map_indexed_points_to_axis`` instead, which is that same
+mapping evaluated once per distinct value and gathered rather than a
+second mapping.
 """
 
 import logging
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, Tuple
 
 import numpy as np
 from numpy.typing import NDArray
@@ -28,12 +32,18 @@ from ...core.frames import FrameScans
 from .mobility_heatmap import (
     MobilityHeatmap,
     finish_mobility_heatmap,
+    map_indexed_points_to_axis,
     map_points_to_axis,
 )
 from .mobility_table import GridDiscovery, GridScatter, _report_discovery
 from .msms_table import MsmsAccumulator
 
 logger = logging.getLogger(__name__)
+
+#: One frame's points on the mass axis: ``(bins, mobility, intensities,
+#: n_dropped)``, what both mapping functions return and what every
+#: mobility sink's ``add_mapped`` takes.
+MappedPoints = Tuple[NDArray[np.int64], NDArray[np.float64], NDArray[np.float64], int]
 
 
 class SiblingPasses:
@@ -82,6 +92,33 @@ class SiblingPasses:
         """Whether there is nothing left to feed."""
         return not (self.wants_mobility or self.wants_precursors)
 
+    # -- the mapping -----------------------------------------------------
+
+    def _mapped_points(self, frame: FrameScans) -> Optional[MappedPoints]:
+        """One frame's points on the mass axis, through the cheapest view it offers.
+
+        A record that hands its points over indexed
+        (:meth:`~thyra.core.frames.FrameScans.mobility_points_indexed`,
+        which the Bruker TDF record does because it reads digitizer
+        indices anyway) is mapped by its distinct m/z values and
+        gathered; any other record is mapped point by point. The bins,
+        the mask and the drop count are the same either way -- the
+        mapping is elementwise in the m/z -- so which view a record
+        offers cannot change what a sink sees.
+
+        ``None`` when the frame holds no points.
+        """
+        indexed = getattr(frame, "mobility_points_indexed", None)
+        if indexed is not None:
+            points = indexed()
+            return (
+                None
+                if points is None
+                else map_indexed_points_to_axis(self.axis, *points)
+            )
+        flat = frame.mobility_points()
+        return None if flat is None else map_points_to_axis(self.axis, *flat)
+
     # -- pass 1 ----------------------------------------------------------
 
     def count(self, frame: FrameScans, row: Optional[int]) -> None:
@@ -94,9 +131,8 @@ class SiblingPasses:
         every pixel with points and takes the frame either way.
         """
         if self.wants_mobility:
-            points = frame.mobility_points()
-            if points is not None:
-                mapped = map_points_to_axis(self.axis, *points)
+            mapped = self._mapped_points(frame)
+            if mapped is not None:
                 if self.heatmap is not None:
                     self.heatmap.add_mapped(frame.coords, *mapped)
                 if self.discovery is not None:
@@ -147,11 +183,9 @@ class SiblingPasses:
         if row is None:
             return
         if self.grid_scatter is not None:
-            points = frame.mobility_points()
-            if points is not None:
-                self.grid_scatter.add_mapped_row(
-                    row, *map_points_to_axis(self.axis, *points)
-                )
+            mapped = self._mapped_points(frame)
+            if mapped is not None:
+                self.grid_scatter.add_mapped_row(row, *mapped)
         if self.msms is not None and self.msms.has_rows:
             self.msms.scatter(row, frame.precursor_spectra())
 

--- a/thyra/converters/spatialdata/mobility_heatmap.py
+++ b/thyra/converters/spatialdata/mobility_heatmap.py
@@ -27,7 +27,11 @@ points onto the mass axis once and hands the result to whichever sinks
 were given -- the heatmap, the mobility grid's discovery pass, or both.
 Mapping is the expensive part of the pass (the vendor read is a fifth of
 it), so a grid conversion that fuses its discovery into the heatmap's
-pass pays for it once rather than twice.
+pass pays for it once rather than twice. A frame whose points come
+indexed by their distinct m/z values -- a TDF frame reads as digitizer
+indices, so about three fifths as many distinct values as points -- goes
+through :func:`map_indexed_points_to_axis`, which maps those once and
+gathers for the same bins.
 
 Mobility is a feature coordinate. Nothing here knows where a pixel is.
 """
@@ -148,6 +152,51 @@ def map_points_to_axis(
         if mzs.size == 0:
             return np.zeros(0, dtype=np.int64), mobility, intensities, n_dropped
     return _nn_map_to_bins(axis, mzs).astype(np.int64), mobility, intensities, n_dropped
+
+
+def map_indexed_points_to_axis(
+    axis: NDArray[np.float64],
+    unique_mz: NDArray[np.float64],
+    inverse: NDArray[np.int64],
+    mobility: NDArray[np.float64],
+    intensities: NDArray[np.float64],
+) -> Tuple[NDArray[np.int64], NDArray[np.float64], NDArray[np.float64], int]:
+    """:func:`map_points_to_axis` for points whose m/z is ``unique_mz[inverse]``.
+
+    Both halves of that function are elementwise in the m/z, so both
+    commute with the gather exactly: the nearest bin of
+    ``unique_mz[inverse]`` is the nearest bin of ``unique_mz`` gathered
+    by ``inverse``, and a point is in range exactly when its unique m/z
+    is. Mapping the unique values and gathering therefore gives the same
+    bins, the same mask and the same drop count as mapping every point
+    -- for as many binary searches as the frame has distinct m/z values
+    rather than points, which on a TDF frame is about three fifths.
+
+    A source whose points do not share m/z values keeps
+    :func:`map_points_to_axis`; this is the same mapping, not a second
+    one, and the two are pinned against each other in the tests.
+
+    Returns:
+        What :func:`map_points_to_axis` returns for ``unique_mz[inverse]``.
+    """
+    unique_mz = np.asarray(unique_mz, dtype=np.float64)
+    inverse = np.asarray(inverse)
+    mobility = np.asarray(mobility, dtype=np.float64)
+    intensities = np.asarray(intensities, dtype=np.float64)
+    if inverse.size == 0:
+        return np.zeros(0, dtype=np.int64), mobility, intensities, 0
+    bins = _nn_map_to_bins(axis, unique_mz).astype(np.int64)
+    in_range = (unique_mz >= axis[0]) & (unique_mz <= axis[-1])
+    if in_range.all():
+        return bins[inverse], mobility, intensities, 0
+    kept = in_range[inverse]
+    n_dropped = int(inverse.size - kept.sum())
+    inverse = inverse[kept]
+    mobility = mobility[kept]
+    intensities = intensities[kept]
+    if inverse.size == 0:
+        return np.zeros(0, dtype=np.int64), mobility, intensities, n_dropped
+    return bins[inverse], mobility, intensities, n_dropped
 
 
 class MobilityHeatmap:

--- a/thyra/core/frames.py
+++ b/thyra/core/frames.py
@@ -26,6 +26,12 @@ from numpy.typing import NDArray
 Coords = Tuple[int, int, int]
 Spectrum = Tuple[NDArray[np.float64], NDArray[np.float64]]
 MobilityPoints = Tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]]
+IndexedMobilityPoints = Tuple[
+    NDArray[np.float64],
+    NDArray[np.int64],
+    NDArray[np.float64],
+    NDArray[np.float64],
+]
 PrecursorSpectrum = Tuple[int, NDArray[np.float64], NDArray[np.float64]]
 
 
@@ -49,6 +55,24 @@ class FrameScans(Protocol):
 
     def mobility_points(self) -> Optional[MobilityPoints]:
         """``(mzs, mobility, intensities)`` as ``iter_mobility_spectra`` yields, or ``None``."""
+
+    def mobility_points_indexed(self) -> Optional[IndexedMobilityPoints]:
+        """The same points with the m/z left factored, or ``None`` for no points.
+
+        ``(unique_mz, inverse, mobility, intensities)`` where
+        ``unique_mz[inverse]`` is exactly the ``mzs`` of
+        :meth:`mobility_points`, element for element, and the three other
+        arrays are that method's own. A digitizer reports the points of
+        one frame at far fewer distinct m/z values than it reports
+        points, so a consumer that has to map m/z onto an axis can map
+        ``unique_mz`` once and gather by ``inverse`` for the same bins.
+
+        ``None`` exactly where :meth:`mobility_points` returns ``None``:
+        the frame holds no points. A record whose points do not factor
+        this way does not offer the method at all -- consumers reach for
+        it with :func:`getattr` and fall back to the flat view -- so
+        ``None`` never means "ask the other way".
+        """
 
     def precursor_spectra(self) -> List[PrecursorSpectrum]:
         """``[(window_index, mzs, intensities), ...]`` as ``iter_precursor_spectra`` yields.

--- a/thyra/readers/bruker/timstof/timstof_reader.py
+++ b/thyra/readers/bruker/timstof/timstof_reader.py
@@ -310,6 +310,33 @@ class TdfFrameScans:
             )
             return None
 
+    def mobility_points_indexed(
+        self,
+    ) -> Optional[
+        Tuple[
+            NDArray[np.float64],
+            NDArray[np.int64],
+            NDArray[np.float64],
+            NDArray[np.float64],
+        ]
+    ]:
+        """The point cloud with the m/z left factored (:class:`~thyra.core.frames.FrameScans`).
+
+        ``unique_mz[inverse]`` is :meth:`mobility_points`' ``mzs``: the
+        frame is read as digitizer indices, and this hands over the
+        conversion of the unique ones together with the map back to the
+        points, which is what the reader has anyway.
+        """
+        reader = self._reader
+        try:
+            values, n_axis = reader._mobility_values()
+            return reader._indexed_mobility_points_from(self, values, n_axis)
+        except Exception as e:
+            logger.warning(
+                f"Error reading mobility scans for frame {self.frame_id}: {e}"
+            )
+            return None
+
     def precursor_spectra(
         self,
     ) -> List[Tuple[int, NDArray[np.float64], NDArray[np.float64]]]:
@@ -1325,23 +1352,33 @@ class BrukerReader(BrukerBaseMSIReader):
             raise SDKError("The per-scan 1/K0 axis is not available")
         return axis.values, int(axis.values.size)
 
-    def _mobility_points_from(
+    def _indexed_mobility_points_from(
         self,
         frame: "TdfFrameScans",
         values: NDArray[np.float64],
         n_axis: int,
-    ) -> Optional[Tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]]]:
-        """One frame's ``(m/z, 1/K0, intensity)`` points from its raw read.
+    ) -> Optional[
+        Tuple[
+            NDArray[np.float64],
+            NDArray[np.int64],
+            NDArray[np.float64],
+            NDArray[np.float64],
+        ]
+    ]:
+        """One frame's points as ``(unique m/z, index of each point, 1/K0, intensity)``.
 
-        The one derivation behind :meth:`iter_mobility_spectra` and the
-        frame record's ``mobility_points``: ``tims_index_to_mz`` on the
-        frame's unique indices only, the scan number of each pair turned
-        into ``values[scan]``. ``None`` when the frame holds no points
-        (or none above the intensity threshold).
+        The one derivation behind :meth:`iter_mobility_spectra`, the
+        frame record's ``mobility_points`` and its indexed view:
+        ``tims_index_to_mz`` on the frame's unique indices only, the scan
+        number of each pair turned into ``values[scan]``. The m/z of the
+        points is left as ``unique_mz[inverse]`` rather than expanded,
+        because a consumer that maps m/z onto an axis can map the unique
+        values once and gather -- a TDF frame carries about three fifths
+        as many unique indices as points. ``None`` when the frame holds
+        no points (or none above the intensity threshold).
         """
         if frame.indices.size == 0:
             return None
-        mzs = frame.unique_mz[frame.inverse]
         scans = frame.scans
         if int(scans.max()) >= n_axis and not self._mobility_scan_overflow_warned:
             self._mobility_scan_overflow_warned = True
@@ -1351,18 +1388,36 @@ class BrukerReader(BrukerBaseMSIReader):
                 frame.frame_id,
                 n_axis,
             )
+        inverse = frame.inverse
         mobility = np.take(values, scans, mode="clip")
         intensities = frame.intensities.astype(np.float64)
         if self._intensity_threshold is not None:
             keep = intensities >= self._intensity_threshold
-            mzs, mobility, intensities = (
-                mzs[keep],
+            inverse, mobility, intensities = (
+                inverse[keep],
                 mobility[keep],
                 intensities[keep],
             )
-        if mzs.size == 0:
+        if inverse.size == 0:
             return None
-        return mzs, mobility, intensities
+        return frame.unique_mz, inverse, mobility, intensities
+
+    def _mobility_points_from(
+        self,
+        frame: "TdfFrameScans",
+        values: NDArray[np.float64],
+        n_axis: int,
+    ) -> Optional[Tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]]]:
+        """One frame's ``(m/z, 1/K0, intensity)`` points, the indexed view expanded.
+
+        ``None`` when the frame holds no points (or none above the
+        intensity threshold).
+        """
+        indexed = self._indexed_mobility_points_from(frame, values, n_axis)
+        if indexed is None:
+            return None
+        unique_mz, inverse, mobility, intensities = indexed
+        return unique_mz[inverse], mobility, intensities
 
     def _precursor_scan_map(
         self, windows: Tuple[IsolationWindow, ...]


### PR DESCRIPTION
A TDF frame is read as digitizer indices and the reader converts the unique ones to m/z already: **28,560 unique per 49,070 points** on the 26,087-pixel slide, 58 percent. The sibling tables' mapping is elementwise in the m/z, so mapping the distinct values and gathering by the frame's own inverse gives the same bins, the same mask and the same drop count for 58 percent of the binary searches. Design decision D5 named this as the next lever and left it undone; this takes it.

## What changed

- `FrameScans.mobility_points_indexed()` — an optional indexed view of a frame's point cloud, `(unique_mz, inverse, mobility, intensities)`, implemented on `TdfFrameScans`. The flat `mobility_points()` is now that view expanded, so `iter_mobility_spectra` and both record views come from one derivation.
- `map_indexed_points_to_axis()` beside `map_points_to_axis()` in `mobility_heatmap.py`.
- `SiblingPasses` reaches for the indexed view with `getattr` and falls back to the flat one; the iterators, the standalone passes and the in-memory route are untouched.

## Measured (whole 26,087-pixel slide, warm, local, `--no-optical`; each pair one session)

| | v3.19.0 | this branch | |
|---|---|---|---|
| default, wall | 419.7 s | 343.3 s | -18 % |
| default, pass 1 (maps every point, for the heatmap) | 250.0 s | 171.0 s | -32 % |
| default, pass 2 (no mobility sink) | 136.8 s | 139.4 s | the control |
| `--mobility-grid` at the default axis, wall | 1,201.0 s | 723.9 s | -40 % |
| grid, pass 1 (heatmap + discovery) | 401.2 s | 237.4 s | -41 % |
| grid, pass 2 (grid scatter) | 627.3 s | 356.7 s | -43 % |

The default's second pass has no mobility sink to map for and is unchanged, which is the control that says the gain is the mapping and nothing else.

## Identity

Stores written by v3.19.0 and by this branch, compared array by array:

| pair | verdict |
|---|---|
| 400 frames, `--mobility-grid --streaming true` | IDENTICAL |
| 400 frames, default streaming | IDENTICAL |
| 713-pixel PASEF, `--streaming true` (MS/MS split) | IDENTICAL |
| whole slide, default | IDENTICAL (144 arrays hashed in chunks) |
| whole slide, `--mobility-grid` at the default axis | IDENTICAL (309 arrays) |

X data/indices/indptr with dtypes, `var`, `obs` and `uns` recursively — the heatmap's `counts` and the marginal blocks included.

## Also in this PR: two measurements the design decisions were waiting on

**D4 — the whole slide with the grid at the default axis converts.** 21,101,151 occupied (m/z bin, mobility channel) pairs, 1,627,659,585 non-zeros, 239 of 256 channels, marginal exactly 1.0, an 8.0 GB store. The memory guard neither warned nor refused: 6.5 GB projected against ~90 GB free. The old fixed 20M ceiling refused this same conversion. `VAR_BYTES_PER_FEATURE` was checked on it — 302 bytes per feature measured the way the constant was set, 184 for the `var` frame's own step — and stays at 330.

**D5 — the cold lab-share numbers the entry deferred.** The slide copied to the SMB share, the file pushed out of the machine's standby list so the first read is genuinely cold: 365 s cold against 342 s warm, pass 1 178 s against 170 s. A cold network read is within seconds of a warm local one (171 s for the same pass), so the mapping and not the read is what a conversion of this shape spends its time on.

## Tests

`tests/unit -q`: 2,335 passed. `tests/integration/test_bruker_tdf_synthetic.py -o addopts=""`: 32 passed. New: the indexed mapping pinned against the unindexed one (repeated indices, out-of-range on both sides, all-out-of-range, empty, ties, one mapping call per distinct value); a stub record whose flat view raises, so a completed conversion proves the indexed view was taken, and one without the method that still converts; and the two views of a real TDF frame checked against each other through the vendor library. pre-commit clean, complexity monitor 0.
