### PR TITLE
docs: refer to datasets by registry name, not by lab-share path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,9 @@ benchmarks/test_*.py
 
 # Virtual environment (uv creates it in-project by default)
 .venv/
+
+# Dataset registry, if a copy is ever placed in the repo. The real one lives
+# at ~/.msi-datasets.toml, outside every checkout, so it cannot be committed;
+# this is insurance against a copy landing here.
+.msi-datasets.toml
+datasets.toml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,39 @@
 # exemption guards the staging side of the same hazard; this guards the
 # worktree side.
 repos:
+  # Lab-share paths must not reach a public repo.
+  #
+  # Every identifying string this repo has ever leaked -- four colleagues'
+  # names, a specimen filename, the share layout -- arrived as a component of
+  # a path, because a path is how a note points at a dataset. So the guard is
+  # on the path shape, not on a list of names: a denylist of real names would
+  # have to be committed here, which republishes the very thing it removes.
+  #
+  # Datasets are referred to by the names in ~/.msi-datasets.toml instead.
+  # That file is in the home directory, outside every repo, so it cannot be
+  # committed by accident.
+  #
+  # A path written in prose uses single separators; a path inside source is
+  # escaped and doubles them. Requiring a single separator is what tells the
+  # two apart, so the fixtures in tests/unit/utils/test_windows_paths.py do
+  # not trip it. The drive letter must be uppercase, which is the convention
+  # in a real path and keeps the hook off Python slices such as "if a:"
+  # followed by an escape.
+  #
+  # A UNC branch was tried and dropped: it matched every escaped newline in
+  # the notebooks and caught nothing real, and no leak here arrived by UNC.
+  #
+  # docs/getting-started.md is exempt because documenting Windows path
+  # handling is that page's subject; its paths are generic placeholders.
+  - repo: local
+    hooks:
+      - id: no-lab-share-paths
+        name: no lab-share paths in tracked files
+        language: pygrep
+        entry: '\b[A-Z]:\\(?!\\)[A-Za-z0-9_]'
+        types: [text]
+        exclude: ^docs/getting-started\.md$
+
   # Basic file formatting and checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -239,10 +239,10 @@ ion current: `current_ratio` 0.9717425865942857 against
 
 ### The share census
 
-Every `analysis.tdf` under `V:\Instruments` and `V:\Users` was opened
-read-only and asked what it is: **1,021** of them, plus the nine in the
-local corpus. `V:\Instruments\TimsTOF` holds 25 -- most `.d` folders there
-are TSF, TIMS off -- and the other twenty instrument directories hold none.
+Every `analysis.tdf` on the lab share was opened read-only and asked what it
+is: **1,021** of them, plus the nine in the local corpus. The share's timsTOF
+instrument directory holds 25 -- most `.d` folders there are TSF, TIMS off --
+and the other twenty instrument directories hold none.
 Of the 1,021, 230 are imaging acquisitions (they have `MaldiFrameInfo`) and
 95 carry `PasefFrameMsMsInfo`, but only **six are both**, and those six are
 the four positive-mode files above (two of them duplicate copies) plus the
@@ -253,9 +253,9 @@ tables -- a clean conversion failure, not a crash.
 Their *schedules* are still worth reading, and reading them exercised two
 refusals no real file had reached before.
 
-- **Data-dependent PASEF.** `V:\Users\Cillero-Pastor_Berta\Pereira_Betzabeth\TIMS TOF 2 PRO\20260313`
-  holds fourteen DDA runs on a timsTOF Pro 2. One
-  (`260313_BP_26_DDA_S2-G10_1_741.d`) has 1,840 survey and 9,912 fragment
+- **Data-dependent PASEF.** The datasets registered as `tims_dda_pro2_2026`
+  are fourteen DDA runs on a timsTOF Pro 2. One
+  (`tims_dda_pro2_2026_741`) has 1,840 survey and 9,912 fragment
   frames and **14,952 distinct isolation windows, each in 1 to 8 frames**;
   across the share the count reaches 90,915. The precursors are chosen per
   frame, so there is no global feature axis, and the windows overlap on the
@@ -567,8 +567,8 @@ written to read. It cannot say what the field **means**.
 
 ### What the real files say
 
