### PR TITLE
ci(release): batch releases instead of publishing on every merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,22 @@
 name: Create Release & Publish to PyPI
 
 on:
-  push:
-    branches:
-      - main
+  # Deliberately NOT `push: [main]`. `semantic-release version` computes the
+  # bump from every commit since the last tag, so it batches by nature; the
+  # push trigger was the only thing turning one merge into one release. Ten
+  # fixes merged over a week now ship as one patch version with ten changelog
+  # lines under one heading, instead of ten versions and ten PyPI uploads.
+  # Merge cadence and release cadence are independent now, which is the point.
+  #
+  # The cron is the safety net, not the mechanism: it releases whatever has
+  # accumulated and no-ops (released=false) when nothing since the last tag was
+  # a feat/fix/perf. Cut a release the moment you want one instead of waiting
+  # for it -- `gh workflow run release.yml`, or the Run workflow button.
+  #
+  # GitHub disables `schedule` on a repository with no activity for 60 days.
+  # If releases ever go quiet for that long, check this trigger first.
+  schedule:
+    - cron: '0 6 * * 1'  # Mondays, 06:00 UTC
   release:
     types: [published]
   workflow_dispatch:
@@ -27,20 +40,33 @@ on:
 # steps leaves the repo tagged-but-not-bumped, which is far worse than a queued
 # run. Nothing here is safe to interrupt.
 #
-# The group is keyed on the event as well as the ref so a publish-only
-# workflow_dispatch is not stuck behind a push run -- it never calls
-# semantic-release (the release job is `if: github.event_name == 'push'`), so it
-# has nothing to race with. Only push-to-main runs need to serialise.
+# The group used to be keyed on the event as well as the ref, so a publish-only
+# workflow_dispatch would not queue behind a push run. That key is now WRONG and
+# must not come back: a workflow_dispatch without `publish_only` calls
+# semantic-release, exactly as a scheduled run does, so keying on the event puts
+# two version-creating runs in different groups and lets them race -- the very
+# failure this block exists to prevent. One group, everything serialises.
+#
+# The cost is that a publish-only dispatch can queue behind a release run. It is
+# small and getting smaller: with the push trigger gone, a run's Tests gate is
+# satisfied on the first poll (main's tip merged hours ago and its test run has
+# long since finished) rather than waiting minutes for a run that started at the
+# same instant, so a release run now takes about as long as it takes to install
+# semantic-release.
 concurrency:
-  group: release-${{ github.event_name }}-${{ github.ref }}
+  group: release-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    # Skip this job if triggered by release event or manual publish
-    if: github.event_name == 'push'
+    # Cut a version from whatever has accumulated on main: on the cron, or on
+    # demand. Never on the `release` event, where the tag already exists, and
+    # never on a publish-only dispatch, which exists precisely to skip this job.
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.publish_only != true)
     permissions:
       contents: write
       pull-requests: write
@@ -226,15 +252,23 @@ jobs:
           # main moved while we waited then $RELEASE_SHA is no longer the tip,
           # the checkout is stale, and `semantic-release version` would die on
           # "Upstream branch 'origin/main' has changed!" -- the failure the tip
-          # checkout above was added to end. Stand down cleanly instead: the
-          # merge that moved main queued its own release run behind this one,
-          # and semantic-release bumps from every commit since the last tag, so
-          # that run covers these commits too. Nothing is dropped by yielding.
+          # checkout above was added to end. Stand down cleanly instead.
+          #
+          # Yielding used to be self-healing: the merge that moved main was a
+          # push, so it queued its own release run behind this one. Without the
+          # push trigger nothing queues, so a yield here means no release until
+          # the next cron or the next `gh workflow run release.yml`. That is a
+          # delay, never a loss -- the commits stay on main and semantic-release
+          # bumps from every commit since the last tag, so the next run covers
+          # them. The window is also far narrower than it was: the gate above
+          # now clears on its first poll, so main has to move inside this job's
+          # first minute for the yield to fire at all.
           git fetch origin +refs/heads/main:refs/remotes/origin/main
           TIP=$(git rev-parse refs/remotes/origin/main)
           if [ "$TIP" != "$RELEASE_SHA" ]; then
             echo "No release: main moved $RELEASE_SHA -> $TIP while waiting for tests."
