### PR TITLE
docs(decisions): the two D7 gaps point at the issues that track them

### DIFF
--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -549,7 +549,7 @@ parallel acquisition repeats them.
 
 (That file grids to 1x1, because the reader builds the grid from laser
 coordinates and a DESI stage records none. That is a separate gap, tracked
-outside this entry; it is not what D7 is about.)
+in #213; it is not what D7 is about.)
 
 ### Decision
 
@@ -614,7 +614,7 @@ per spectrum whatever the source, which is 0.57 GB for this run, while the
 streaming converter's own estimate once running is **74.1 GB** (7,682
 pixels x 2,590,447 bins). Left on `auto` the conversion stays in memory and
 dies at 72 percent asking for a 24.5 GiB array on a 128 GB machine. That
-estimate is a general defect, tracked separately.
+estimate is a general defect, tracked in #214.
 
 The alternative -- forcing the whole run to the profile trace whenever a
 chunk cannot be centroided -- would keep the image whole automatically, but


### PR DESCRIPTION
D7 says of two gaps that they are "tracked outside this entry" and "tracked separately". Neither was, until now. Filed both and pointed the sentences at them.

- #213 -- Waters DESI acquisitions grid to 1x1 (the grid comes from laser positions a DESI stage never moves; a constant position passes the no-positions check and yields a 1x1 raster with a 0.0 um pitch, silently)
- #214 -- `--streaming auto` assumes 10,000 peaks per spectrum whatever the source, under-estimating the D7 profile run 0.57 GB against 74.1 GB and keeping it in memory until it dies at 72 percent

Docs only, two sentences.