### PR TITLE
Refuse a one-pixel Waters grid, fix the raster pitch, and size --streaming auto from the data

### DIFF
--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -624,9 +624,15 @@ every one of the 16 lands on the **same** position. So the two cases
 separate cleanly on the positions: a chunked raster tiles them, a real
 parallel acquisition repeats them.
 
-(That file grids to 1x1, because the reader builds the grid from laser
-coordinates and a DESI stage records none. That is a separate gap, tracked
-outside this entry; it is not what D7 is about.)
+(That file grids to 1x1 -- one unique x, one unique y -- and the reader now
+refuses it rather than converting the whole acquisition onto a single pixel
+with a 0.0 um pitch (issue #213). The refusal is right for this file: it is a
+single-spot DDA run, not an image. It is *not* a DESI gap, as that issue
+first supposed. Surveying the whole share settled it: real DESI images do
+carry stage coordinates in the same laser fields and grid normally --
+401x401, 247x140, 200x63 -- while 76 of the 105 `.raw` dirs there collapse
+to one pixel and every one of those is a calibration, a tuning run, a lysis
+test or a single-spot acquisition. Not one is an image.)
 
 ### Decision
 
@@ -685,13 +691,48 @@ the cost and the flags:
     of centroids: pass --waters-spectrum profile --streaming true to convert
     the whole image.
 
-`--streaming true` is in that sentence because the profile store is large
-and `--streaming auto` does not notice: its estimate assumes 10,000 peaks
-per spectrum whatever the source, which is 0.57 GB for this run, while the
-streaming converter's own estimate once running is **74.1 GB** (7,682
-pixels x 2,590,447 bins). Left on `auto` the conversion stays in memory and
-dies at 72 percent asking for a 24.5 GiB array on a 128 GB machine. That
-estimate is a general defect, tracked separately.
+`--streaming true` is in that sentence because, when it was written,
+`--streaming auto` did not notice how large the profile store is: its
+estimate assumed 10,000 peaks per spectrum whatever the source, which is
+0.57 GB for this run, while the streaming converter's own estimate once
+running is **74.1 GB** (7,682 pixels x 2,590,447 bins). Left on `auto` the
+conversion stayed in memory and died at 72 percent asking for a 24.5 GiB
+array on a 128 GB machine.
+
+That was a general defect, not a Waters one, and it is fixed (issue #214).
+Two things were wrong with the old estimate and both had to go, which the
+measurements below settled:
+
+| what `auto` scores this run at | GB |
+|---|---|
+| the old fixed 10,000 peaks per spectrum, 8 bytes each | 0.57 |
+| the source's own measured width (85,117 points per spectrum), 16 bytes each | 9.7 |
+| the same, against the axis the run is resampled onto (2,590,447 bins) | 296.5 |
+
+The first fix is to stop guessing the width. `total_peaks` divided by the
+spectrum count is *measured* by every extractor, and it is the profile bin
+count on profile data and the peak count on centroided data. The second is
+to count the 16 bytes a value costs the standard converter's COO arrays
+(`int32` row, `int32` column, `float64` value) rather than 8.
+
+Those two alone give 9.7 GB, which is still under the 10 GB threshold --
+so they do not fix this run, and that is why the axis is consulted as well.
+Interpolating a contiguous trace onto an axis 30x finer than it (2,590,447
+bins against 85,117 points) fills the bins in between, and the array the
+conversion died on says by how much: 24.5 GiB of `float64` is 3.3e9 values,
+about 428,000 per spectrum, five times the source width. So a *profile*
+source is sized at the axis it will be written onto and a centroid source
+at its own peak count, since peaks stay peaks and a finer axis does not
+multiply them. The bin count comes from the converter's own planner rather
+than a second copy of that arithmetic, which is what issue #87 was.
+
+This run now scores 296.5 GB and upgrades itself, so `--streaming true` is
+belt-and-braces rather than required. That over-states what the conversion
+really needs -- those 3.3e9 values are about 49 GB across the three COO
+arrays -- and deliberately so: the decision is one-sided, since
+under-estimating keeps a conversion in memory that had to stream and it
+dies there, while over-estimating costs at most a streaming run that would
+also have fit.
 
 The alternative -- forcing the whole run to the profile trace whenever a
 chunk cannot be centroided -- would keep the image whole automatically, but

--- a/tests/unit/metadata/extractors/test_waters_extractor.py
+++ b/tests/unit/metadata/extractors/test_waters_extractor.py
@@ -51,8 +51,9 @@ def _make_grid_and_ml(n_x=3, n_y=2, n_peaks=5):
 
     lateral_width = x_positions[-1] - x_positions[0] if n_x > 1 else 0.0
     lateral_height = y_positions[-1] - y_positions[0] if n_y > 1 else 0.0
-    pixel_size_x = lateral_width / n_x if n_x > 1 else 0.0
-    pixel_size_y = lateral_height / n_y if n_y > 1 else 0.0
+    # Extent over intervals, matching build_imaging_grid; see issue #217.
+    pixel_size_x = lateral_width / (n_x - 1) if n_x > 1 else 0.0
+    pixel_size_y = lateral_height / (n_y - 1) if n_y > 1 else 0.0
 
     grid = ImagingGrid(
         x_index_map=x_index_map,

--- a/tests/unit/readers/test_waters_imaging_grid.py
+++ b/tests/unit/readers/test_waters_imaging_grid.py
@@ -216,20 +216,40 @@ class TestBuildImagingGrid:
         assert grid.pixel_count_y == 1
         assert len(grid.scan_map) == 3  # all scans in map (including no-pos)
 
-    def test_single_pixel_grid(self):
-        """Test grid with only one position."""
-        positions = [(0, 0, 0.5, 0.5)]
+    def test_single_pixel_grid_is_refused(self):
+        """A stage that never moved is a spot acquisition, not an image.
+
+        This used to return a 1x1 grid with a 0.0 um pitch and let the
+        conversion report success with the whole acquisition on one pixel
+        (issue #213). On the Xevo DESI share that is what 76 of 105 .raw
+        dirs look like -- calibrations, tuning runs, single-spot DDA.
+        """
+        positions = [(0, 0, 0.5, 0.5), (0, 1, 0.5, 0.5), (0, 2, 0.5, 0.5)]
+        mock_ml = self._setup_mock_ml(positions)
+        func_types = {0: FunctionType.MS}
+
+        with pytest.raises(ValueError, match="same stage position"):
+            build_imaging_grid(mock_ml, "handle", func_types)
+
+    def test_single_row_grid_is_kept(self):
+        """One line of a raster is real data, and must survive the refusal.
+
+        The share holds aborted line scans (138x1, 48x1) alongside the
+        completed rasters they were retried into. Only a grid that
+        collapses on *both* axes is a spot.
+        """
+        positions = [
+            (0, 0, 0.1, 0.05),
+            (0, 1, 0.2, 0.05),
+            (0, 2, 0.3, 0.05),
+        ]
         mock_ml = self._setup_mock_ml(positions)
         func_types = {0: FunctionType.MS}
 
         grid = build_imaging_grid(mock_ml, "handle", func_types)
 
-        assert grid.pixel_count_x == 1
+        assert grid.pixel_count_x == 3
         assert grid.pixel_count_y == 1
-        assert grid.lateral_width == 0.0
-        assert grid.lateral_height == 0.0
-        assert grid.pixel_size_x == 0.0
-        assert grid.pixel_size_y == 0.0
 
     def test_no_valid_positions_raises(self):
         """Test error when no scans have valid positions."""

--- a/tests/unit/readers/test_waters_imaging_grid.py
+++ b/tests/unit/readers/test_waters_imaging_grid.py
@@ -281,9 +281,12 @@ class TestBuildImagingGrid:
         assert len(grid.scan_map) == 4
 
     def test_pixel_size_calculation(self):
-        """Test that pixel sizes are correctly computed."""
-        # 4 positions: x at 0.1, 0.2, 0.3, 0.4 mm = 100, 200, 300, 400 um
-        # lateral_width = 300 um, pixel_count_x = 4, pixel_size_x = 75 um
+        """The pitch is the extent over the *intervals*, not the positions.
+
+        Four positions 100 um apart are a 100 um raster. Dividing the
+        300 um centre-to-centre span by the position count reported 75 um
+        (issue #217); it is 300 / 3.
+        """
         positions = [
             (0, 0, 0.1, 0.1),
             (0, 1, 0.2, 0.1),
@@ -296,4 +299,45 @@ class TestBuildImagingGrid:
         grid = build_imaging_grid(mock_ml, "handle", func_types)
 
         assert grid.lateral_width == 300.0
-        assert grid.pixel_size_x == 75.0  # 300 / 4
+        assert grid.pixel_size_x == 100.0  # 300 / (4 - 1)
+
+    def test_a_square_raster_is_not_reported_as_anisotropic(self):
+        """The old error was 1/N per axis, so it invented anisotropy.
+
+        A 100 um raster three wide and two tall came out 66.67 x 50.0.
+        Only x reaches the store, so the disagreement never showed.
+        """
+        positions = [
+            (0, 0, 0.1, 0.1),
+            (0, 1, 0.2, 0.1),
+            (0, 2, 0.3, 0.1),
+            (0, 3, 0.1, 0.2),
+            (0, 4, 0.2, 0.2),
+            (0, 5, 0.3, 0.2),
+        ]
+        mock_ml = self._setup_mock_ml(positions)
+        func_types = {0: FunctionType.MS}
+
+        grid = build_imaging_grid(mock_ml, "handle", func_types)
+
+        assert grid.pixel_size_x == 100.0
+        assert grid.pixel_size_y == 100.0
+
+    def test_an_axis_with_one_position_reports_no_pitch(self):
+        """One position has no interval, so 0.0 rather than a made-up number.
+
+        The extractor turns that into ``pixel_size=None``, which becomes
+        the "use --pixel-size" refusal. Aborted single-line scans take
+        this path, so it must not become a division by zero.
+        """
+        positions = [
+            (0, 0, 0.1, 0.05),
+            (0, 1, 0.2, 0.05),
+        ]
+        mock_ml = self._setup_mock_ml(positions)
+        func_types = {0: FunctionType.MS}
+
+        grid = build_imaging_grid(mock_ml, "handle", func_types)
+
+        assert grid.pixel_size_x == 100.0
+        assert grid.pixel_size_y == 0.0

--- a/tests/unit/test_streaming_auto_estimate.py
+++ b/tests/unit/test_streaming_auto_estimate.py
@@ -127,7 +127,16 @@ class TestValuesPerSpectrum:
         assert _values_per_spectrum(meta, 500) == 500
 
     def test_an_unknown_representation_is_treated_as_centroid(self):
-        """The conservative half: it never inflates a source we cannot type."""
+        """Bruker is the source that leaves this unset, and it is sparse.
+
+        No Bruker extractor populates ``spectrum_type``, so this branch is
+        the TDF/TSF path rather than an edge case. Its summed spectra are
+        per-index counts with gaps, which is the centroid case; sizing them
+        densely would send every Bruker conversion to streaming. Measured
+        on two real slides (2026-09-08), the routing is unchanged either
+        way: a 33,800-pixel slide scores 1.17 GB and a 918,855-pixel one
+        28.06 GB, the same side of the threshold as before.
+        """
         meta = _meta((10, 10, 1), total_peaks=2_000 * 100, n_spectra=100)
         assert _values_per_spectrum(meta, 240_794) == 2_000
 

--- a/tests/unit/test_streaming_auto_estimate.py
+++ b/tests/unit/test_streaming_auto_estimate.py
@@ -1,0 +1,220 @@
+"""``--streaming auto`` sizes a conversion from what the source measured.
+
+Issue #214: the estimate assumed 10,000 peaks per spectrum whatever the
+source, which under-counts profile data badly. The mistake falls the unsafe
+way -- ``auto`` keeps the conversion in memory exactly when it should have
+streamed, and it dies there.
+
+The numbers here are measured on the run in that report, 7,682 pixels of
+``180814_EVO_Fresh_image.raw`` read as the profile trace (2026-09-08):
+
+===============================  ==============
+``total_peaks``                  653,947,763
+``n_spectra``                    7,683
+points per spectrum              85,117
+the axis the conversion resamples onto  2,590,447 bins
+===============================  ==============
+
+Both halves are needed. The source width alone estimates 9.7 GB and stays
+under the 10 GB threshold; the run really died holding a 24.5 GiB array,
+because interpolating a contiguous trace onto a 30x finer axis fills the
+bins in between. The axis width is what puts it over.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from thyra.convert import (
+    _ASSUMED_VALUES_PER_SPECTRUM,
+    _resolved_target_bins,
+    _should_use_streaming,
+    _values_per_spectrum,
+)
+from thyra.resampling.constants import SpectrumType, Thresholds
+
+# The Waters profile run from issue #214, as measured.
+_EVO_PIXELS = 7682
+_EVO_POINTS_PER_SPECTRUM = 85_117
+_EVO_TARGET_BINS = 2_590_447
+
+
+def _meta(dimensions, total_peaks, n_spectra, spectrum_type=None):
+    return SimpleNamespace(
+        dimensions=dimensions,
+        total_peaks=total_peaks,
+        n_spectra=n_spectra,
+        spectrum_type=spectrum_type,
+    )
+
+
+def _reader(meta):
+    return SimpleNamespace(get_essential_metadata=lambda: meta)
+
+
+def _probe(target_bins, resampling_config=object()):
+    """A stand-in for the converter whose axis planner is consulted."""
+    return SimpleNamespace(
+        _resampling_config=resampling_config,
+        _resolve_resampling_plan=lambda: (100.0, 1000.0, "tof", target_bins),
+    )
+
+
+class TestResolvedTargetBins:
+    def test_asks_the_converters_own_planner(self):
+        assert _resolved_target_bins(_probe(60_000)) == 60_000
+
+    def test_no_probe_means_no_axis(self):
+        assert _resolved_target_bins(None) is None
+
+    def test_a_conversion_that_resamples_nothing_has_no_axis(self):
+        assert _resolved_target_bins(_probe(60_000, resampling_config=None)) is None
+
+    def test_a_planner_that_cannot_resolve_is_not_fatal(self):
+        """Sizing is best-effort; a refusal here must not fail the run."""
+
+        def boom():
+            raise ValueError("needs the instrument's width law")
+
+        probe = SimpleNamespace(
+            _resampling_config=object(), _resolve_resampling_plan=boom
+        )
+        assert _resolved_target_bins(probe) is None
+
+
+class TestValuesPerSpectrum:
+    def test_uses_the_measured_source_width(self):
+        """``total_peaks`` is measured by every extractor, not guessed."""
+        meta = _meta((10, 10, 1), total_peaks=500_000, n_spectra=100)
+        assert _values_per_spectrum(meta) == 5_000
+
+    def test_rounds_a_fractional_width_up(self):
+        meta = _meta((10, 10, 1), total_peaks=101, n_spectra=100)
+        assert _values_per_spectrum(meta) == 2
+
+    def test_a_profile_source_is_sized_at_the_axis_it_is_written_onto(self):
+        """A trace has no gaps to keep the resampled row sparse."""
+        meta = _meta(
+            (10, 10, 1),
+            total_peaks=_EVO_POINTS_PER_SPECTRUM * 100,
+            n_spectra=100,
+            spectrum_type=SpectrumType.PROFILE,
+        )
+        assert _values_per_spectrum(meta, _EVO_TARGET_BINS) == _EVO_TARGET_BINS
+
+    def test_a_centroid_source_keeps_its_peak_count(self):
+        """Peaks stay peaks -- a finer axis does not multiply them.
+
+        Without this, every resampled centroid conversion would be sized at
+        its dense width and sent to streaming: a 26k-pixel TDF slide on a
+        240k-bin axis would score 93 TB instead of 0.8 GB.
+        """
+        meta = _meta(
+            (10, 10, 1),
+            total_peaks=2_000 * 100,
+            n_spectra=100,
+            spectrum_type=SpectrumType.CENTROID,
+        )
+        assert _values_per_spectrum(meta, 240_794) == 2_000
+
+    def test_a_coarser_axis_can_only_merge_peaks(self):
+        meta = _meta(
+            (10, 10, 1),
+            total_peaks=50_000 * 100,
+            n_spectra=100,
+            spectrum_type=SpectrumType.CENTROID,
+        )
+        assert _values_per_spectrum(meta, 500) == 500
+
+    def test_an_unknown_representation_is_treated_as_centroid(self):
+        """The conservative half: it never inflates a source we cannot type."""
+        meta = _meta((10, 10, 1), total_peaks=2_000 * 100, n_spectra=100)
+        assert _values_per_spectrum(meta, 240_794) == 2_000
+
+    @pytest.mark.parametrize(
+        "total_peaks, n_spectra",
+        [(0, 100), (500, 0), (None, 100), (500, None)],
+    )
+    def test_falls_back_when_the_source_measured_nothing(self, total_peaks, n_spectra):
+        """A Bruker preview handle skips the peak count; do not divide by it."""
+        meta = _meta((10, 10, 1), total_peaks, n_spectra)
+        assert _values_per_spectrum(meta) == _ASSUMED_VALUES_PER_SPECTRUM
+
+    def test_an_unmeasured_source_still_uses_the_axis(self):
+        meta = _meta((10, 10, 1), total_peaks=0, n_spectra=0)
+        assert _values_per_spectrum(meta, 250_000) == 250_000
+
+
+class TestAutoNoticesProfileData:
+    def _evo_meta(self):
+        return _meta(
+            (_EVO_PIXELS, 1, 1),
+            total_peaks=_EVO_PIXELS * _EVO_POINTS_PER_SPECTRUM,
+            n_spectra=_EVO_PIXELS,
+            spectrum_type=SpectrumType.PROFILE,
+        )
+
+    def test_the_waters_profile_run_upgrades_to_streaming(self):
+        """The regression in issue #214, at its measured size."""
+        assert (
+            _should_use_streaming(
+                "auto", _reader(self._evo_meta()), _probe(_EVO_TARGET_BINS)
+            )
+            is True
+        )
+
+    def test_the_old_fixed_guess_would_have_missed_it(self):
+        """Pins the gap so a fixed per-spectrum count cannot come back.
+
+        10,000 peaks per spectrum scored this run at 0.57 GB against a
+        10 GB threshold -- 130x under the streaming converter's own 74.1 GB.
+        """
+        old_estimate_gb = (_EVO_PIXELS * 10_000 * 8) / (1024**3)
+        assert old_estimate_gb < 1
+        assert _values_per_spectrum(self._evo_meta()) == _EVO_POINTS_PER_SPECTRUM
+
+    def test_the_source_width_alone_is_not_enough(self):
+        """Why the axis is consulted at all: 9.7 GB is under the threshold.
+
+        This is the measurement that rejected sizing profile data from
+        ``total_peaks`` alone.
+        """
+        source_only_gb = (_EVO_PIXELS * _EVO_POINTS_PER_SPECTRUM * 16) / (1024**3)
+        assert source_only_gb < Thresholds.STREAMING_SIZE_GB
+        assert _should_use_streaming("auto", _reader(self._evo_meta())) is False
+
+    def test_a_centroid_run_of_the_same_shape_stays_in_memory(self):
+        """The upgrade tracks the data, not the pixel count."""
+        meta = _meta(
+            (_EVO_PIXELS, 1, 1),
+            total_peaks=_EVO_PIXELS * 2_000,
+            n_spectra=_EVO_PIXELS,
+            spectrum_type=SpectrumType.CENTROID,
+        )
+        assert (
+            _should_use_streaming("auto", _reader(meta), _probe(_EVO_TARGET_BINS))
+            is False
+        )
+
+
+class TestUnchangedBehaviour:
+    def test_explicit_settings_never_touch_the_reader(self):
+        def explode():
+            raise AssertionError("must not be called")
+
+        reader = SimpleNamespace(get_essential_metadata=explode)
+        assert _should_use_streaming(True, reader) is True
+        assert _should_use_streaming(False, reader) is False
+
+    def test_a_refusal_still_propagates(self):
+        def refuse():
+            raise ValueError("imzML spectrum 3 declares a m/z array ending at ...")
+
+        with pytest.raises(ValueError, match="spectrum 3"):
+            _should_use_streaming(
+                "auto", SimpleNamespace(get_essential_metadata=refuse)
+            )
+
+    def test_unusable_dimensions_still_fall_back_quietly(self):
+        meta = SimpleNamespace(dimensions=None, total_peaks=10, n_spectra=1)
+        assert _should_use_streaming("auto", _reader(meta)) is False

--- a/thyra/convert.py
+++ b/thyra/convert.py
@@ -1,5 +1,6 @@
 # thyra/convert.py
 import logging
+import math
 import traceback
 import warnings
 from pathlib import Path
@@ -7,6 +8,7 @@ from typing import Any, Dict, Literal, Optional, Tuple, Union
 
 from .core.base_converter import PixelSizeSource
 from .core.registry import detect_format, get_converter_class, get_reader_class
+from .resampling.constants import SpectrumType, Thresholds
 from .utils.windows_paths import prepare_zarr_output_path
 
 logger = logging.getLogger(__name__)
@@ -199,13 +201,120 @@ def _determine_pixel_size(
     return final_pixel_size, PixelSizeSource.AUTO_DETECTED, pixel_size_detection_info
 
 
-def _should_use_streaming(streaming: Union[bool, Literal["auto"]], reader: Any) -> bool:
+#: Bytes one stored value costs the standard converter. It pre-allocates
+#: parallel COO arrays -- int32 row, int32 column, float64 intensity (see
+#: ``spatialdata_2d_converter._create_sparse_matrix_for_slice``) -- so a
+#: value costs 16 bytes there, not the 8 the estimate used to count. That
+#: allocation is what ``auto`` is deciding about, so it is what gets counted.
+_BYTES_PER_STORED_VALUE = 16
+
+#: Values per spectrum assumed when the source reports neither a peak count
+#: nor a spectrum count. A last resort: every extractor measures
+#: ``total_peaks``, so this is reached by a Bruker handle built with
+#: ``skip_total_peaks`` and little else.
+_ASSUMED_VALUES_PER_SPECTRUM = 10000
+
+
+def _resolved_target_bins(probe: Any) -> Optional[int]:
+    """The bin count the converter's axis planner will actually choose.
+
+    Asked of a converter instance rather than recomputed here, because
+    ``target_bins`` is set only when the caller passed ``--resample-bins``;
+    the default derives the count from a bin width at a reference m/z, on
+    a law that depends on the axis type the decision tree picks. Issue #87
+    was a second copy of that arithmetic drifting from the first, so this
+    calls the one implementation instead of growing a third.
+
+    Args:
+        probe: A converter instance, or ``None``.
+
+    Returns:
+        The resolved bin count, or ``None`` when the conversion resamples
+        nothing or the plan cannot be resolved without reading the file.
+    """
+    if probe is None or getattr(probe, "_resampling_config", None) is None:
+        return None
+    try:
+        _min_mz, _max_mz, _axis_type, target_bins = probe._resolve_resampling_plan()
+    except Exception as e:  # pragma: no cover - depends on the source file
+        logger.debug(f"Could not resolve the resampling plan for auto-streaming: {e}")
+        return None
+    return int(target_bins) if target_bins else None
+
+
+def _values_per_spectrum(
+    essential_meta: Any,
+    target_bins: Optional[int] = None,
+) -> int:
+    """How many values one converted spectrum will hold.
+
+    Two numbers decide this, and which one wins depends on whether the
+    source is profile or centroid:
+
+    * **The source's own width**, ``total_peaks / n_spectra``. This is
+      *measured*, not guessed -- Waters and PHI scan the spectra, imzML
+      reads the array lengths, Bruker sums ``NumPeaks``. It is the profile
+      bin count on profile data and the peak count on centroided data. A
+      fixed 10,000 stood in for it before issue #214.
+    * **The resampled axis width**, when the conversion resamples. Onto a
+      finer axis an interpolating method fills the bins between the source
+      points, so a *contiguous* profile trace approaches the axis width,
+      while centroided peaks stay peaks with gaps between them and do not.
+
+    So a profile source is sized at the axis it will be written onto and a
+    centroid source at its own peak count, each capped by the other where
+    that is the smaller. Measured on the issue #214 run
+    (``180814_EVO_Fresh_image.raw`` as a profile trace): 85,117 points per
+    spectrum against a 2,590,447-bin axis, and the conversion died holding
+    a 24.5 GiB array -- about 428,000 values per spectrum, five times the
+    source width. The source width alone estimates 9.7 GB and stays under
+    the threshold; the axis width is what puts it over.
+
+    Args:
+        essential_meta: The reader's ``EssentialMetadata``.
+        target_bins: The resampled axis width, from
+            :func:`_resolved_target_bins`, or ``None`` when nothing is
+            resampled.
+
+    Returns:
+        Values per spectrum.
+    """
+    total_peaks = getattr(essential_meta, "total_peaks", None) or 0
+    n_spectra = getattr(essential_meta, "n_spectra", None) or 0
+    source_width = (
+        math.ceil(total_peaks / n_spectra)
+        if total_peaks > 0 and n_spectra > 0
+        else None
+    )
+
+    if target_bins is None:
+        return source_width or _ASSUMED_VALUES_PER_SPECTRUM
+    if source_width is None:
+        return target_bins
+
+    spectrum_type = getattr(essential_meta, "spectrum_type", None)
+    if spectrum_type == SpectrumType.PROFILE:
+        # A trace has no gaps to keep the resampled row sparse.
+        return max(source_width, target_bins)
+    # Peaks stay peaks; a coarser axis can only merge them.
+    return min(source_width, target_bins)
+
+
+def _should_use_streaming(
+    streaming: Union[bool, Literal["auto"]],
+    reader: Any,
+    probe: Any = None,
+) -> bool:
     """Determine if streaming converter should be used.
 
     Args:
         streaming: True to force streaming, False to force the standard
             converter, ``"auto"`` to pick on estimated size.
         reader: The reader for the input.
+        probe: An instance of the converter that would otherwise run, used
+            to resolve the resampled axis width. ``None`` sizes the
+            conversion from the source alone, which under-counts a profile
+            source that will be resampled onto a finer axis.
 
     Returns:
         True if the streaming converter should be used.
@@ -227,24 +336,41 @@ def _should_use_streaming(streaming: Union[bool, Literal["auto"]], reader: Any) 
     # progress with the real reason invisible.
     essential_meta = reader.get_essential_metadata()
 
-    # Auto-detect based on estimated dataset size (>10GB). Only the estimate
+    # Auto-detect based on estimated in-memory size. Only the estimate
     # itself is best-effort: a reader whose dimensions are missing or oddly
     # shaped simply does not get the automatic upgrade.
+    #
+    # Sizing the grid rather than the spectrum count is deliberate: a sparse
+    # raster has fewer spectra than pixels, and over-estimating is the safe
+    # direction. The whole decision is one-sided -- under-estimating keeps a
+    # conversion in memory that needed to stream and it dies there, while
+    # over-estimating costs at most a streaming run that would also have fit.
     try:
         dims = essential_meta.dimensions
         n_pixels = dims[0] * dims[1] * dims[2]
-        # Rough estimate: assume average 10k peaks per spectrum, 8 bytes each
-        estimated_gb = (n_pixels * 10000 * 8) / (1024**3)
+        per_spectrum = _values_per_spectrum(
+            essential_meta, _resolved_target_bins(probe)
+        )
+        estimated_gb = (n_pixels * per_spectrum * _BYTES_PER_STORED_VALUE) / (1024**3)
     except Exception as e:
         logger.debug(f"Could not estimate dataset size for auto-streaming: {e}")
         return False
 
-    if estimated_gb > 10:
+    threshold = Thresholds.STREAMING_SIZE_GB
+    detail = (
+        f"{n_pixels:,} pixels x {per_spectrum:,} values per spectrum "
+        f"x {_BYTES_PER_STORED_VALUE} bytes"
+    )
+    if estimated_gb > threshold:
         logger.info(
-            f"Auto-detected large dataset (~{estimated_gb:.1f} GB), "
+            f"Auto-detected large dataset (~{estimated_gb:.1f} GB: {detail}), "
             "using streaming converter"
         )
         return True
+    logger.info(
+        f"Estimated in-memory size ~{estimated_gb:.1f} GB ({detail}), at or "
+        f"below the {threshold} GB threshold -- using the standard converter"
+    )
     return False
 
 
@@ -280,9 +406,23 @@ def _create_converter(
         **kwargs,
     }
 
+    converter_class = _resolve_converter_class(format_type)
+
+    # On the "auto" path, size the conversion against the axis it will
+    # actually write. Only the converter's own planner knows that width --
+    # ``target_bins`` is usually None and the real count comes from a bin
+    # width on a law the decision tree picks -- so an instance is built to
+    # ask it. Construction only sets attributes (nothing touches
+    # ``output_path`` before ``convert()``), and when the estimate stays
+    # under the threshold this same instance is the converter returned, so
+    # the probe is free in the common case.
+    probe = None
+    if streaming == "auto":
+        probe = converter_class(reader, output_path, **converter_kwargs)
+
     # Try streaming converter if requested
     if (
-        _should_use_streaming(streaming, reader)
+        _should_use_streaming(streaming, reader, probe)
         and "spatialdata" in format_type.lower()
     ):
         try:
@@ -296,9 +436,17 @@ def _create_converter(
             logger.warning(f"Streaming converter not available: {e}")
             logger.warning("Falling back to standard converter")
 
+    if probe is not None:
+        return probe
+    return converter_class(reader, output_path, **converter_kwargs)
+
+
+def _resolve_converter_class(format_type: str) -> Any:
+    """The converter class for ``format_type``, with the SpatialData hint."""
     try:
         converter_class = get_converter_class(format_type.lower())
         logger.info(f"Using converter: {converter_class.__name__}")
+        return converter_class
     except ValueError as e:
         if "spatialdata" in format_type.lower():
             logger.error(
@@ -311,7 +459,6 @@ def _create_converter(
             raise ValueError("SpatialData converter unavailable") from e
         else:
             raise e
-    return converter_class(reader, output_path, **converter_kwargs)
 
 
 def _perform_conversion_with_cleanup(converter: Any, reader: Any) -> bool:

--- a/thyra/readers/waters/imaging_grid.py
+++ b/thyra/readers/waters/imaging_grid.py
@@ -28,10 +28,10 @@ class ImagingGrid:
     y_index_map: Dict[float, int]  # position (um) -> 0-based y index
     pixel_count_x: int
     pixel_count_y: int
-    pixel_size_x: float  # in micrometers
-    pixel_size_y: float  # in micrometers
-    lateral_width: float  # max_x - min_x in micrometers
-    lateral_height: float  # max_y - min_y in micrometers
+    pixel_size_x: float  # raster pitch in um; 0.0 when the axis has one position
+    pixel_size_y: float  # raster pitch in um; 0.0 when the axis has one position
+    lateral_width: float  # max_x - min_x in um, so centre-to-centre, not edge-to-edge
+    lateral_height: float  # max_y - min_y in um, so centre-to-centre, not edge-to-edge
     scan_map: Dict[Tuple[int, int], ScanInfoData] = field(repr=False)
 
     @property
@@ -157,14 +157,28 @@ def build_imaging_grid(
             f"image -- Thyra has no raster to build from it."
         )
 
-    # Calculate pixel sizes (from ImagingMetadata.java lines 146-148)
+    # Laser positions are pixel *centres*, so the span from the first to the
+    # last is N - 1 pitches, not N. This used to divide by the count, which
+    # mixed a centre-to-centre extent with an edge-to-edge one and reported
+    # a pitch low by exactly 1/N -- independently per axis, so a square
+    # raster came out anisotropic: measured, a 30 um acquisition gave
+    # 29.66 x 28.93 and a 100 um one gave 99.40 x 97.83. Nothing caught it
+    # because _determine_pixel_size keeps only x, so the disagreement
+    # between the two axes never reached anywhere it would look wrong.
+    # See issue #217. (mzmine, which this file translates, computes the
+    # extent the other way round -- lateralWidth = count * pixelWidth -- and
+    # has the divide-by-count form commented out in ImagingParameters.java.)
+    #
+    # An axis with a single position has no interval to measure, and keeps
+    # 0.0: waters_extractor turns that into pixel_size=None, which becomes
+    # the actionable "Pixel size not found in metadata. Use --pixel-size"
+    # refusal rather than a fabricated number. Aborted single-line scans
+    # (the share holds 138x1 and 48x1) take that path.
     lateral_width = sorted_x[-1] - sorted_x[0] if pixel_count_x > 1 else 0.0
     lateral_height = sorted_y[-1] - sorted_y[0] if pixel_count_y > 1 else 0.0
 
-    pixel_size_x = lateral_width / pixel_count_x if pixel_count_x > 1 else lateral_width
-    pixel_size_y = (
-        lateral_height / pixel_count_y if pixel_count_y > 1 else lateral_height
-    )
+    pixel_size_x = lateral_width / (pixel_count_x - 1) if pixel_count_x > 1 else 0.0
+    pixel_size_y = lateral_height / (pixel_count_y - 1) if pixel_count_y > 1 else 0.0
 
     logger.info(
         f"Built imaging grid: {pixel_count_x}x{pixel_count_y} pixels, "

--- a/thyra/readers/waters/imaging_grid.py
+++ b/thyra/readers/waters/imaging_grid.py
@@ -96,6 +96,11 @@ def build_imaging_grid(
 
     Returns:
         ImagingGrid with coordinate maps and pixel metadata.
+
+    Raises:
+        ValueError: If no scan carries a laser position, or if every
+            positioned scan carries the *same* one -- a single-pixel
+            "raster" is a spot acquisition, not an image.
     """
     x_positions: set = set()
     y_positions: set = set()
@@ -130,6 +135,27 @@ def build_imaging_grid(
 
     pixel_count_x = len(sorted_x)
     pixel_count_y = len(sorted_y)
+
+    # A stage that never moved is not a raster. The check above only catches
+    # the total absence of positions; a *constant* position passes it, and
+    # everything downstream then agrees the run is a legitimate 1x1 image
+    # with a 0.0 um pitch (lateral extent is 0, so both pixel sizes below
+    # come out 0.0) and converts the whole acquisition onto one pixel
+    # without a word. Measured on the Xevo DESI share, 76 of 105 .raw dirs
+    # land here -- every one of them a calibration, a tuning run, a lysis
+    # test or a single-spot DDA acquisition, and not one of them an image.
+    # Real DESI images on that same share do carry stage coordinates in
+    # these fields and grid normally (401x401, 247x140, ...), so this
+    # refuses the non-images without costing anything real. See issue #213.
+    if pixel_count_x == 1 and pixel_count_y == 1:
+        raise ValueError(
+            f"Every positioned scan reports the same stage position "
+            f"(x={sorted_x[0]:.1f} um, y={sorted_y[0]:.1f} um), so this "
+            f"acquisition has a single pixel: {total_scans} positioned scans "
+            f"in {len(scan_map)} total. A one-pixel raster with a 0.0 um "
+            f"pitch is a spot, calibration or tuning acquisition, not an "
+            f"image -- Thyra has no raster to build from it."
+        )
 
     # Calculate pixel sizes (from ImagingMetadata.java lines 146-148)
     lateral_width = sorted_x[-1] - sorted_x[0] if pixel_count_x > 1 else 0.0

--- a/thyra/readers/waters/waters_reader.py
+++ b/thyra/readers/waters/waters_reader.py
@@ -227,15 +227,10 @@ class WatersReader(BaseMSIReader):
             candidates, self._imaging_grid
         )
 
-        # Verify the grid has more than one position (otherwise not really imaging)
-        if (
-            self._imaging_grid.pixel_count_x <= 1
-            and self._imaging_grid.pixel_count_y <= 1
-        ):
-            logger.warning(
-                "Imaging grid has only 1 pixel -- this may not be true imaging data. "
-                "Proceeding anyway."
-            )
+        # A single-pixel grid is refused by build_imaging_grid() above rather
+        # than warned about here: "this may not be true imaging data,
+        # proceeding anyway" produced a 1x1 store with a 0.0 um pitch and
+        # reported success, which is the defect in issue #213.
 
         logger.info(
             f"Initialized Waters reader: {self.data_path.name}, "


### PR DESCRIPTION
Fixes the three most recent issues. They are independent, but all three
surfaced from the same D7 investigation, and two of them touch the same
function, so they ride together rather than as a conflict-prone stack.

## #213 -- a Waters acquisition whose stage never moved

`build_imaging_grid` only refused when *no* scan carried a laser position.
A **constant** position passed that check: the grid came out 1x1, both
pixel sizes came out 0.0 um, the whole acquisition was converted onto a
single pixel, and the run reported success. The reader logged "may not be
true imaging data. Proceeding anyway" and proceeded.

**The premise in the issue did not survive being checked.** It supposed a
DESI stage records no coordinates and that the fix would have to find them
somewhere else (`_extern.inf`, the scan headers). Surveying all 105 `.raw`
dirs on the Xevo DESI share says otherwise:

- Real DESI **images** carry stage positions in the same laser fields the
  reader already reads, and grid normally -- 401x401, 247x140, 200x63, and
  150x27 at exactly the 50 um pitch its filename declares.
- **76 of the 105** collapse to one pixel, and every one of those is a
  calibration, a tuning run, a lysis test or a single-spot DDA
  acquisition. Not one is an image.

So there is no second coordinate source to go hunting for, and the fix is
only the refusal. A collapse on *both* axes is refused; a single row is
not, because the share holds aborted line scans (138x1, 48x1) next to the
completed rasters they were retried into, and those are real data.

Verified against the share: the spot files now refuse with the position
and scan count named, and `...01ulmin2 Analyte 1.raw` still converts at
(138, 1, 1).

## #214 -- `--streaming auto` under-counting profile data

The estimate assumed 10,000 peaks per spectrum whatever the source, at 8
bytes each. Measured on `180814_EVO_Fresh_image.raw` read as the profile
trace, three numbers decided the shape of the fix:

| what `auto` scores that run at | GB |
|---|---|
| the old fixed 10,000 peaks per spectrum, 8 bytes each | 0.57 |
| its measured width (85,117 points per spectrum), 16 bytes each | 9.7 |
| the same, against the axis it is resampled onto (2,590,447 bins) | 296.5 |

**The obvious fix alone does not work, which is why this is bigger than it
looks.** Replacing the guess with `total_peaks / n_spectra` -- measured by
every extractor -- and counting the 16 bytes a value really costs the
standard converter's COO arrays gives 9.7 GB, still under the 10 GB
threshold. The reported run would still have stayed in memory and died.

So the axis is consulted too. Interpolating a contiguous trace onto an axis
30x finer fills the bins between its points: the 24.5 GiB array the run
died on is 3.3e9 values, ~428,000 per spectrum against the source's 85,117.
A **profile** source is therefore sized at the axis it will be written
onto, and a **centroid** source at its own peak count -- peaks stay peaks,
and sizing centroids densely would send a 26k-pixel TDF slide to streaming
at a fictional 93 TB instead of 0.8 GB.

The bin count is asked of the converter's own planner rather than
recomputed, since a second copy of that arithmetic drifting from the first
is exactly what #87 was. `target_bins` is set only when the caller passed
`--resample-bins`, so the standard converter is built first and asked.
Construction only sets attributes and `get_essential()` is cached on the
extractor the reader shares, so the probe costs nothing -- and when the
estimate stays under the threshold it *is* the converter returned.

The estimate errs high by design: the decision is one-sided, since
under-counting kills a conversion and over-counting costs at most a
streaming run that would also have fit.

Verified end to end on the reported file: it now resolves 2,590,447 bins,
scores 296.5 GB, and picks `StreamingSpatialDataConverter`.

## #217 -- the Waters raster pitch

`build_imaging_grid` divided the raster extent by the position *count*.
Laser positions are pixel centres, so the span from the first to the last
is `N - 1` pitches, not `N`: the old arithmetic mixed a centre-to-centre
extent with an edge-to-edge one and reported `pitch * (N - 1) / N`.

The error applied per axis, so it also **invented anisotropy** -- and that
is why nothing ever caught it. `_determine_pixel_size` keeps only the x
value, so the two axes never disagreed anywhere visible.

Measured against acquisitions whose true pitch is the round number their
method declares:

| acquisition | grid | before | after |
|---|---|---|---|
| 30 um raster | 87x28 | 29.66 x 28.93 | **30.00 x 30.00** |
| 50 um raster | 150x36 | 49.67 x 48.61 | **50.00 x 50.00** |
| 500 um raster | 60x33 | 491.67 x 484.85 | **500.00 x 500.00** |
| 100 um MALDI, Synapt G1 | 167x46 | 99.40 x 97.83 | **100.00 x 100.00** |

The last one is MALDI, so this was never DESI-specific -- it is every
Waters imaging acquisition, and the share holds 7,486 `.raw` dirs.

An axis with one position has no interval and still reports 0.0, which the
extractor turns into `pixel_size=None` and the "use `--pixel-size`"
refusal. The single-line scans kept by #213 take that path, and now report
their real 30 um pitch on x.

Checking the reference the code cited: mzmine computes the extent the
other way round (`lateralWidth = count * pixelWidth`) and has the
divide-by-count form commented out, so it did not call for the old
arithmetic.

**Worth a reviewer's attention:** this changes the pixel size recorded for
every Waters store. An old store cannot be told from a new one except by
the version that wrote it. I did *not* mark it a `BREAKING CHANGE` -- that
would take semantic-release to 4.0.0, and the repo shipped a larger data
change (#208, every TDF store's numbers) as a minor. It is a `fix:`, so a
patch bump, with the warning in the commit body and so in the changelog.
Say the word if you want it released differently.

## Notes
The estimate moves in both directions, since the old fixed 10,000 also
*over*-stated centroid widths. Measured on two real Bruker slides, the
routing does not move: 33,800 pixels goes from 2.52 GB to 1.17 GB and stays
on the standard converter, and 918,855 pixels goes from 110.22 GB to
28.06 GB and still streams. No Bruker extractor sets `spectrum_type`, so
TDF/TSF takes the centroid branch, which is right -- its summed spectra are
per-index counts with gaps.


- The Waters warning still advises `--waters-spectrum profile --streaming
  true`. That is now belt-and-braces rather than required; it is left
  alone as still-correct advice.
- `--streaming auto`'s estimate still cannot see a resampled axis whose
  bin count comes from a width rather than `--resample-bins` when the
  probe cannot be built; it errs high everywhere it can.

2374 unit tests pass. The grid refusal replaces the test that pinned the
old 1x1 behaviour with one for the refusal and one for the single-row
case that has to survive it; the estimate gets a new file of 22.