-7,486 Waters `.raw` directories were found on the lab share (the six Waters
-instrument folders under `V:\Instruments`, plus `V:\Users\Cuypers_Eva`);
+7,486 Waters `.raw` directories were found on the lab share (its six Waters
+instrument folders, plus one user directory);
 1,396 hold more than one `_FUNC*.DAT`, and the multi-function ones were
 opened. **Every multi-function MALDI imaging run is a single-function raster
 that MassLynx split across functions**, because it caps a `_FUNC*.DAT` file
@@ -615,7 +615,8 @@ is why.
 
 **One real multi-function acquisition was found**, and it is what makes the
 rule below decidable rather than a guess:
-`Xevo DESI\Pierre\DESI_PIMAX.PRO\Data\20191107_fastDDA_neg_002.raw`. Its
+the dataset registered as `waters_dda_neg_16func`, a fast-DDA run on a Xevo
+DESI. Its
 `_extern.inf` declares **16** functions -- one "TOF FAST DDA FUNCTION" and
 15 "TOF SURVEY FUNCTION"s -- against the one function the chunked files
 declare. Function 0 is MS1 with no precursor; functions 1 to 15 are level 2
@@ -712,7 +713,7 @@ artefact above, and reads as MS1.
 | `180814_EVO_Fresh_image.raw` converted, default centroid | 6,408 pixels against v3.19.0's 3,200, no duplicate coordinates, no empty pixel, `ms_functions [0, 1]`, `excluded_functions["2"]` carrying `n_unique_pixels 1274` and its reason, `fragmentation` MS1. The TIC image is continuous across the chunk boundary at row 19 |
 | the same run with `--waters-spectrum profile --streaming true --resample-bins 60000` | all three chunks, **7,682 pixels** -- the whole 167 x 46 raster, no duplicate coordinate, no empty pixel -- and the TIC image is continuous across both chunk boundaries, so the band above was the representation and nothing else. 109M non-zeros, 870 MB. The axis was coarsened only to keep the store off a full disk; the default axis is the 74.1 GB estimate above |
 | `20170818_08.raw`, a real single-precursor MS/MS run | `fragmentation` MS level 2, one window at m/z 377.4, collision energy 35.0, CID; the converter declines a demultiplexed table because one precursor needs none |
-| `20191107_fastDDA_neg_002.raw`, the real DDA run | functions 1 to 15 recorded under `excluded_functions` with their per-scan precursors, function 0 converted, `fragmentation` MS1 |
+| `waters_dda_neg_16func`, the real DDA run | functions 1 to 15 recorded under `excluded_functions` with their per-scan precursors, function 0 converted, `fragmentation` MS1 |
 | every file in the table above | no two converted functions share a pixel, and converted plus recorded pixels equal the file's distinct laser positions |
 
 ### Objections considered

--- a/handouts/loose-ends-after-scils-alignment.md
+++ b/handouts/loose-ends-after-scils-alignment.md
@@ -43,10 +43,10 @@ have, and the pin situation is looser than "loose".
 
 ### What is actually installed
 
-Measured in `C:\Users\P70078823\Desktop\Ousia\backend\.venv`:
+Measured in `<ousia-checkout>/backend/.venv`:
 
 ```
-thyra code path : C:\Users\P70078823\Desktop\Thyra\thyra\__init__.py
+thyra code path : <thyra-checkout>/thyra/__init__.py
 thyra version   : 2.2.3
 spatialdata     : 0.7.0a1.dev62+gbfd2b5fac   thyra 2.x needs >=0.8.0, <0.9   VIOLATED
 anndata         : 0.13.0.dev62+g3c90d3cc2    thyra 2.x needs >=0.13.2, <0.14 VIOLATED
@@ -369,7 +369,7 @@ walking up from the working directory, and a worktree has its own
 uv run pytest -q
 ```
 
-**Reproducing item 1's violation**, from `C:\Users\P70078823\Desktop\Ousia\backend`:
+**Reproducing item 1's violation**, from `<ousia-checkout>/backend`:
 
 ```bash
 ./.venv/Scripts/python.exe -c "
@@ -379,7 +379,7 @@ print(spatialdata.__version__, anndata.__version__, zarr.__version__)"
 ```
 
 **Real data** lives outside every worktree, at