-            echo "The queued run for $TIP releases these commits."
+            echo "Nothing is queued to pick these up -- re-run this workflow to"
+            echo "release $TIP, or leave them for the Monday cron."
             echo "released=false" >> $GITHUB_OUTPUT
             exit 0
           fi
@@ -270,11 +304,17 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: [release]
-    # Run if: semantic-release created a release, OR a release was published, OR manual dispatch
-    # Use always() to allow running even when 'release' job is skipped
+    # Run if: the release job cut a version, OR a release was published, OR this
+    # is a publish-only dispatch. always() is what lets this run at all when the
+    # `release` job is skipped -- a skipped dependency otherwise skips this too.
+    #
+    # The first clause carries no event check. `released` is set only by a run
+    # of the release job that actually created a tag, so it already implies the
+    # trigger was one that cuts versions; naming the event as well is how the
+    # push-trigger removal could have silently disabled publishing.
     if: |
       always() && (
-        (github.event_name == 'push' && needs.release.outputs.released == 'true') ||
+        needs.release.outputs.released == 'true' ||
         github.event_name == 'release' ||
         (github.event_name == 'workflow_dispatch' && inputs.publish_only == true)
       )

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,9 +3,15 @@ name: Tests
 on:
   # Kept narrow on purpose -- only main, never every push to every feature
   # branch, whose PRs the trigger below already covers. Without this, NOTHING
