### PR TITLE
feat(cli): drop --sparse-format, CSC is the only layout written

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -269,7 +269,6 @@ thyra input.imzML output.zarr \
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--streaming [auto\|true\|false]` | `auto` | Streaming mode for large datasets |
-| `--sparse-format [csc\|csr]` | `csc` | Sparse matrix storage format. Streaming writes CSC only |
 
 !!! info "Streaming mode"
     - **`auto`** (default) -- Thyra estimates dataset size and enables streaming
@@ -279,23 +278,29 @@ thyra input.imzML output.zarr \
 
     Streaming makes two passes over the source and scatters straight into
     memory-mapped CSC arrays, so the matrix is never held in RAM. The output
-    is identical to standard mode, except that streaming always stores CSC.
+    is identical to standard mode.
 
 ### Examples
 
 ```bash
 # Force streaming for a large dataset
 thyra large.d output.zarr --streaming true
-
-# Use CSR format (faster row access, slower column access). Only the
-# in-memory converter writes CSR, so streaming has to be off.
-thyra input.imzML output.zarr --sparse-format csr --streaming false
 ```
 
-!!! tip "CSC vs CSR"
-    **CSC** (default) is optimised for extracting ion images (one m/z across all
-    pixels). **CSR** is optimised for extracting spectra (one pixel across all
-    m/z values). Choose based on your downstream access pattern.
+!!! warning "`--sparse-format` was removed in v3.22"
+    Every route now writes CSC, so there is nothing left to choose and the
+    option is gone rather than kept as a no-op. It was only ever honoured by
+    the in-memory converters, which made its meaning depend on `--streaming`;
+    on the streaming route a `csr` request spent a release silently producing
+    CSC.
+
+    CSC is the layout an ion image reads down -- one m/z across all pixels is
+    one contiguous column. If you want the row-wise layout instead, take it
+    after reading rather than at write time:
+
+    ```python
+    X = sdata.tables["dataset_z0"].X.tocsr()
+    ```
 
 !!! warning "`--optimize-chunks` is deprecated"
     The flag is still accepted, so existing scripts keep running, but it does

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -818,10 +818,68 @@ the hand-written layout with no oracle.
 **One thing this settled by accident.** `sparse_format="csr"` was only
 honoured by COO; PCS ignored it and stored CSC. Since COO was unreachable
 from `convert()`, a streaming CSR request had been silently producing CSC
-for a release. The streaming converter now refuses `csr` and names the
-in-memory converter as the one that writes it.
+for a release. This release made the streaming converter refuse `csr` and
+name the in-memory converter as the one that wrote it; D10 then removed the
+keyword from every route, so the refusal now comes from the base converter
+and applies to `csc` as well.
 
 **Not decided here.** Whether PCS should grow a z term and route its table
 through spatialdata's writer, at which point the in-memory converters and
-the parity tests both become removable, and whether `--sparse-format`
-earns its place as a flag at all. Both are filed as issues.
+the parity tests both become removable. Filed as issue #218. The second
+question left open, whether `--sparse-format` earns its place as a flag at
+all, is D10.
+
+---
+
+## D10. CSC is the only layout, and `sparse_format` is gone
+
+**Status:** Implemented (2026-09-08).
+
+**Decision.** Every converter writes CSC. `--sparse-format` and the
+`sparse_format` keyword on `convert_msi` and the converters are removed,
+and passing the keyword raises rather than being ignored. A caller who
+wants row-major access calls `.tocsr()` on the matrix they read back.
+
+**Why.** After D9 the flag was honoured by the in-memory converters only.
+That made it a flag whose effect depended on a second flag: `csr` did
+something with `--streaming false` and was refused with it on. One option
+per concept, and no option whose meaning changes with another, is the rule
+the flag review of 2026-09-07 set; this was the clearest violation of it
+left in the CLI. The layout it selected is also not one anybody here asked
+for. Every consumer of a Thyra store reads columns -- an ion image is one
+m/z across all pixels, which is one contiguous CSC column -- and Ousia,
+the only shipped consumer, never passed the keyword at all.
+
+**The alternative, and why it lost.** The honest version of keeping the
+flag is to teach the streaming route a row-wise scatter, mirroring the
+column one, so `csr` means the same thing on both routes. That is a second
+two-pass write path, with its own count-then-scatter arithmetic and its own
+half of every parity test, carried for a layout with no requester. The
+conversion it replaces costs one `.tocsr()` in memory on data the caller
+has already read.
+
+**Why the keyword raises instead of being accepted as a no-op.** Unknown
+keyword arguments fall through `**kwargs` into `BaseMSIConverter.options`
+without a word. Dropping `sparse_format` from the signature and stopping
+there would mean `sparse_format="csr"` silently producing CSC -- which is
+exactly the failure D9 found and this decision is meant to end. So the
+base converter names it: the message says the keyword is gone, that CSC is
+what is written, and what to call for rows. `"csc"` is refused on the same
+terms, because a keyword that is accepted and does nothing is the shape of
+option being cleared out here.
+
+**The CLI differs, and deliberately.** `--sparse-format` is deleted
+outright rather than kept as a hidden no-op the way `--optimize-chunks`
+was. The precedents point in the same direction once the difference is
+named: `--optimize-chunks` never had an effect, so accepting it could not
+mislead anyone, while `--tof-a`/`--tof-b`/`--bins-per-fwhm` did have
+effects and were removed outright. `--sparse-format csr` had an effect, and
+the docs told people to pass it together with `--streaming false`; those
+command lines have to fail loudly rather than quietly write the opposite
+layout. Click's unknown-option error is that failure, and it arrives
+before any data is read.
+
+**Known limit.** A script passing `--sparse-format csc`, which asked for
+what it would have got anyway, also stops working and needs the argument
+deleted. That is the cost of not having a value that is accepted and
+ignored.

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -183,10 +183,11 @@ print(f"Non-zero: {X.nnz:,} ({X.nnz / (X.shape[0] * X.shape[1]) * 100:.2f}%)")
 ```
 
 !!! tip "Sparse format"