-`C:\Users\P70078823\Desktop\Thyra\test_data`: `bellini.imzML` (IONTOF TOF-SIMS,
+`<thyra-checkout>/test_data`: `bellini.imzML` (IONTOF TOF-SIMS,
 profile, 16,384 spectra), `pea.imzML` (SCiLS/Bruker flex, centroid),
 `20240826_xenium_0041899.imzML`, and two timsTOF `.d` folders. All five route
 to `nearest_neighbor`.

--- a/handouts/resampling-scils-alignment.md
+++ b/handouts/resampling-scils-alignment.md
@@ -316,7 +316,7 @@ uv run python <script.py>
 ```
 
 **Real data lives outside the worktree**, at
-`C:\Users\P70078823\Desktop\Thyra\test_data`. A previous investigation missed
+`<thyra-checkout>/test_data`. A previous investigation missed
 it entirely by searching only the worktree, and reached the wrong conclusion
 as a result. Inventory, with what Thyra's real decision tree selects:
 

--- a/tests/unit/readers/test_bruker_reader_comprehensive.py
+++ b/tests/unit/readers/test_bruker_reader_comprehensive.py
@@ -394,7 +394,7 @@ class BrukerReaderTester:
 def main():
     """Main test function."""
     # Test data path - update this to your actual test data
-    test_data_path = r"C:\Users\tvisv\Downloads\MSIConverter\20231109_PEA_NEDC_bruker.d"
+    test_data_path = "test_data/bruker.d"
 
     if not Path(test_data_path).exists():
         print(f"❌ Test data not found at: {test_data_path}")

--- a/tests/unit/readers/test_waters_instrument.py
+++ b/tests/unit/readers/test_waters_instrument.py
@@ -48,7 +48,7 @@ MRT_HEADER = (
     "$$ Cal Function 1: 0.000000000000000E+00,1.000000000000000E+00,T1\n"
 )
 SYNAPT_EXTERN = (
-    "Parameters for E:\\Britt.PRO\\Acqudb\\synapt on MALDI MS.exp\n"
+    "Parameters for E:\\MassLynx.PRO\\Acqudb\\synapt on MALDI MS.exp\n"
     "Created by 4.1 SCN957\n"
     " \n"
     "Instrument Configuration:\n"


### PR DESCRIPTION
Six identifying strings had reached this public repo. Four are served live
right now from the docs site and its search index.

## What was exposed

| where | what |
|---|---|
| `docs/design-decisions.md` (live on the site) | the share census directory listing, and three colleagues names as path components |
| `docs/design-decisions.md` (live on the site) | a specimen filename, cited twice |
| `tests/unit/readers/test_waters_instrument.py` | a fourth colleague name inside an `_extern.inf` fixture |
| `tests/unit/readers/test_bruker_reader_comprehensive.py` | an old username and a dataset filename |
| `handouts/*.md` (2 files) | local checkout paths carrying the operator Windows username |

Every one of them arrived as a component of a path, because a path is how a
note points at a dataset.

## What changes

Datasets get names. The mapping lives in `~/.msi-datasets.toml`, in the home
directory and outside every checkout, so a real path cannot be committed by
accident. Prose refers to the name: the DDA evidence file is
`waters_dda_neg_16func` in both places it is cited, and the share census
keeps all of its numbers while dropping its directory listing.

The `no-lab-share-paths` pre-commit guard matches the path *shape*, not a
list of names -- committing the names in order to catch the names would
republish exactly what this removes. It distinguishes prose paths (single
separator) from escaped paths in source (doubled), so the Windows-path
fixtures and the `\\?\` documentation do not trip it. It passes on the tree
as it stands.

The `_extern.inf` fixture rename is safe: the assertions read `Resolution`,
`Lteff` and `Pusher Cycle Time`, never the header line that held the name.

## What is deliberately not done

Git history is untouched. The repo has been public throughout and has a fork,
so those commits are already fetchable and a rewrite would not recall them.
Stopping the strings being *served and indexed* is the part still in reach.

Ousia is different -- it is still private, so a history rewrite there would
genuinely work, and it has one commit with the same problem.