-  # ran the suite against main: a release is cut from a push to main
-  # (release.yml) and publishes to PyPI, so v3.0.0 shipped from a commit no
-  # test job had ever seen.
+  # ran the suite against main, and releases publish to PyPI from main's tip, so
+  # v3.0.0 shipped from a commit no test job had ever seen.
+  #
+  # This trigger is load-bearing for releases and must not be narrowed further.
+  # release.yml gates on a completed run of THIS workflow for the exact commit
+  # it is about to release, and it fails closed: drop this trigger and every
+  # release blocks for 30 minutes and then errors, rather than shipping
+  # ungated. Releases no longer run on push, so this is the only thing that
+  # gives main's tip a test run to be gated on.
   push:
     branches: [ main ]
   # Deliberately unfiltered. `branches:` on a pull_request trigger matches the

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -247,6 +247,55 @@ Thyra follows [Semantic Versioning](https://semver.org/) (SemVer):
    `CHANGELOG.md`. Never edit it by hand; the [Changelog](changelog.md) page
    includes that file verbatim.
 
+### Releases are batched, not per-merge
+
+**Merging a pull request does not publish a release.** Releases are cut on a
+schedule or on demand, and each one covers every commit merged since the
+previous tag.
+
+`semantic-release version` reads all commits since the last tag and applies the
+highest bump among them, so a batch of eight `fix:` merges becomes one patch
+version whose changelog section lists all eight. Releasing per merge would have
+turned the same eight into eight versions and eight PyPI uploads.
+
+`.github/workflows/release.yml` therefore has no `push` trigger. It runs:
+
+- **on a cron**, Mondays at 06:00 UTC, releasing whatever has accumulated;
+- **on demand**, whenever you want a release sooner:
+
+  ```bash
+  gh workflow run release.yml
+  ```
+
+- **publish-only**, to re-upload the current version to PyPI without cutting a
+  new one, via the `publish_only` input on the Run workflow button.
+
+A run with nothing releasable since the last tag - only `chore:`, `ci:`,
+`docs:`, `refactor:`, `style:`, `test:` or `build:` commits - reports
+`No release` and exits green. Only `feat:` (minor) and `fix:`/`perf:` (patch)
+move the version.
+
+Nothing is lost by waiting: unreleased commits sit on `main` and the next run
+picks them up. What you should *not* do is merge a fix and then expect
+`pip install thyra` to have it minutes later - check the tags, or trigger a
+release yourself.
+
+### Grouping issues into release batches
+
+Open issues are grouped into **milestones**, one per planned batch. A milestone
+is the unit of release: work through its issues on one branch, open one pull
+request that closes all of them, merge, then cut a release.
+
+Milestones rather than draft pull requests, because a draft PR needs a branch
+with commits on it - six placeholder branches would each run CI, go stale
+against a moving `main`, and say nothing a milestone does not. Open the pull
+request when you start writing the code, not when you plan the batch.
+
+Group by the code the issues touch, not by how they were found. Issues that
+edit the same reader or the same function belong in one batch: fixing them in
+separate pull requests means solving the same merge conflict once per pull
+request.
+
 ### Development Versions
 
 - **Alpha/Beta** releases may be created for testing: `1.2.0-alpha.1`


### PR DESCRIPTION
## What

Merging a pull request no longer publishes a release. Releases are cut on a Monday cron or on demand, and each one covers every commit merged since the previous tag.

## Why

`semantic-release version` computes the bump from **every commit since the last tag** — it already batches. `on: push: [main]` was the only thing turning one merge into one release. Ten releases went out in the two days before this change (v3.17.1 through v3.23.0), and the 38 open issues now grouped into batches would have meant roughly that many more PyPI uploads.

Eight `fix:` merges now become one patch version whose changelog section lists all eight.

## How

```yaml
on:
  schedule:
    - cron: '0 6 * * 1'   # Mondays, 06:00 UTC
  release:
    types: [published]
  workflow_dispatch:      # gh workflow run release.yml
```

Everything downstream already worked against `origin/main`'s tip rather than the triggering commit, so the job bodies are unchanged. What did need changing:

| Change | Reason |
|---|---|
| `release` job `if` | `github.event_name == 'push'` → schedule, or dispatch without `publish_only` |
| `publish` job `if` | first clause keys on `needs.release.outputs.released` alone; that output already implies a version-cutting trigger, and naming the event there is how removing the push trigger could have silently disabled publishing |
| concurrency group | event key removed. It is now actively **wrong**: a dispatch without `publish_only` calls semantic-release exactly as a scheduled run does, so keying on the event would put two version-creating runs in different groups and let them race |
| "main moved" stand-down | no longer self-healing, because a merge no longer queues its own run. A delay, not a loss — commits stay on main for the next run — and the window shrank, since the Tests gate now clears on its first poll rather than waiting for a run that started at the same instant. Message updated |
| `tests.yml` comment | its `push: [main]` trigger is now load-bearing for releases: release.yml gates on a completed `Tests` run for the commit it releases and **fails closed**, and nothing else gives main's tip a run to gate on |

A run with nothing releasable since the last tag reports `No release` and exits green, as before.

## Issue grouping

Six milestones created, one per release batch, covering 38 open issues:

| Milestone | Issues |
|---|---|
| Batch 1: Waters and rapifleX raster geometry | 9 |
| Batch 2: CLI surface | 11 |
| Batch 3: Two-pass, CSC and memory accounting | 7 |
| Batch 4: Store correctness | 3 |
| Batch 5: Resampling and reader edge cases | 4 |
| Batch 6: Repo and CI hygiene | 4 |

Milestones rather than placeholder draft pull requests: a draft PR needs a branch with commits, so six placeholder branches would each run CI, go stale against a moving `main`, and record nothing a milestone does not.

Grouping is by the code the issues touch. #227, #231, #232 and #235 all edit the same Waters grid construction, so separate pull requests would mean solving one merge conflict four times.

#39, #54, #67, #114, #188 and #189 are left unmilestoned — long-horizon or externally blocked, not batch work.

**#224 is not addressed by this.** Branch protection on `main` is still blocked: semantic-release still pushes the version commit with `GITHUB_TOKEN`, which cannot bypass required status checks. This changes when that push happens, not what it is.

## Docs

`docs/contributing.md` gains "Releases are batched, not per-merge" and "Grouping issues into release batches".

## Verifying this one

This PR cannot be tested by merging it, since merging no longer releases. After merge: `gh workflow run release.yml` should cut a version from whatever is on main, and the run log should say `releasing from origin/main tip <sha>` followed by the Tests gate passing on its first poll.