-    The default storage is CSC (Compressed Sparse Column), which is fast for
-    extracting ion images (column = one m/z across all pixels). If you need fast
-    per-pixel access, convert with `--sparse-format csr --streaming false`;
-    only the in-memory converter writes CSR.
+    The storage is CSC (Compressed Sparse Column) on every route, which is fast
+    for extracting ion images (column = one m/z across all pixels). If you need
+    fast per-pixel access, call `X.tocsr()` on the matrix you read back -- that
+    is one conversion in memory, and it is why there is no format choice at
+    write time.
 
     The stored matrix is canonical: within every column the row indices are in
     ascending order, whatever order the source delivered its pixels in (a

--- a/tests/unit/converters/test_routing_estimate.py
+++ b/tests/unit/converters/test_routing_estimate.py
@@ -155,14 +155,15 @@ class TestUseCscIsCompatibilityOnly:
         with pytest.raises(ValueError, match=r"COO route, which has been removed"):
             _converter((10, 10, 1), use_csc=False)
 
-    def test_csr_is_refused_rather_than_stored_as_csc(self):
-        """The route has no CSR layout.
+    def test_sparse_format_is_refused_by_the_base(self):
+        """The keyword is gone from every converter, not just this one.
 
-        It used to accept ``sparse_format="csr"`` and store CSC anyway,
-        which nothing reported; a caller who asked for row access got the
-        opposite. The refusal names the converter that does write CSR.
+        This route used to accept ``sparse_format="csr"`` and store CSC
+        anyway, which nothing reported; a caller who asked for row access
+        got the opposite. Now no route takes the keyword, and the base
+        refuses it rather than letting ``**kwargs`` eat it in silence.
         """
-        with pytest.raises(ValueError, match=r"CSC only.*streaming=False"):
+        with pytest.raises(ValueError, match=r"sparse_format was removed"):
             _converter((10, 10, 1), sparse_format="csr")
 
     def test_the_route_machinery_is_gone(self):

--- a/tests/unit/converters/test_spatialdata_converter.py
+++ b/tests/unit/converters/test_spatialdata_converter.py
@@ -694,111 +694,71 @@ class TestSpatialDataConverter:
         assert csr1[pixel_idx1, mz_indices1[1]] == 250.0
 
 
-class TestSparseFormat:
-    """Test sparse matrix format configuration (CSC vs CSR)."""
+class TestSparseFormatIsGone:
+    """CSC is the one layout written, and ``sparse_format`` no longer selects.
 
-    def test_default_sparse_format_is_csc(self, temp_dir):
-        """Test that the default sparse format is CSC."""
-        output_path = temp_dir / "test_output.zarr"
-        mock_reader = create_mock_reader_with_dimensions((3, 3, 1))
+    The keyword chose between CSC and CSR until v3.22, honoured by the
+    in-memory converters only -- so its meaning depended on ``streaming``,
+    and on the streaming route a ``csr`` request had spent a release
+    silently producing CSC. It is removed rather than mirrored: every
+    consumer here reads columns, and a caller who wants rows can call
+    ``X.tocsr()`` on what they read back for one conversion in memory.
 
-        converter = SpatialDataConverter(
-            mock_reader,
-            output_path,
-            dataset_id="test_dataset",
-            pixel_size_um=2.5,
-        )
+    Removing it from the signature is not enough on its own. An unknown
+    keyword falls through ``**kwargs`` into ``BaseMSIConverter.options``
+    without a word, which would reproduce exactly the silent-CSC failure
+    the removal was meant to end, so passing it has to raise.
+    """
 
-        assert converter._sparse_format == "csc"
-
-    def test_sparse_format_csc(self, temp_dir):
-        """Test converter with explicit CSC sparse format."""
-        output_path = temp_dir / "test_output.zarr"
-        mock_reader = create_mock_reader_with_dimensions((3, 3, 1))
-
-        converter = SpatialDataConverter(
-            mock_reader,
-            output_path,
-            dataset_id="test_dataset",
-            pixel_size_um=2.5,
-            sparse_format="csc",
-        )
-
-        assert converter._sparse_format == "csc"
-
-    def test_sparse_format_csr(self, temp_dir):
-        """Test converter with CSR sparse format."""
-        output_path = temp_dir / "test_output.zarr"
-        mock_reader = create_mock_reader_with_dimensions((3, 3, 1))
-
-        converter = SpatialDataConverter(
-            mock_reader,
-            output_path,
-            dataset_id="test_dataset",
-            pixel_size_um=2.5,
-            sparse_format="csr",
-        )
-
-        assert converter._sparse_format == "csr"
-
-    def test_sparse_format_case_insensitive(self, temp_dir):
-        """Test that sparse format parameter is case-insensitive."""
-        output_path = temp_dir / "test_output.zarr"
-        mock_reader = create_mock_reader_with_dimensions((3, 3, 1))
-
-        converter = SpatialDataConverter(
-            mock_reader,
-            output_path,
-            dataset_id="test_dataset",
-            sparse_format="CSC",
-        )
-
-        assert converter._sparse_format == "csc"
-
-    def test_invalid_sparse_format_raises_error(self, temp_dir):
-        """Test that an invalid sparse format raises ValueError."""
+    def test_the_keyword_is_refused_rather_than_swallowed(self, temp_dir):
         import pytest
 
-        output_path = temp_dir / "test_output.zarr"
         mock_reader = create_mock_reader_with_dimensions((3, 3, 1))
 
-        with pytest.raises(ValueError, match="sparse_format must be 'csc' or 'csr'"):
+        with pytest.raises(ValueError, match=r"sparse_format was removed"):
             SpatialDataConverter(
                 mock_reader,
-                output_path,
+                temp_dir / "test_output.zarr",
                 dataset_id="test_dataset",
-                sparse_format="invalid",
+                pixel_size_um=2.5,
+                sparse_format="csr",
             )
 
-    def test_sparse_format_3d_converter(self, temp_dir):
-        """Test sparse format is passed to 3D converter."""
-        output_path = temp_dir / "test_output.zarr"
-        mock_reader = create_mock_reader_with_dimensions((3, 3, 2))
+    def test_csc_is_refused_too(self, temp_dir):
+        """Even the value that matches what is written.
 
+        Accepting ``"csc"`` would leave a keyword that does nothing, which
+        is the shape of option this removal is clearing out. The error
+        costs the caller one deleted argument.
+        """
+        import pytest
+
+        mock_reader = create_mock_reader_with_dimensions((3, 3, 1))
+
+        with pytest.raises(ValueError, match=r"sparse_format was removed"):
+            SpatialDataConverter(
+                mock_reader,
+                temp_dir / "test_output.zarr",
+                dataset_id="test_dataset",
+                sparse_format="csc",
+            )
+
+    def test_the_selector_is_gone_from_the_converters(self, temp_dir):
+        """A leftover ``_sparse_format`` would read as a live choice.
+
+        Left behind, the next person sets it and the branch that consumed
+        it no longer exists.
+        """
+        mock_reader = create_mock_reader_with_dimensions((3, 3, 1))
         converter = SpatialDataConverter(
             mock_reader,
-            output_path,
+            temp_dir / "test_output.zarr",
             dataset_id="test_dataset",
-            handle_3d=True,
-            sparse_format="csr",
+            pixel_size_um=2.5,
         )
 
-        assert converter._sparse_format == "csr"
-
-    def test_sparse_format_2d_converter(self, temp_dir):
-        """Test sparse format is passed to 2D converter."""
-        output_path = temp_dir / "test_output.zarr"
-        mock_reader = create_mock_reader_with_dimensions((3, 3, 2))
-
-        converter = SpatialDataConverter(
-            mock_reader,
-            output_path,
-            dataset_id="test_dataset",
-            handle_3d=False,
-            sparse_format="csr",
-        )
-
-        assert converter._sparse_format == "csr"
+        assert not hasattr(converter, "_sparse_format")
+        assert "sparse_format" not in converter.options
 
 
 class TestNormalizeResamplingConfig:

--- a/tests/unit/test_read_lazy_contract.py
+++ b/tests/unit/test_read_lazy_contract.py
@@ -176,8 +176,8 @@ class TestEncodingMetadata:
 
         assert isinstance(x_group, zarr.Group), "X must stay a Group, not an Array"
         assert set(x_group.keys()) == {"data", "indices", "indptr"}
-        # Both are legitimate: the streaming writer emits csr, the others csc.
-        assert x_group.attrs["encoding-type"] in {"csc_matrix", "csr_matrix"}
+        # CSC is the only layout any route writes since sparse_format went.
+        assert x_group.attrs["encoding-type"] == "csc_matrix"
         # anndata matches this exactly; '0.2.0' raises IORegistryError.
         assert x_group.attrs["encoding-version"] == "0.1.0"
         assert list(x_group.attrs["shape"]) == [len(COORDINATES), N_MZ]

--- a/thyra/__main__.py
+++ b/thyra/__main__.py
@@ -444,7 +444,7 @@ class GroupedCommand(click.Command):
             "--resample-gap-tolerance",
             "--tof-law",
         ],
-        "Performance": ["--streaming", "--sparse-format"],
+        "Performance": ["--streaming"],
         "imzML-specific": ["--spectrum-type"],
         "Bruker-specific": [
             "--use-recalibrated",
@@ -653,15 +653,6 @@ class GroupedCommand(click.Command):
     hidden=True,
     help="Deprecated no-op, accepted so existing scripts keep running.",
 )
-@click.option(
-    "--sparse-format",
-    type=click.Choice(["csc", "csr"]),
-    default="csc",
-    help=(
-        "Sparse matrix format: csc or csr (default: csc). The streaming "
-        "route writes csc only, so csr needs --streaming false."
-    ),
-)
 # -- Resampling (advanced) --
 @click.option(
     "--resample-method",
@@ -836,7 +827,6 @@ def main(
     mass_axis_type: str,
     tof_law: Optional[Tuple[float, float]],
     spectrum_type: str,
-    sparse_format: str,
     include_optical: bool,
     mobility_table: bool,
     mobility_heatmap: bool,
@@ -938,7 +928,6 @@ def main(
         z_spacing_um=z_spacing,
         resampling_config=resampling_config,
         reader_options=reader_options,
-        sparse_format=sparse_format,
         include_optical=include_optical,
         streaming=_parse_streaming_option(streaming),
         region=region,

--- a/thyra/convert.py
+++ b/thyra/convert.py
@@ -258,7 +258,6 @@ def _create_converter(
     handle_3d: bool,
     pixel_size_detection_info: Dict[str, Any],
     resampling_config: Optional[Dict[str, Any]] = None,
-    sparse_format: str = "csc",
     include_optical: bool = True,
     apply_optical_alignment: bool = True,
     streaming: Union[bool, Literal["auto"]] = "auto",
@@ -274,7 +273,6 @@ def _create_converter(
         "z_spacing_um": z_spacing_um,
         "pixel_size_detection_info": pixel_size_detection_info,
         "resampling_config": resampling_config,
-        "sparse_format": sparse_format,
         "include_optical": include_optical,
         "apply_optical_alignment": apply_optical_alignment,
         **kwargs,
@@ -336,7 +334,6 @@ def convert_msi(
     z_spacing_um: Optional[float] = None,
     resampling_config: Optional[Dict[str, Any]] = None,
     reader_options: Optional[Dict[str, Any]] = None,
-    sparse_format: str = "csc",
     include_optical: bool = True,
     apply_optical_alignment: bool = True,
     streaming: Union[bool, Literal["auto"]] = "auto",
@@ -418,9 +415,6 @@ def convert_msi(
               files where it disagrees with what detection would
               have chosen, because the representation feeds
               instrument and axis-type selection.
-        sparse_format: Sparse matrix format ('csc' or 'csr'). The
-            streaming converter writes CSC only and refuses 'csr'; pass
-            streaming=False to write CSR.
         include_optical: Include optical images (default: True)
         apply_optical_alignment: If True (default) and the MSI source
             carries FlexImaging Area metadata, MSI elements are placed
@@ -512,7 +506,6 @@ def convert_msi(
             handle_3d,
             pixel_size_detection_info,
             resampling_config,
-            sparse_format,
             include_optical=include_optical,
             apply_optical_alignment=apply_optical_alignment,
             streaming=streaming,

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -707,7 +707,6 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         z_spacing_um: Optional[float] = None,
         pixel_size_detection_info: Optional[Dict[str, Any]] = None,
         resampling_config: Optional[Union[Dict[str, Any], ResamplingConfig]] = None,
-        sparse_format: str = "csc",
         include_optical: bool = True,
         apply_optical_alignment: bool = True,
         write_mobility_table: bool = True,
@@ -738,7 +737,6 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             pixel_size_detection_info: Optional metadata about pixel size
                 detection
             resampling_config: Optional resampling configuration dict
-            sparse_format: Sparse matrix format ('csc' or 'csr', default: 'csc')
             include_optical: Whether to include optical images in output
                 (default: True)
             write_mobility_table: When the reader shares one set of
@@ -794,9 +792,21 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
 
         Raises:
             ImportError: If SpatialData dependencies are not available
-            ValueError: If pixel_size_um is not positive or dataset_id is
-                empty
+            ValueError: If pixel_size_um is not positive, dataset_id is
+                empty, or ``sparse_format`` is passed
         """
+        # ``sparse_format`` chose between CSC and CSR until v3.22. CSC is now
+        # the only layout written, so the keyword has nothing left to select --
+        # but an unknown keyword lands in ``self.options`` without a word, and a
+        # caller who asked for CSR would get CSC and no signal. That is the
+        # failure this removal was meant to end, so say it instead.
+        if "sparse_format" in kwargs:
+            raise ValueError(
+                "sparse_format was removed: every converter writes CSC, which "
+                "is the layout an ion image reads down. Drop the argument; for "
+                "row-wise access call X.tocsr() on the matrix you read back."
+            )
+
         # Check if SpatialData is available
         if not SPATIALDATA_AVAILABLE:
             error_msg = (
@@ -850,7 +860,6 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             if resampling_config is not None
             else None
         )
-        self._sparse_format = sparse_format.lower()
         self._include_optical = include_optical
         self._apply_optical_alignment = apply_optical_alignment
         # Filled by _build_resampled_mass_axis(); consumed by
@@ -902,10 +911,6 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         self._msms_table_key: Optional[str] = None
         self._fragmentation_schedule: Any = None
         self._fragmentation_read = False
-        if self._sparse_format not in ("csc", "csr"):
-            raise ValueError(
-                f"sparse_format must be 'csc' or 'csr', got '{sparse_format}'"
-            )
 
         # Metadata caches (populated lazily during conversion). These have
         # to exist before _setup_resampling below: its strategy selection

--- a/thyra/converters/spatialdata/converter.py
+++ b/thyra/converters/spatialdata/converter.py
@@ -29,7 +29,6 @@ class SpatialDataConverter:
         handle_3d: bool = False,
         pixel_size_detection_info: Optional[Dict[str, Any]] = None,
         resampling_config: Optional[Dict[str, Any]] = None,
-        sparse_format: str = "csc",
         **kwargs: Any,
     ):
         """Create appropriate converter based on handle_3d parameter and data dimensions.
@@ -44,7 +43,6 @@ class SpatialDataConverter:
             pixel_size_detection_info: Optional metadata about pixel size
                 detection
             resampling_config: Optional resampling configuration dict
-            sparse_format: Sparse matrix format ('csc' or 'csr', default: 'csc')
             **kwargs: Additional keyword arguments
 
         Returns:
@@ -64,7 +62,6 @@ class SpatialDataConverter:
                 pixel_size_um=pixel_size_um,
                 pixel_size_detection_info=pixel_size_detection_info,
                 resampling_config=resampling_config,
-                sparse_format=sparse_format,
                 **kwargs,
             )
         elif dimensions[2] == 1:
@@ -76,7 +73,6 @@ class SpatialDataConverter:
                 pixel_size_um=pixel_size_um,
                 pixel_size_detection_info=pixel_size_detection_info,
                 resampling_config=resampling_config,
-                sparse_format=sparse_format,
                 **kwargs,
             )
         else:
@@ -88,7 +84,6 @@ class SpatialDataConverter:
                 pixel_size_um=pixel_size_um,
                 pixel_size_detection_info=pixel_size_detection_info,
                 resampling_config=resampling_config,
-                sparse_format=sparse_format,
                 **kwargs,
             )
 

--- a/thyra/converters/spatialdata/spatialdata_2d_converter.py
+++ b/thyra/converters/spatialdata/spatialdata_2d_converter.py
@@ -269,9 +269,8 @@ class SpatialData2DConverter(BaseSpatialDataConverter):
         # Process each slice separately
         for slice_id, slice_data in data_structures["slices_data"].items():
             try:
-                # Convert COO arrays to sparse matrix (CSC or CSR based on config)
-                format_name = "CSC" if self._sparse_format == "csc" else "CSR"
-                logger.info(f"Converting COO arrays to {format_name} for {slice_id}...")
+                # Convert the COO arrays to CSC, the one layout written
+                logger.info(f"Converting COO arrays to CSC for {slice_id}...")
                 coo_arrays = slice_data["sparse_data"]
                 current_idx = coo_arrays["current_idx"]
 
@@ -287,16 +286,11 @@ class SpatialData2DConverter(BaseSpatialDataConverter):
                     shape=(coo_arrays["n_rows"], coo_arrays["n_cols"]),
                     dtype=np.float64,
                 )
-                # Convert to configured sparse format
-                sparse_matrix: Any
-                if self._sparse_format == "csc":
-                    sparse_matrix = coo.tocsc()
-                else:
-                    sparse_matrix = coo.tocsr()
+                sparse_matrix = coo.tocsc()
 
                 logger.info(
                     f"Converted sparse matrix for {slice_id}: "
-                    f"{sparse_matrix.nnz:,} non-zero entries ({format_name})"
+                    f"{sparse_matrix.nnz:,} non-zero entries (CSC)"
                 )
 
                 # Create AnnData for this slice

--- a/thyra/converters/spatialdata/spatialdata_3d_converter.py
+++ b/thyra/converters/spatialdata/spatialdata_3d_converter.py
@@ -173,9 +173,8 @@ class SpatialData3DConverter(BaseSpatialDataConverter):
             # Store pixel count for metadata
             self._non_empty_pixel_count = data_structures["pixel_count"]
 
-            # Convert COO arrays to sparse matrix (CSC or CSR based on config)
-            format_name = "CSC" if self._sparse_format == "csc" else "CSR"
-            logger.info(f"Converting COO arrays to {format_name} format...")
+            # Convert the COO arrays to CSC, the one layout written
+            logger.info("Converting COO arrays to CSC format...")
             coo_arrays = data_structures["sparse_matrix"]
             current_idx = coo_arrays["current_idx"]
 
@@ -193,15 +192,10 @@ class SpatialData3DConverter(BaseSpatialDataConverter):
                 shape=(coo_arrays["n_rows"], coo_arrays["n_cols"]),
                 dtype=np.float64,
             )
-            # Convert to configured sparse format
-            sparse_matrix: Any
-            if self._sparse_format == "csc":
-                sparse_matrix = coo.tocsc()
-            else:
-                sparse_matrix = coo.tocsr()
+            sparse_matrix = coo.tocsc()
 
             logger.info(
-                f"Converted sparse matrix: {sparse_matrix.nnz:,} non-zero entries ({format_name})"
+                f"Converted sparse matrix: {sparse_matrix.nnz:,} non-zero entries (CSC)"
             )
 
             # Create AnnData

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -102,11 +102,10 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
             **kwargs: Keyword arguments passed to BaseSpatialDataConverter
 
         Raises:
-            ValueError: On ``use_csc=False``, and on ``sparse_format="csr"``.
-                This route scatters straight into CSC arrays and has no CSR
-                layout to write; it used to accept ``csr`` and silently
-                store CSC. The in-memory converter (``streaming=False``)
-                writes CSR.
+            ValueError: On ``use_csc=False``. There is one route left for it
+                to select, and falling through to it as if it had been
+                chosen is how a caller ends up with the opposite of what
+                they asked for.
 
         Note:
             Intensity thresholding (filtering noise below a minimum value) is
@@ -121,13 +120,6 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                 "use_csc=False selected the streaming COO route, which has been "
                 "removed: the PCS route was faster and lighter at every size "
                 "measured. Pass use_csc=True or leave it out."
-            )
-        if self._sparse_format != "csc":
-            raise ValueError(
-                "The streaming converter writes CSC only, but "
-                f"sparse_format='{self._sparse_format}' was requested. Pass "
-                "streaming=False to write CSR through the in-memory converter, "
-                "or sparse_format='csc'."
             )
 
         # Resolved once here rather than per spectrum: _process_spectrum is


### PR DESCRIPTION
Closes #219 with **option 1**.

## What changed

`sparse_format` is removed from `convert_msi`, `_create_converter`, the SpatialData factory, the base converter and the CLI, along with the `csr` branch of the 2D and 3D in-memory converters and the streaming route's now-unreachable `csr` refusal. Every route writes CSC.

## Why option 1

After the streaming COO route went in #220, the flag was honoured by the in-memory converters only: `csr` did something with `--streaming false` and was refused with it on. A flag whose meaning depends on a second flag is what the flag review of 2026-09-07 ruled out.

The layout it selected has no requester either. Every consumer of a Thyra store reads columns -- an ion image is one m/z across all pixels, which is one contiguous CSC column -- and Ousia, the only shipped consumer, never passed the keyword (checked its working tree; the only hits are in stale worktrees).

Option 2 would mean a second two-pass write path with its own count-then-scatter arithmetic and its own half of every parity test, carried for a layout nobody asked for, against one `.tocsr()` in memory on data the caller has already read.

## Two things the issue did not specify

**Passing the keyword raises rather than being ignored.** Unknown keyword arguments fall through `**kwargs` into `BaseMSIConverter.options` without a word, so deleting the parameter and stopping there would leave `sparse_format="csr"` silently producing CSC -- exactly the failure #220 found and this change is meant to end. `"csc"` is refused on the same terms: a keyword that is accepted and does nothing is the shape of option being cleared out here.

**The CLI differs deliberately.** `--sparse-format` is deleted outright rather than kept as a hidden no-op the way `--optimize-chunks` was. The two precedents point the same way once the difference is named: `--optimize-chunks` never had an effect, so accepting it cannot mislead, while `--tof-a`/`--tof-b`/`--bins-per-fwhm` did and were removed outright. This one had an effect, and the docs told people to pass it alongside `--streaming false`, so those command lines have to fail loudly rather than quietly write the opposite layout.

```
$ thyra x.imzML y.zarr --sparse-format csr
Error: No such option '--sparse-format'. Did you mean '--format'?
```

The known cost: `--sparse-format csc`, which asked for what it would have got anyway, also stops working and needs the argument deleted.

## Tests

The three converter tests pin the refusal and the absence of `_sparse_format` instead of the old CSC/CSR round trips. `test_read_lazy_contract` tightens `encoding-type` from `{csc_matrix, csr_matrix}` to `csc_matrix` -- its comment claimed the streaming writer emits CSR, which has not been true since #220. Both routes are now pinned to CSC end to end, the streaming one by `test_pcs_column_order`.

Full suite: **2306 passed, 13 skipped**. black / isort / flake8 / mypy / bandit / pydocstyle all clean via pre-commit.

## Docs

- `docs/cli.md` and `docs/output-format.md` drop the `--streaming false` workaround and point at `X.tocsr()` instead.
- Recorded as **D10** in `docs/design-decisions.md`; D9's open question about whether the flag earns its place is closed there, and its stale "the streaming converter now refuses `csr`" paragraph now points forward.
