### PR TITLE
fix(waters): fit the raster to a lattice, and to the converted functions

### DIFF
--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -209,6 +209,17 @@ Two things to know up front:
 A folder of `*.dat` files with `*_poslog.txt` and `*_info.txt` alongside. The
 position log supplies the pixel grid. No SDK required.
 
+The raster step comes from the `Raster:` line in `*_info.txt` or the
+`<Raster>` element of the `.mis`. Without either, Thyra refuses and asks for
+`--pixel-size`, the same way the solariX reader does -- it used to fall back
+to 20 um and record that guess in the store as an automatically detected
+measurement.
+
+The `.dat` header's raster origin reaches the store as
+`coordinate_offsets_px`, with `stage_offset_um` beside it, so a Rapiflex
+store can be placed against its optical image the way a solariX or timsTOF
+one can. The stored pixel coordinates themselves stay 0-based.
+
 ## Waters MassLynx
 
 A `.raw` **directory** of `_FUNC*.DAT` files, read through the MassLynxRaw and
@@ -216,6 +227,21 @@ MLReader native libraries (bundled for Windows and Linux). The pixel grid is
 reconstructed from the laser X/Y position recorded on each scan; MRM and
 ion-mobility functions are classified and skipped, and which of the rest hold
 the image is decided from those same positions (below).
+
+The grid is a *lattice* fitted to those positions -- an origin, a pitch and a
+count per axis -- not a ranking of the distinct ones. The pitch is the
+neighbour interval, so a raster missing an interior row keeps its true pitch
+and leaves that row empty, rather than inflating the pitch and shifting every
+row past the gap up by one. Positions that do not lie on the fitted raster
+are refused, naming the axis and how far off the worst reading sits, instead
+of becoming a grid with a pixel per stage wobble. A scan reporting a
+non-finite position is unpositioned; two scans reporting the same position
+are summed into one pixel and the log names it.
+
+A `.raw` directory is refused when the library declares more functions than
+it has `_FUNC*.DAT` files. MassLynx keeps reporting a function whose data
+file is gone, with 0 scans and no error, so a chunk lost from a split raster
+would otherwise drop its rows of the image in silence.
 
 ### Which representation is read
 
@@ -299,7 +325,14 @@ pixel grid is built from:
 
 - A function landing on pixels no earlier function covers **extends the
   raster** and is converted, whatever level MassLynx reports and whether or
-  not MassLynx calls it the lockmass function.
+  not MassLynx calls it the lockmass function -- provided its positions lie
+  on the raster. The tail of a split raster continues it, so it shares the
+  fitted lattice; a reference or calibration spot parked off the sample also
+  covers pixels nothing else covers but does not, and is excluded and named
+  rather than converted as an image pixel.
+- The lattice itself is fitted to the MS functions, then re-fitted to
+  whatever is finally converted, so a function that contributes no pixel
+  never leaves its pitch behind in the grid.
 - Functions **competing for the same pixels** were acquired in parallel:
   MSe low and high energy, a data-dependent run, a co-acquired lockmass
   reference. Only one of them can be the pixel's spectrum, and summing an

--- a/tests/unit/metadata/extractors/test_waters_extractor.py
+++ b/tests/unit/metadata/extractors/test_waters_extractor.py
@@ -472,3 +472,109 @@ class TestWatersResamplingDetection:
         axis, method, _, _ = self._chain_answer(False, use_centroid=False)
         assert axis is AxisType.REFLECTOR_TOF
         assert method is ResamplingMethod.NEAREST_NEIGHBOR
+
+
+class TestScansSharingAPixel:
+    """Two scans on one stage position (issue #233).
+
+    ``n_spectra`` and ``total_peaks`` counted scans while
+    ``peak_counts_per_pixel`` kept only the last one, so the totals that
+    size the memory estimate and the per-pixel counts described two
+    different datasets. Real instance: the registry's 100 um MALDI set has
+    1275 positioned scans on 1274 distinct pixels, the stage having stopped
+    between two acquisitions 40 ms apart.
+    """
+
+    def _extractor_with_a_repeated_position(self, n_peaks=5):
+        mock_ml, handle, grid, ft, ms = _make_grid_and_ml(n_x=2, n_y=2, n_peaks=n_peaks)
+        # One more scan on the pixel scan 0 already covers.
+        grid.scan_map[(0, 4)] = _make_scan_info(0.1, 0.1)
+        mock_ml.get_number_of_scans_in_function.return_value = 5
+        return WatersMetadataExtractor(
+            mock_ml, handle, Path("/test/data.raw"), grid, ft, ms
+        )
+
+    def test_n_spectra_counts_pixels_not_scans(self):
+        essential = self._extractor_with_a_repeated_position().get_essential()
+
+        # Five scans land on four pixels; four spectra are written.
+        assert essential.n_spectra == 4
+
+    def test_the_per_pixel_counts_sum_to_the_total(self):
+        extractor = self._extractor_with_a_repeated_position(n_peaks=5)
+        essential = extractor.get_essential()
+        counts = extractor.get_essential().peak_counts_per_pixel
+
+        assert counts is not None
+        assert int(counts.sum()) == essential.total_peaks
+
+    def test_the_shared_pixel_carries_both_scans(self):
+        extractor = self._extractor_with_a_repeated_position(n_peaks=5)
+        counts = extractor.get_essential().peak_counts_per_pixel
+
+        # Pixel (0, 0) holds two scans of five peaks each; the rest hold one.
+        assert counts[0] == 10
+        assert list(counts[1:]) == [5, 5, 5]
+
+    def test_a_clean_raster_is_unaffected(self):
+        mock_ml, handle, grid, ft, ms = _make_grid_and_ml(n_x=2, n_y=2, n_peaks=5)
+        extractor = WatersMetadataExtractor(
+            mock_ml, handle, Path("/test/data.raw"), grid, ft, ms
+        )
+        essential = extractor.get_essential()
+
+        assert essential.n_spectra == 4
+        assert essential.total_peaks == 20
+
+
+class TestTheResampledAxisRange:
+    """The acquisition range, widened rather than abandoned (issue #230).
+
+    The Xevo DESI runs overshoot their declared 100-1200 range by 0.01 to
+    0.25 Da on every conversion measured, so the shared axis PR #207 added
+    was never once used on them -- and the fallback logged "using the
+    stored span so nothing is dropped" in the same run in which the axis
+    builder then dropped the edge peaks.
+    """
+
+    def _range_for(self, acquisition, observed):
+        mock_ml, handle, grid, ft, ms = _make_grid_and_ml(n_x=2, n_y=2)
+        mock_ml.get_acquisition_range.return_value = acquisition
+        extractor = WatersMetadataExtractor(
+            mock_ml, handle, Path("/test/data.raw"), grid, ft, ms
+        )
+        return extractor._axis_mass_range(observed)
+
+    def test_a_contained_span_still_takes_the_declared_range(self):
+        assert self._range_for((100.0, 1200.0), (100.5, 1199.5)) == (100.0, 1200.0)
+
+    def test_an_overshoot_widens_the_range_instead_of_abandoning_it(self):
+        # The measured Xevo DESI case: 99.9878-1200.2158 against 100-1200.
+        assert self._range_for((100.0, 1200.0), (99.9878, 1200.2158)) == (
+            99.9878,
+            1200.2158,
+        )
+
+    def test_an_overshoot_on_one_side_keeps_the_declared_bound_on_the_other(self):
+        assert self._range_for((100.0, 1200.0), (100.5, 1200.2158)) == (
+            100.0,
+            1200.2158,
+        )
+
+    def test_the_widened_range_covers_every_stored_value(self):
+        observed = (99.9878, 1200.2158)
+        lo, hi = self._range_for((100.0, 1200.0), observed)
+
+        assert lo <= observed[0] and hi >= observed[1]
+
+    def test_no_acquisition_range_falls_back_to_the_stored_span(self):
+        assert self._range_for(None, (110.0, 900.0)) == (110.0, 900.0)
+
+    def test_the_log_no_longer_claims_nothing_is_dropped(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            self._range_for((100.0, 1200.0), (99.9878, 1200.2158))
+
+        assert "so nothing is dropped" not in caplog.text
+        assert "widened" in caplog.text

--- a/tests/unit/readers/test_rapiflex_reader.py
+++ b/tests/unit/readers/test_rapiflex_reader.py
@@ -466,3 +466,113 @@ class TestRapiflexFormatDetection:
 
         with pytest.raises(ValueError):
             detect_format(folder)
+
+
+class TestMissingRasterDeclaration:
+    """A pitch nobody declared must not be invented (issue #236).
+
+    The reader used to fall back to 20 um, which convert.py then recorded
+    as ``pixel_size_source: automatic`` with ``detection_successful: True``
+    while ``format_specific.raster_step_um`` sat empty -- a guess the store
+    called a measurement. Every other reader returns None here and the CLI
+    refuses with the actionable "use --pixel-size" hint.
+    """
+
+    @staticmethod
+    def _strip_raster(folder):
+        """Remove every declaration of the raster step from the acquisition."""
+        info_path = folder / "sample_info.txt"
+        kept = [
+            line
+            for line in info_path.read_text().splitlines(keepends=True)
+            if not line.startswith("Raster:")
+        ]
+        info_path.write_text("".join(kept))
+        (folder / "sample.mis").unlink()
+
+    def test_no_raster_declaration_means_no_pixel_size(self, create_mock_rapiflex_data):
+        folder, _, _, _, _, _ = create_mock_rapiflex_data
+        self._strip_raster(folder)
+
+        reader = RapiflexReader(folder)
+        essential = reader._create_metadata_extractor().get_essential()
+
+        assert essential.pixel_size is None
+        reader.close()
+
+    def test_a_declared_raster_is_still_read(self, create_mock_rapiflex_data):
+        folder, _, _, _, _, _ = create_mock_rapiflex_data
+
+        reader = RapiflexReader(folder)
+        essential = reader._create_metadata_extractor().get_essential()
+
+        assert essential.pixel_size == (20.0, 20.0)
+        reader.close()
+
+    def test_the_missing_declaration_is_reported(
+        self, create_mock_rapiflex_data, caplog
+    ):
+        import logging
+
+        folder, _, _, _, _, _ = create_mock_rapiflex_data
+        self._strip_raster(folder)
+
+        reader = RapiflexReader(folder)
+        with caplog.at_level(logging.WARNING):
+            reader._create_metadata_extractor().get_essential()
+
+        assert "declares no raster step" in caplog.text
+        assert "--pixel-size" in caplog.text
+        reader.close()
+
+
+class TestRasterOrigin:
+    """Where on the slide the raster starts (issue #237).
+
+    The .dat header carries it and it was discarded for a hard-coded
+    (0, 0, 0), so no Rapiflex store could be placed against its optical
+    image the way a solariX one can -- that reader records
+    ``coordinate_offsets_px [516, 520, 0]`` for a section whose raster
+    starts at stage (516, 520).
+    """
+
+    @staticmethod
+    def _set_first_raster(folder, first_x, first_y):
+        """Rewrite the header's first_raster_x/y, at byte offsets 8 and 12."""
+        dat_path = folder / "sample.dat"
+        raw = bytearray(dat_path.read_bytes())
+        raw[8:16] = struct.pack("<2I", first_x, first_y)
+        dat_path.write_bytes(bytes(raw))
+
+    def test_the_raster_origin_reaches_the_metadata(self, create_mock_rapiflex_data):
+        folder, _, _, _, _, _ = create_mock_rapiflex_data
+        self._set_first_raster(folder, 100, 50)
+
+        reader = RapiflexReader(folder)
+        essential = reader._create_metadata_extractor().get_essential()
+
+        assert essential.coordinate_offsets == (100, 50, 0)
+        reader.close()
+
+    def test_a_raster_starting_at_the_origin_still_reads_zero(
+        self, create_mock_rapiflex_data
+    ):
+        folder, _, _, _, _, _ = create_mock_rapiflex_data
+
+        reader = RapiflexReader(folder)
+        essential = reader._create_metadata_extractor().get_essential()
+
+        assert essential.coordinate_offsets == (0, 0, 0)
+        reader.close()
+
+    def test_the_pixel_coordinates_stay_zero_based(self, create_mock_rapiflex_data):
+        """The offset is metadata; the stored coordinates are normalised."""
+        folder, _, _, _, _, _ = create_mock_rapiflex_data
+        self._set_first_raster(folder, 100, 50)
+
+        reader = RapiflexReader(folder)
+        coords = [c for c, _, _ in reader.iter_spectra()]
+
+        assert min(x for x, _, _ in coords) == 0
+        assert min(y for _, y, _ in coords) == 0
+        reader.close()

--- a/tests/unit/readers/test_waters_raster_geometry.py
+++ b/tests/unit/readers/test_waters_raster_geometry.py
@@ -1,0 +1,332 @@
+"""The raster Thyra fits to Waters stage readings.
+
+Covers the geometry half of the 2026-09-08 sweep: an interior gap in the
+raster (#227), stage readings that do not lie on one (#231), a grid built
+from functions that are not converted (#232), two scans on one pixel
+(#233), and the per-function scan index that function selection reads
+(#235). MassLynxLib is never loaded -- these build a ``scan_map`` directly,
+which is what ``build_imaging_grid`` hands on once the DLL sweep is done.
+"""
+
+import logging
+import math
+
+import pytest
+
+from thyra.readers.waters.imaging_grid import (
+    _grid_from_scan_map,
+    _mm_to_um_key,
+    regrid_for_functions,
+)
+from thyra.readers.waters.masslynx_lib import ScanInfoData
+
+
+def _scan(x_mm, y_mm, func_level=1):
+    return ScanInfoData(
+        ms_level=func_level,
+        polarity=0,
+        drift_scan_count=0,
+        is_profile=0,
+        precursor_mz=0.0,
+        rt=1.0,
+        laser_x_pos=x_mm,
+        laser_y_pos=y_mm,
+    )
+
+
+def _raster(
+    n_x, n_y, pitch_um, func=0, skip_rows=(), jitter_um=0.0, origin_mm=(0.0, 0.0)
+):
+    """A scan map for one rectangular raster, in MassLynx's millimetres."""
+    scan_map = {}
+    scan = 0
+    x0, y0 = origin_mm
+    for row in range(n_y):
+        if row in skip_rows:
+            continue
+        for col in range(n_x):
+            wobble_x = jitter_um * math.sin(row * 7.0 + col * 3.0)
+            wobble_y = jitter_um * math.cos(row * 5.0 + col * 11.0)
+            scan_map[(func, scan)] = _scan(
+                x0 + (col * pitch_um + wobble_x) / 1000.0,
+                y0 + (row * pitch_um + wobble_y) / 1000.0,
+            )
+            scan += 1
+    return scan_map
+
+
+class TestCompleteRasterIsUnchanged:
+    """The fit must not move a raster that was already right (#217)."""
+
+    @pytest.mark.parametrize("pitch", [30.0, 50.0, 100.0, 500.0])
+    def test_a_complete_raster_keeps_its_declared_pitch_exactly(self, pitch):
+        grid = _grid_from_scan_map(_raster(8, 6, pitch))
+
+        assert grid.pixel_count_x == 8
+        assert grid.pixel_count_y == 6
+        assert grid.pixel_size_x == pytest.approx(pitch, abs=1e-9)
+        assert grid.pixel_size_y == pytest.approx(pitch, abs=1e-9)
+
+    def test_a_single_line_scan_keeps_a_zero_pitch_on_its_short_axis(self):
+        """138x1 and 48x1 runs exist; a 0.0 pitch becomes the --pixel-size refusal."""
+        grid = _grid_from_scan_map(_raster(6, 1, 30.0))
+
+        assert (grid.pixel_count_x, grid.pixel_count_y) == (6, 1)
+        assert grid.pixel_size_x == pytest.approx(30.0)
+        assert grid.pixel_size_y == 0.0
+
+
+class TestInteriorGap:
+    """A missing row must not inflate the pitch or shift the rows past it."""
+
+    def test_the_pitch_comes_from_the_neighbour_interval_not_the_extent(self):
+        # Row 5 of 10 is missing: the extent still spans 9 pitches while only
+        # 8 intervals are counted, which reported 33.75 um for a 30 um raster.
+        grid = _grid_from_scan_map(_raster(20, 10, 30.0, skip_rows=(5,)))
+
+        assert grid.pixel_size_y == pytest.approx(30.0, abs=1e-9)
+        assert grid.pixel_size_x == pytest.approx(30.0, abs=1e-9)
+
+    def test_the_grid_keeps_the_missing_row_as_empty_pixels(self):
+        grid = _grid_from_scan_map(_raster(20, 10, 30.0, skip_rows=(5,)))
+
+        assert grid.pixel_count_y == 10
+        assert grid.lateral_height == pytest.approx(270.0)
+
+    def test_rows_below_the_gap_keep_their_own_index(self):
+        """The defect: every row below the gap was stored one row up."""
+        grid = _grid_from_scan_map(_raster(20, 10, 30.0, skip_rows=(5,)))
+
+        # Row 6 sits at 180 um. Ranking the 9 distinct values put it at 5.
+        assert grid.y_index_map[_mm_to_um_key(0.180)] == 6
+        assert grid.y_index_map[_mm_to_um_key(0.270)] == 9
+        assert _mm_to_um_key(0.150) not in grid.y_index_map
+
+    def test_a_missing_last_row_simply_shortens_the_raster(self):
+        grid = _grid_from_scan_map(_raster(20, 10, 30.0, skip_rows=(9,)))
+
+        assert grid.pixel_count_y == 9
+        assert grid.pixel_size_y == pytest.approx(30.0)
+
+    def test_the_gap_is_reported(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            _grid_from_scan_map(_raster(20, 10, 30.0, skip_rows=(5,)))
+
+        assert "missing 1 of its 10 raster lines" in caplog.text
+
+
+class TestReadingsThatAreNotARaster:
+    """Sub-pitch jitter used to explode the grid instead of being refused."""
+
+    def test_jitter_is_refused_rather_than_made_into_a_grid(self):
+        # +-1 % of a 30 um pitch gave a 187x171 store with a 3 x 1.6 um
+        # "pitch" and 200 of 31,977 pixels filled, silently.
+        with pytest.raises(ValueError, match="do not lie on a regular raster|only"):
+            _grid_from_scan_map(_raster(20, 10, 30.0, jitter_um=0.3))
+
+    def test_jitter_far_below_the_key_resolution_still_grids(self):
+        """0.003 um is under the 0.01 um key rounding, so it is not jitter."""
+        grid = _grid_from_scan_map(_raster(20, 10, 30.0, jitter_um=0.003))
+
+        assert (grid.pixel_count_x, grid.pixel_count_y) == (20, 10)
+        assert grid.pixel_size_x == pytest.approx(30.0, abs=1e-6)
+
+    def test_the_refusal_names_the_axis_and_the_pitch_it_fitted(self):
+        with pytest.raises(ValueError) as excinfo:
+            _grid_from_scan_map(_raster(20, 10, 30.0, jitter_um=0.3))
+
+        assert "x axis" in str(excinfo.value) or "y axis" in str(excinfo.value)
+
+
+class TestNonFinitePositions:
+    """NaN is not equal to itself, so it passed the sentinel test."""
+
+    def test_a_nan_position_is_not_a_position(self):
+        assert not _scan(float("nan"), 0.05).has_position
+        assert not _scan(0.1, float("nan")).has_position
+
+    def test_an_infinite_position_is_not_a_position(self):
+        assert not _scan(float("inf"), 0.05).has_position
+        assert not _scan(0.1, float("-inf")).has_position
+
+    def test_a_nan_scan_does_not_reach_the_grid(self):
+        scan_map = _raster(5, 4, 30.0)
+        scan_map[(0, 999)] = _scan(float("nan"), 0.03)
+
+        grid = _grid_from_scan_map(scan_map)
+
+        assert (grid.pixel_count_x, grid.pixel_count_y) == (5, 4)
+        assert math.isfinite(grid.pixel_size_x)
+        assert grid.pixel_size_x == pytest.approx(30.0)
+
+    def test_two_nan_scans_do_not_change_the_real_pitch(self):
+        scan_map = _raster(5, 4, 30.0)
+        scan_map[(0, 998)] = _scan(float("nan"), 0.03)
+        scan_map[(0, 999)] = _scan(float("nan"), 0.06)
+
+        grid = _grid_from_scan_map(scan_map)
+
+        assert grid.pixel_count_x == 5
+        assert grid.pixel_size_x == pytest.approx(30.0)
+
+    def test_the_dropped_scans_are_reported(self, caplog):
+        scan_map = _raster(5, 4, 30.0)
+        scan_map[(0, 999)] = _scan(float("inf"), 0.03)
+
+        with caplog.at_level(logging.WARNING):
+            _grid_from_scan_map(scan_map)
+
+        assert "non-finite stage position" in caplog.text
+
+
+class TestSentinelOnTheRaster:
+    """-1.0 mm is a coordinate a stage can really visit."""
+
+    def test_a_raster_passing_through_the_sentinel_says_so(self, caplog):
+        # 100 um raster from (-1.2, -1.2) mm, so (-1.0, -1.0) is on it.
+        scan_map = _raster(5, 5, 100.0, origin_mm=(-1.2, -1.2))
+        # The scan that would have landed there reports the sentinel.
+        scan_map[(0, 12)] = _scan(-1.0, -1.0)
+
+        with caplog.at_level(logging.WARNING):
+            _grid_from_scan_map(scan_map)
+
+        assert "no-position sentinel" in caplog.text
+
+    def test_a_raster_nowhere_near_the_sentinel_stays_quiet(self, caplog):
+        scan_map = _raster(5, 5, 100.0)
+        scan_map[(0, 99)] = _scan(-1.0, -1.0)
+
+        with caplog.at_level(logging.WARNING):
+            _grid_from_scan_map(scan_map)
+
+        assert "no-position sentinel" not in caplog.text
+
+
+class TestSharedPixels:
+    """Two scans on one pixel are summed; that was silent."""
+
+    def test_a_repeated_stage_position_is_reported(self, caplog):
+        scan_map = _raster(4, 3, 30.0)
+        # The stage stopped: one more scan at the position of scan 0.
+        scan_map[(0, 500)] = _scan(0.0, 0.0)
+
+        with caplog.at_level(logging.WARNING):
+            _grid_from_scan_map(scan_map)
+
+        assert "carry the SUM of every scan on them" in caplog.text
+        assert "(0, 0)" in caplog.text
+
+    def test_a_clean_raster_stays_quiet(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            _grid_from_scan_map(_raster(4, 3, 30.0))
+
+        assert "SUM of every scan" not in caplog.text
+
+
+class TestGridFromConvertedFunctionsOnly:
+    """The pitch must not come from a function that contributes no pixel."""
+
+    def test_an_off_raster_spot_does_not_stretch_the_grid(self):
+        scan_map = _raster(10, 5, 30.0, func=0)
+        # A reference spot parked well off the raster, as its own function.
+        # Folded in, it used to make an 11x6 image at a 1097 x 440 um
+        # "pitch"; the occupancy guard now refuses that outright, and the
+        # reader never offers it the chance by fitting the MS functions only.
+        scan_map[(1, 0)] = _scan(11.0, 4.4)
+
+        with pytest.raises(ValueError, match="carry a reading"):
+            _grid_from_scan_map(scan_map)
+
+        without_spot = _grid_from_scan_map(scan_map, functions=[0])
+
+        assert without_spot.pixel_count_x == 10
+        assert without_spot.pixel_count_y == 5
+        assert without_spot.pixel_size_x == pytest.approx(30.0)
+        assert without_spot.pixel_size_y == pytest.approx(30.0)
+
+    def test_a_half_pitch_offset_function_is_not_interleaved_into_the_raster(self):
+        """The second #232 layout: MS2 read half a pitch off the MS1 raster."""
+        scan_map = _raster(10, 5, 30.0, func=0)
+        scan_map.update(_raster(10, 5, 30.0, func=1, origin_mm=(0.015, 0.0)))
+
+        interleaved = _grid_from_scan_map(scan_map)
+        ms1_only = _grid_from_scan_map(scan_map, functions=[0])
+
+        # Folded in, the offset function doubles the columns and halves the
+        # pitch; on its own the MS1 raster is what it always was.
+        assert interleaved.pixel_count_x == 20
+        assert interleaved.pixel_size_x == pytest.approx(15.0)
+        assert ms1_only.pixel_count_x == 10
+        assert ms1_only.pixel_size_x == pytest.approx(30.0)
+        # And the offset readings are not on the MS1 raster, so the reader
+        # excludes them rather than converting them as image pixels.
+        assert not ms1_only.lies_on_raster(_scan(0.015, 0.0))
+
+    def test_an_off_raster_reading_does_not_lie_on_the_raster(self):
+        grid = _grid_from_scan_map(_raster(10, 5, 30.0))
+
+        assert grid.lies_on_raster(_scan(0.060, 0.030))
+        assert not grid.lies_on_raster(_scan(0.075, 0.030))  # half a pitch off
+        assert not grid.lies_on_raster(_scan(11.0, 4.4))
+
+    def test_the_tail_of_a_split_raster_does_lie_on_it(self):
+        """A chunk MassLynx split off continues the raster past its extent."""
+        grid = _grid_from_scan_map(_raster(10, 5, 30.0))
+
+        # Row 7 is beyond this chunk's five rows but shares its phase.
+        assert grid.lies_on_raster(_scan(0.060, 0.210))
+
+    def test_a_hand_built_grid_is_taken_on_trust(self):
+        grid = _grid_from_scan_map(_raster(10, 5, 30.0))
+        grid.x_lattice = None
+
+        assert grid.lies_on_raster(_scan(11.0, 4.4))
+
+    def test_regrid_returns_the_same_object_when_nothing_moves(self):
+        grid = _grid_from_scan_map(_raster(10, 5, 30.0, func=0))
+
+        assert regrid_for_functions(grid, [0]) is grid
+
+    def test_regrid_reports_a_geometry_it_had_to_change(self, caplog):
+        scan_map = _raster(10, 5, 30.0, func=0)
+        scan_map.update(_raster(10, 5, 30.0, func=1, origin_mm=(0.015, 0.0)))
+        grid = _grid_from_scan_map(scan_map)
+
+        with caplog.at_level(logging.WARNING):
+            refitted = regrid_for_functions(grid, [0])
+
+        assert refitted is not grid
+        assert refitted.pixel_size_x == pytest.approx(30.0)
+        assert "re-fitted to the converted functions" in caplog.text
+
+
+class TestScansByFunction:
+    """One pass instead of a re-sort per query (#235)."""
+
+    def test_scans_are_grouped_by_function_in_scan_order(self):
+        scan_map = _raster(3, 2, 30.0, func=0)
+        scan_map.update(_raster(3, 2, 30.0, func=1))
+        grid = _grid_from_scan_map(scan_map)
+
+        grouped = grid.scans_by_function
+
+        assert set(grouped) == {0, 1}
+        assert len(grouped[0]) == 6
+        assert grouped[0][0].laser_x_pos == pytest.approx(0.0)
+        assert grouped[0][-1].laser_x_pos == pytest.approx(0.060)
+
+    def test_unpositioned_scans_are_left_out(self):
+        scan_map = _raster(3, 2, 30.0)
+        scan_map[(0, 900)] = _scan(-1.0, -1.0)
+        scan_map[(0, 901)] = _scan(float("nan"), float("nan"))
+        grid = _grid_from_scan_map(scan_map)
+
+        assert len(grid.scans_by_function[0]) == 6
+
+    def test_a_function_with_no_positioned_scan_is_absent(self):
+        scan_map = _raster(3, 2, 30.0, func=0)
+        scan_map[(4, 0)] = _scan(-1.0, -1.0)
+        grid = _grid_from_scan_map(scan_map)
+
+        assert grid.scans_by_function.get(4, []) == []

--- a/tests/unit/readers/test_waters_reader.py
+++ b/tests/unit/readers/test_waters_reader.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
-from thyra.readers.waters.imaging_grid import ImagingGrid
+from thyra.readers.waters.imaging_grid import ImagingGrid, _grid_from_scan_map
 from thyra.readers.waters.masslynx_lib import FunctionType, ScanInfoData
 from thyra.readers.waters.waters_reader import WatersReader
 
@@ -524,6 +524,15 @@ def _chunked_grid(levels, scans_per_function=3, profile_functions=()):
     )
 
 
+def _declare_function_files(raw_dir, n_funcs):
+    """Give a mock .raw directory one _FUNC*.DAT per function.
+
+    MassLynx numbers them from one, so function 0 is _FUNC001.DAT.
+    """
+    for f in range(n_funcs):
+        (raw_dir / f"_FUNC{f + 1:03d}.DAT").write_bytes(b"\x00" * 64)
+
+
 def _open_reader(
     mock_ml_cls,
     mock_build_grid,
@@ -534,6 +543,13 @@ def _open_reader(
     scans_per_function=3,
     use_centroid=True,
 ):
+    # A real .raw directory has one _FUNC*.DAT per declared function, and
+    # the reader now refuses one that does not (issue #229). The fixture
+    # writes only _FUNC001.DAT, so a test mocking more functions than that
+    # has to put their files there too, or it is asserting against a
+    # directory MassLynx could not have produced.
+    _declare_function_files(mock_waters_data, n_funcs)
+
     mock_ml = MagicMock()
     mock_ml_cls.get_instance.return_value = mock_ml
     mock_ml.is_imaging_file.return_value = True
@@ -794,4 +810,146 @@ class TestWatersReaderChunkedRaster:
         assert len(list(reader.iter_spectra())) == 9
         assert reader._ms_functions == [0, 1, 2]
         assert reader._excluded_functions == {}
+        reader.close()
+
+
+class TestWatersReaderMissingFunctionFiles:
+    """A function whose _FUNC*.DAT is gone still reports, with 0 scans.
+
+    The DLL never complains, so the only symptom of a lost chunk file is a
+    smaller scan total than the acquisition had -- and on a raster MassLynx
+    split across functions, entire rows of the image simply do not appear
+    (issue #229).
+    """
+
+    @patch("thyra.readers.waters.waters_reader.MassLynxLib")
+    @patch("thyra.readers.waters.waters_reader.build_imaging_grid")
+    def test_a_missing_function_file_is_refused(
+        self, mock_build_grid, mock_ml_cls, mock_waters_data
+    ):
+        grid = _chunked_grid({0: 1, 1: 2, 2: 0})
+        reader, _ = _open_reader(
+            mock_ml_cls,
+            mock_build_grid,
+            mock_waters_data,
+            grid,
+            3,
+            types={0: FunctionType.MS, 1: FunctionType.MS, 2: FunctionType.LOCKMASS},
+        )
+        (mock_waters_data / "_FUNC002.DAT").unlink()
+
+        with pytest.raises(ValueError, match="_FUNC002.DAT"):
+            list(reader.iter_spectra())
+
+    @patch("thyra.readers.waters.waters_reader.MassLynxLib")
+    @patch("thyra.readers.waters.waters_reader.build_imaging_grid")
+    def test_the_refusal_names_every_missing_file(
+        self, mock_build_grid, mock_ml_cls, mock_waters_data
+    ):
+        grid = _chunked_grid({0: 1, 1: 2, 2: 0})
+        reader, _ = _open_reader(
+            mock_ml_cls,
+            mock_build_grid,
+            mock_waters_data,
+            grid,
+            3,
+            types={0: FunctionType.MS, 1: FunctionType.MS, 2: FunctionType.LOCKMASS},
+        )
+        (mock_waters_data / "_FUNC002.DAT").unlink()
+        (mock_waters_data / "_FUNC003.DAT").unlink()
+
+        with pytest.raises(ValueError) as excinfo:
+            list(reader.iter_spectra())
+
+        assert "_FUNC002.DAT" in str(excinfo.value)
+        assert "_FUNC003.DAT" in str(excinfo.value)
+
+    @patch("thyra.readers.waters.waters_reader.MassLynxLib")
+    @patch("thyra.readers.waters.waters_reader.build_imaging_grid")
+    def test_a_complete_directory_opens(
+        self, mock_build_grid, mock_ml_cls, mock_waters_data
+    ):
+        grid = _chunked_grid({0: 1, 1: 2, 2: 0})
+        reader, _ = _open_reader(
+            mock_ml_cls,
+            mock_build_grid,
+            mock_waters_data,
+            grid,
+            3,
+            types={0: FunctionType.MS, 1: FunctionType.MS, 2: FunctionType.LOCKMASS},
+        )
+
+        assert len(list(reader.iter_spectra())) == 9
+        reader.close()
+
+
+class TestWatersReaderOffRasterFunctions:
+    """The #210 rescue rule assumed what it did not check.
+
+    "Covers pixels no MS function covers" is true of the tail of a split
+    raster and equally true of a reference spot parked off the sample. The
+    tail continues the raster, so it lands on the same lattice; the spot
+    does not (issue #232).
+    """
+
+    def _grid(self, spot_mm=None):
+        scan_map = {}
+        scan = 0
+        for col in range(6):
+            scan_map[(0, scan)] = _make_scan_info((col * 100) / 1000.0, 0.05)
+            scan += 1
+        if spot_mm is not None:
+            scan_map[(1, 0)] = _make_scan_info(*spot_mm)
+        else:
+            # The tail of the same raster, as its own function.
+            for col in range(6, 9):
+                scan_map[(1, scan)] = _make_scan_info((col * 100) / 1000.0, 0.05)
+                scan += 1
+        return _grid_from_scan_map(scan_map, functions=[0])
+
+    @patch("thyra.readers.waters.waters_reader.MassLynxLib")
+    @patch("thyra.readers.waters.waters_reader.build_imaging_grid")
+    def test_a_lockmass_spot_off_the_raster_is_excluded(
+        self, mock_build_grid, mock_ml_cls, mock_waters_data
+    ):
+        grid = self._grid(spot_mm=(11.0, 4.4))
+        reader, _ = _open_reader(
+            mock_ml_cls,
+            mock_build_grid,
+            mock_waters_data,
+            grid,
+            2,
+            types={0: FunctionType.MS, 1: FunctionType.LOCKMASS},
+        )
+        reader._ensure_initialized()
+
+        assert reader._ms_functions == [0]
+        assert (
+            reader._excluded_functions[1]["reason"]
+            == "stage positions do not lie on the imaging raster"
+        )
+        reader.close()
+
+    @patch("thyra.readers.waters.waters_reader.MassLynxLib")
+    @patch("thyra.readers.waters.waters_reader.build_imaging_grid")
+    def test_the_tail_of_a_split_raster_is_still_rescued(
+        self, mock_build_grid, mock_ml_cls, mock_waters_data
+    ):
+        grid = self._grid()
+        reader, _ = _open_reader(
+            mock_ml_cls,
+            mock_build_grid,
+            mock_waters_data,
+            grid,
+            2,
+            types={0: FunctionType.MS, 1: FunctionType.LOCKMASS},
+            use_centroid=False,
+        )
+        reader._ensure_initialized()
+
+        assert reader._ms_functions == [0, 1]
+        assert reader._excluded_functions == {}
+        # The grid grew to hold the rescued tail.
+        assert reader._imaging_grid.pixel_count_x == 9
+        assert reader._imaging_grid.pixel_size_x == pytest.approx(100.0)
         reader.close()

--- a/tests/unit/test_cli_non_finite_numbers.py
+++ b/tests/unit/test_cli_non_finite_numbers.py
@@ -1,0 +1,90 @@
+"""Non-finite numeric options are refused before any file is opened.
+
+``value <= 0`` is False for NaN and for +infinity, so every guard written
+that way admitted both: ``--pixel-size nan`` reached the store as the
+dataset's pixel size, and ``--tof-law nan 1`` was refused only by the axis
+generator, as a traceback, after a 47 s metadata scan (issue #231).
+"""
+
+from __future__ import annotations
+
+import click
+import pytest
+
+from thyra.__main__ import (
+    _validate_basic_params,
+    _validate_positive_float,
+    _validate_tof_law,
+)
+from thyra.convert import _validate_numeric_parameters
+
+NON_FINITE = [float("nan"), float("inf"), float("-inf")]
+
+
+class TestPixelSize:
+    @pytest.mark.parametrize("value", NON_FINITE)
+    def test_a_non_finite_pixel_size_is_refused(self, value):
+        with pytest.raises(click.BadParameter, match="finite"):
+            _validate_basic_params(value, "dataset")
+
+    def test_a_real_pixel_size_is_still_accepted(self):
+        _validate_basic_params(25.0, "dataset")
+
+    def test_no_pixel_size_is_still_accepted(self):
+        _validate_basic_params(None, "dataset")
+
+    @pytest.mark.parametrize("value", [0.0, -1.0])
+    def test_a_non_positive_pixel_size_is_still_refused(self, value):
+        with pytest.raises(click.BadParameter):
+            _validate_basic_params(value, "dataset")
+
+
+class TestPositiveFloats:
+    """--resample-min-mz, --resample-max-mz, --resample-width-at-mz, --z-spacing."""
+
+    @pytest.mark.parametrize("value", NON_FINITE)
+    def test_a_non_finite_value_is_refused(self, value):
+        with pytest.raises(click.BadParameter, match="finite"):
+            _validate_positive_float(value, "z_spacing", "Z spacing")
+
+    def test_a_real_value_is_still_accepted(self):
+        _validate_positive_float(10.0, "z_spacing", "Z spacing")
+        _validate_positive_float(None, "z_spacing", "Z spacing")
+
+
+class TestTofLaw:
+    @pytest.mark.parametrize(
+        "law",
+        [
+            (float("nan"), 1e-6),
+            (0.02, float("nan")),
+            (float("inf"), 0.0),
+            (0.0, float("inf")),
+        ],
+    )
+    def test_a_non_finite_law_is_refused(self, law):
+        with pytest.raises(click.BadParameter, match="finite"):
+            _validate_tof_law(law)
+
+    def test_a_real_law_is_still_accepted(self):
+        _validate_tof_law((0.0185, 9.1e-6))
+
+    def test_the_width_check_still_applies(self):
+        with pytest.raises(click.BadParameter):
+            _validate_tof_law((0.0, 0.0))
+
+
+class TestTheApiValidatesToo:
+    """convert_msi can be called directly, without the CLI's guards."""
+
+    @pytest.mark.parametrize("value", NON_FINITE)
+    def test_a_non_finite_pixel_size_is_refused(self, value):
+        assert _validate_numeric_parameters(value) is False
+
+    @pytest.mark.parametrize("value", NON_FINITE)
+    def test_a_non_finite_z_spacing_is_refused(self, value):
+        assert _validate_numeric_parameters(25.0, value) is False
+
+    def test_real_numbers_pass(self):
+        assert _validate_numeric_parameters(25.0, 10.0) is True
+        assert _validate_numeric_parameters(None, None) is True

--- a/thyra/__main__.py
+++ b/thyra/__main__.py
@@ -5,6 +5,7 @@ import logging  # noqa: E402
 import os  # noqa: E402
 import sqlite3  # noqa: E402
 import warnings  # noqa: E402
+from math import isfinite  # noqa: E402
 from pathlib import Path  # noqa: E402
 from typing import Literal, Optional, Tuple  # noqa: E402
 
@@ -78,10 +79,24 @@ def _get_calibration_states(bruker_path: Path) -> list[dict]:
         return []
 
 
+def _is_usable_number(value: float) -> bool:
+    """Whether a numeric option carries a real, positive quantity.
+
+    ``value <= 0`` is False for NaN and for +infinity, so every guard
+    written that way admitted both. ``--pixel-size nan`` reached the store
+    as the dataset's pixel size, and ``--tof-law nan 1`` was refused only
+    by the axis generator, as a traceback, after a 47 s metadata scan
+    (issue #231).
+    """
+    return isfinite(value) and value > 0
+
+
 def _validate_basic_params(pixel_size: Optional[float], dataset_id: str) -> None:
     """Validate basic conversion parameters."""
-    if pixel_size is not None and pixel_size <= 0:
-        raise click.BadParameter("Pixel size must be positive", param_hint="pixel_size")
+    if pixel_size is not None and not _is_usable_number(pixel_size):
+        raise click.BadParameter(
+            "Pixel size must be a finite positive number", param_hint="pixel_size"
+        )
     if not dataset_id.strip():
         raise click.BadParameter("Dataset ID cannot be empty", param_hint="dataset_id")
 
@@ -96,8 +111,10 @@ def _validate_positive_float(
     value: Optional[float], param_name: str, label: str
 ) -> None:
     """Validate that an optional float parameter is positive if provided."""
-    if value is not None and value <= 0:
-        raise click.BadParameter(f"{label} must be positive", param_hint=param_name)
+    if value is not None and not _is_usable_number(value):
+        raise click.BadParameter(
+            f"{label} must be a finite positive number", param_hint=param_name
+        )
 
 
 def _validate_mz_range(min_mz: Optional[float], max_mz: Optional[float]) -> None:
@@ -126,9 +143,10 @@ def _validate_resampling_params(
 
     _validate_positive_float(resample_width_at_mz, "resample_width_at_mz", "Mass width")
 
-    if resample_reference_mz <= 0:
+    if not _is_usable_number(resample_reference_mz):
         raise click.BadParameter(
-            "Reference m/z must be positive", param_hint="resample_reference_mz"
+            "Reference m/z must be a finite positive number",
+            param_hint="resample_reference_mz",
         )
 
 
@@ -143,6 +161,10 @@ def _validate_tof_law(tof_law: Optional[Tuple[float, float]]) -> None:
     if tof_law is None:
         return
     a, b = tof_law
+    if not (isfinite(a) and isfinite(b)):
+        raise click.BadParameter(
+            "The TOF width law needs two finite numbers", param_hint="tof_law"
+        )
     if a < 0 or b < 0 or (a == 0 and b == 0):
         raise click.BadParameter(
             "The TOF width law needs A >= 0 and B >= 0 with at least one of "

--- a/thyra/convert.py
+++ b/thyra/convert.py
@@ -2,6 +2,7 @@
 import logging
 import traceback
 import warnings
+from math import isfinite
 from pathlib import Path
 from typing import Any, Dict, Literal, Optional, Tuple, Union
 
@@ -51,16 +52,24 @@ def _validate_numeric_parameters(
     pixel_size_um: Optional[float], z_spacing_um: Optional[float] = None
 ) -> bool:
     """Validate numeric parameters."""
+    # `<= 0` is False for NaN and for +infinity, so both used to pass every
+    # one of these guards and reach the store as the dataset's pixel size or
+    # z spacing. The API is validated as well as the CLI because a caller
+    # can hand these in directly (issue #231).
     if pixel_size_um is not None and (
-        not isinstance(pixel_size_um, (int, float)) or pixel_size_um <= 0
+        not isinstance(pixel_size_um, (int, float))
+        or not isfinite(pixel_size_um)
+        or pixel_size_um <= 0
     ):
-        logger.error("Pixel size must be a positive number")
+        logger.error("Pixel size must be a finite positive number")
         return False
 
     if z_spacing_um is not None and (
-        not isinstance(z_spacing_um, (int, float)) or z_spacing_um <= 0
+        not isinstance(z_spacing_um, (int, float))
+        or not isfinite(z_spacing_um)
+        or z_spacing_um <= 0
     ):
-        logger.error("Z spacing must be a positive number")
+        logger.error("Z spacing must be a finite positive number")
         return False
 
     return True

--- a/thyra/metadata/extractors/waters_extractor.py
+++ b/thyra/metadata/extractors/waters_extractor.py
@@ -136,8 +136,9 @@ class WatersMetadataExtractor(MetadataExtractor):
         first and last stored samples happened to be.
 
         Falls back to the stored span when no MS function reports an
-        acquisition range, or when a stored value lies outside it, since a
-        range that drops measured data is worse than one that varies.
+        acquisition range, and widens the declared one to cover the stored
+        span when a value lies outside it, since a range that drops
+        measured data is worse than one that varies.
         """
         acquired = [
             r
@@ -169,14 +170,32 @@ class WatersMetadataExtractor(MetadataExtractor):
             )
             return (lo, hi)
 
+        # Widen rather than abandon. The old fallback returned the observed
+        # span and said "so nothing is dropped", which the axis builder
+        # then contradicted in the same run: it drops the peaks sitting
+        # exactly on the span's bounds, so the store lost 15 peaks of
+        # 19.7 M on every Xevo DESI conversion measured while the log said
+        # nothing was lost. The overshoot is real and small -- the vendor
+        # centroid and the profile trace both exceed a declared 100-1200
+        # range by 0.01 to 0.25 Da on those runs, which is why the shared
+        # axis PR #207 added was never once used on them (issue #230).
+        #
+        # A widened range is run-specific where a purely declared one is
+        # not, so two runs of one method share an axis only when they
+        # overshoot alike. That is the honest trade: an axis that drops
+        # measured data is worse than one that varies.
+        widened = (min(lo, observed[0]), max(hi, observed[1]))
         logger.warning(
             "Stored m/z values %.4f-%.4f fall outside the acquisition range "
-            "%.4f-%.4f; using the stored span so nothing is dropped",
+            "%.4f-%.4f; the resampled axis is widened to %.4f-%.4f to cover "
+            "them. Runs of this method share one axis only if they overshoot "
+            "the acquisition range by the same amount.",
             *observed,
             lo,
             hi,
+            *widened,
         )
-        return observed
+        return widened
 
     def _detect_spectrum_type(self) -> Optional[str]:
         """The representation the reader delivers: profile trace or centroid.
@@ -235,7 +254,6 @@ class WatersMetadataExtractor(MetadataExtractor):
         stats["min_mass"] = min(stats["min_mass"], float(mzs[0]))
         stats["max_mass"] = max(stats["max_mass"], float(mzs[-1]))
         stats["total_peaks"] += n_peaks
-        stats["n_spectra"] += 1
 
         coords = self._imaging_grid.get_coordinates(
             self._imaging_grid.scan_map[(func, scan)]
@@ -244,7 +262,17 @@ class WatersMetadataExtractor(MetadataExtractor):
         n_x, n_y = stats["n_x"], stats["n_y"]
         pixel_idx = z * (n_x * n_y) + y * n_x + x
         if 0 <= pixel_idx < stats["n_pixels"]:
-            stats["peak_counts"][pixel_idx] = n_peaks
+            # Accumulate, and count pixels rather than scans. Two scans can
+            # report the same stage position -- the registry's 100 um MALDI
+            # set has 1275 positioned scans on 1274 pixels, the stage having
+            # stopped between two acquisitions 40 ms apart -- and the
+            # converter sums them into the one pixel. This used to overwrite
+            # with the last scan's count while ``n_spectra`` counted both, so
+            # the per-pixel counts and the totals that size the memory
+            # estimate described two different datasets (issue #233).
+            if stats["peak_counts"][pixel_idx] == 0:
+                stats["n_spectra"] += 1
+            stats["peak_counts"][pixel_idx] += n_peaks
 
     def _scan_all_ms_spectra(
         self,

--- a/thyra/readers/bruker/rapiflex/rapiflex_reader.py
+++ b/thyra/readers/bruker/rapiflex/rapiflex_reader.py
@@ -72,12 +72,39 @@ class RapiflexMetadataExtractor(MetadataExtractor):
 
         # Coordinate bounds are 0-based (normalized)
         coord_bounds = (0.0, float(width - 1), 0.0, float(height - 1))
-        coord_offsets = (0, 0, 0)
 
-        # Get pixel size from raster info
-        pixel_x = info.get("raster_x", 20.0)
-        pixel_y = info.get("raster_y", 20.0)
-        pixel_size = (float(pixel_x), float(pixel_y))
+        # Where on the slide this raster starts, in raster units. The .dat
+        # header carries it and it used to be discarded for a hard-coded
+        # (0, 0, 0), so no Rapiflex store could be placed against its
+        # optical image the way a solariX or timsTOF one can. The converter
+        # turns these into stage_offset_um by multiplying by the pixel
+        # size, so this is the only thing the reader owes it (issue #237).
+        coord_offsets = (
+            int(header.get("first_raster_x", 0)),
+            int(header.get("first_raster_y", 0)),
+            0,
+        )
+
+        # The raster step, or nothing. A missing declaration used to become
+        # 20 um, which convert.py then recorded as
+        # `pixel_size_source: automatic` with `detection_successful: True`
+        # -- a fabricated pitch the store called a measurement, while
+        # `format_specific.raster_step_um` sat empty. Every other reader
+        # returns None here and the CLI refuses with the actionable
+        # "use --pixel-size" hint; a refusal beats an invented number
+        # (issue #236).
+        pixel_x = info.get("raster_x")
+        pixel_y = info.get("raster_y")
+        if pixel_x is None or pixel_y is None:
+            logger.warning(
+                "%s declares no raster step (looked for 'Raster' in "
+                "sample_info.txt and the .mis), so the pixel size is "
+                "unknown. Pass --pixel-size to supply it.",
+                self._reader.data_path.name,
+            )
+            pixel_size = None
+        else:
+            pixel_size = (float(pixel_x), float(pixel_y))
 
         # Mass range
         mass_start = info.get("Mass Start", 0.0)

--- a/thyra/readers/waters/imaging_grid.py
+++ b/thyra/readers/waters/imaging_grid.py
@@ -5,15 +5,87 @@ Translates the logic from mzmine's ImagingMetadata.java to reconstruct
 a pixel coordinate grid from the laser X/Y positions stored in each scan's
 ScanInfo struct. Waters .raw imaging files do not store grid dimensions
 explicitly -- they must be derived from the set of unique laser positions.
+
+The derivation fits a *lattice* to those positions rather than ranking the
+distinct ones. Ranking is exact only for a raster with every row and column
+present: one missing interior row shifts every row below it up by one and
+inflates the pitch, because the extent still spans the missing interval
+while the interval count does not (issue #227). Fitting origin, pitch and
+count, then indexing by ``round((pos - origin) / pitch)``, is right in both
+cases and is what lets a function be tested against the raster it claims to
+belong to (issue #232).
 """
 
 import logging
+import statistics
 from dataclasses import dataclass, field
-from typing import Dict, Optional, Tuple
+from functools import cached_property
+from math import isfinite
+from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
-from .masslynx_lib import FunctionType, MassLynxLib, ScanInfoData
+from .masslynx_lib import NO_POSITION, FunctionType, MassLynxLib, ScanInfoData
 
 logger = logging.getLogger(__name__)
+
+#: How far off its lattice point a stage reading may sit, as a fraction of
+#: the pitch, before the raster is not a raster. A quarter pitch is far
+#: looser than any real stage -- the four registry acquisitions land on
+#: exact multiples of their step -- and still refuses the wobble that used
+#: to explode a 20x10 grid into 187x171 (issue #231).
+_LATTICE_TOLERANCE = 0.25
+
+#: The fraction of a fitted axis's lattice points that must carry a stage
+#: reading. A raster missing a row or two still scores far above this; a
+#: pitch mis-estimated from sub-pitch jitter scores a few percent, because
+#: the fitted pitch is then the wobble and the lattice has orders of
+#: magnitude more points than the acquisition has columns. Held at one half
+#: rather than something tighter because a legitimately ragged acquisition
+#: -- an aborted raster, a non-rectangular region -- still projects onto
+#: nearly every value of each axis, so per-axis occupancy stays high even
+#: when the image itself is sparse.
+_MIN_LATTICE_OCCUPANCY = 0.5
+
+
+@dataclass(frozen=True)
+class AxisLattice:
+    """The regular grid one stage axis was rastered on, in um.
+
+    ``pitch`` is 0.0 and ``count`` is 1 for an axis with a single position:
+    an aborted single-line scan has no interval to measure on its short
+    axis, and waters_extractor turns a 0.0 pitch into ``pixel_size=None``
+    and so into the actionable "use --pixel-size" refusal.
+    """
+
+    origin: float
+    pitch: float
+    count: int
+
+    def index(self, position: float) -> int:
+        """The 0-based lattice index a stage reading belongs to."""
+        if self.pitch <= 0.0:
+            return 0
+        return int(round((position - self.origin) / self.pitch))
+
+    def offset(self, position: float) -> float:
+        """How far a stage reading sits from its lattice point, in um."""
+        if self.pitch <= 0.0:
+            return abs(position - self.origin)
+        return abs(position - (self.origin + self.index(position) * self.pitch))
+
+    def holds(self, position: float) -> bool:
+        """Whether a stage reading lies on this lattice.
+
+        Deliberately unbounded: a raster MassLynx split across functions
+        continues past the extent of any one chunk, so the tail of a split
+        raster lies on the lattice at an index beyond ``count``. What is
+        being asked is whether the position shares the raster's phase, not
+        whether it falls inside the part of it seen so far.
+        """
+        if not isfinite(position):
+            return False
+        if self.pitch <= 0.0:
+            return position == self.origin
+        return self.offset(position) <= _LATTICE_TOLERANCE * self.pitch
 
 
 @dataclass
@@ -33,11 +105,46 @@ class ImagingGrid:
     lateral_width: float  # max_x - min_x in um, so centre-to-centre, not edge-to-edge
     lateral_height: float  # max_y - min_y in um, so centre-to-centre, not edge-to-edge
     scan_map: Dict[Tuple[int, int], ScanInfoData] = field(repr=False)
+    #: The fitted raster, when this grid was built by :func:`build_imaging_grid`.
+    #: ``None`` on a hand-built grid, where every position is taken on trust.
+    x_lattice: Optional[AxisLattice] = None
+    y_lattice: Optional[AxisLattice] = None
 
     @property
     def dimensions(self) -> Tuple[int, int, int]:
         """Grid dimensions as (n_x, n_y, n_z). z is always 1 for 2D imaging."""
         return (self.pixel_count_x, self.pixel_count_y, 1)
+
+    @cached_property
+    def scans_by_function(self) -> Dict[int, List[ScanInfoData]]:
+        """Positioned scan records grouped by function, in scan order.
+
+        Built once and cached. Function selection asks five different
+        questions of one function's scans and used to re-sort the whole
+        scan map for each: O(F x N log N) over the file, measured at 87 s
+        of selection against a 29 s grid build on a 25 M scan raster
+        (issue #235).
+
+        Cached, so ``scan_map`` must not be mutated once coordinates have
+        been queried.
+        """
+        grouped: Dict[int, List[ScanInfoData]] = {}
+        for (func, _scan), info in sorted(self.scan_map.items()):
+            if info.has_position:
+                grouped.setdefault(func, []).append(info)
+        return grouped
+
+    def lies_on_raster(self, scan_info: ScanInfoData) -> bool:
+        """Whether a scan's stage reading shares the fitted raster's phase.
+
+        True when the grid carries no fitted lattice, so a hand-built grid
+        behaves as it always did.
+        """
+        if self.x_lattice is None or self.y_lattice is None:
+            return True
+        return self.x_lattice.holds(
+            _mm_to_um_key(scan_info.laser_x_pos)
+        ) and self.y_lattice.holds(_mm_to_um_key(scan_info.laser_y_pos))
 
     def get_coordinates(
         self, scan_info: ScanInfoData
@@ -60,6 +167,21 @@ class ImagingGrid:
         if x_idx is not None and y_idx is not None:
             return (x_idx, y_idx, 0)
 
+        # A miss is not automatically a failure. The grid is fitted to the
+        # functions that define the raster, so a function selection has not
+        # accepted yet contributes no key to the maps -- including the tail
+        # of a raster MassLynx split across functions, whose pixels are the
+        # whole reason it gets rescued. A reading that lies on the raster
+        # has a pixel even when the extent fitted so far does not reach it;
+        # regrid_for_functions() grows the grid once the tail is kept, so
+        # an index past the current count never survives into iteration.
+        if (
+            self.x_lattice is not None
+            and self.y_lattice is not None
+            and self.lies_on_raster(scan_info)
+        ):
+            return (self.x_lattice.index(x_um), self.y_lattice.index(y_um), 0)
+
         logger.warning(
             f"No index found for laser position x={scan_info.laser_x_pos:.4f}mm "
             f"({x_um:.1f}um) -> {x_idx}, y={scan_info.laser_y_pos:.4f}mm "
@@ -80,61 +202,182 @@ def _mm_to_um_key(mm_value: float) -> float:
     return round(mm_value * 1000.0, 2)
 
 
-def build_imaging_grid(
-    ml: MassLynxLib,
-    handle,
-    function_types: Dict[int, FunctionType],
-) -> ImagingGrid:
-    """Build imaging grid by scanning all functions/scans for laser coordinates.
+def _fit_axis(positions: Sequence[float], axis: str) -> AxisLattice:
+    """Fit origin, pitch and count to one axis's distinct stage readings.
 
-    Translates ImagingMetadata.java constructor logic (lines 56-149).
+    The pitch is seeded from the *median* neighbour interval, which is
+    exact when every column is present and survives a minority of gaps: one
+    missing row among ten turns a single interval into a double one and
+    leaves the median at the true pitch, where ``extent / (n_distinct - 1)``
+    reports it 12.5 % high (issue #227).
 
-    Args:
-        ml: MassLynxLib instance with open handle.
-        handle: The opaque file handle from ml.open_file().
-        function_types: Pre-classified function types for all functions.
-
-    Returns:
-        ImagingGrid with coordinate maps and pixel metadata.
+    It is then refined to ``extent / (count - 1)`` so the two end positions
+    land exactly on lattice points, which keeps a complete raster on the
+    integers it was acquired at: the four registry acquisitions still fit
+    30.0000, 50.0000, 100.0000 and 500.0000 um exactly.
 
     Raises:
-        ValueError: If no scan carries a laser position, or if every
-            positioned scan carries the *same* one -- a single-pixel
-            "raster" is a spot acquisition, not an image.
+        ValueError: If the readings do not lie on a regular raster.
     """
-    x_positions: set = set()
-    y_positions: set = set()
-    scan_map: Dict[Tuple[int, int], ScanInfoData] = {}
+    unique = sorted(set(positions))
+    if len(unique) == 1:
+        return AxisLattice(origin=unique[0], pitch=0.0, count=1)
 
-    n_functions = ml.get_number_of_functions(handle)
-    total_scans = 0
+    intervals = [b - a for a, b in zip(unique, unique[1:])]
+    seed = statistics.median(intervals)
+    span = unique[-1] - unique[0]
+    if seed <= 0.0 or span <= 0.0:
+        raise ValueError(
+            f"Waters stage readings on the {axis} axis have no measurable "
+            f"raster pitch ({len(unique)} distinct positions spanning "
+            f"{span:.4f} um)."
+        )
 
-    for func in range(n_functions):
-        n_scans = ml.get_number_of_scans_in_function(handle, func)
-        for scan in range(n_scans):
-            scan_info = ml.get_scan_info(handle, func, scan)
-            scan_map[(func, scan)] = scan_info
+    count = int(round(span / seed)) + 1
+    pitch = span / (count - 1)
+    lattice = AxisLattice(origin=unique[0], pitch=pitch, count=count)
 
-            if not scan_info.has_position:
-                continue
+    worst = max(unique, key=lattice.offset)
+    worst_offset = lattice.offset(worst)
+    if worst_offset > _LATTICE_TOLERANCE * pitch:
+        raise ValueError(
+            f"Waters stage readings on the {axis} axis do not lie on a "
+            f"regular raster: with a fitted pitch of {pitch:.4f} um the "
+            f"reading at {worst:.2f} um sits {worst_offset:.4f} um "
+            f"({100.0 * worst_offset / pitch:.1f} % of a pitch) off the "
+            f"nearest raster line. Thyra will not guess which pixel it "
+            f"belongs to."
+        )
 
-            x_um = _mm_to_um_key(scan_info.laser_x_pos)
-            y_um = _mm_to_um_key(scan_info.laser_y_pos)
-            x_positions.add(x_um)
-            y_positions.add(y_um)
-            total_scans += 1
+    occupancy = len(unique) / count
+    if occupancy < _MIN_LATTICE_OCCUPANCY:
+        raise ValueError(
+            f"Waters stage readings on the {axis} axis fit a raster of "
+            f"{count} lines at {pitch:.4f} um but only {len(unique)} of "
+            f"them carry a reading ({100.0 * occupancy:.1f} %). That is "
+            f"sub-pitch jitter being read as the pitch, not a raster with "
+            f"gaps: the {len(unique)} distinct readings span "
+            f"{span:.2f} um. Thyra will not build a grid from it."
+        )
 
-    if not x_positions or not y_positions:
+    if len(unique) < count:
+        logger.warning(
+            "The Waters %s axis is missing %d of its %d raster lines "
+            "(pitch %.4f um). The grid keeps every line, so the gaps become "
+            "empty pixels rather than shifting the rows past them.",
+            axis,
+            count - len(unique),
+            count,
+            pitch,
+        )
+
+    return lattice
+
+
+@dataclass
+class _PositionCensus:
+    """What the stage readings of a set of functions looked like."""
+
+    x_positions: List[float] = field(default_factory=list)
+    y_positions: List[float] = field(default_factory=list)
+    positioned: int = 0
+    unpositioned: int = 0
+    non_finite: int = 0
+    partial_sentinel: int = 0
+
+
+def _census(
+    scan_map: Dict[Tuple[int, int], ScanInfoData],
+    functions: Optional[Iterable[int]] = None,
+) -> _PositionCensus:
+    """Collect the stage readings of the given functions (all, when None)."""
+    wanted = None if functions is None else set(functions)
+    census = _PositionCensus()
+    for (func, _scan), info in scan_map.items():
+        if wanted is not None and func not in wanted:
+            continue
+        x_mm, y_mm = info.laser_x_pos, info.laser_y_pos
+        if not (isfinite(x_mm) and isfinite(y_mm)):
+            census.non_finite += 1
+            continue
+        if not info.has_position:
+            census.unpositioned += 1
+            continue
+        if x_mm == NO_POSITION or y_mm == NO_POSITION:
+            census.partial_sentinel += 1
+        census.x_positions.append(_mm_to_um_key(x_mm))
+        census.y_positions.append(_mm_to_um_key(y_mm))
+        census.positioned += 1
+    return census
+
+
+def _grid_from_scan_map(
+    scan_map: Dict[Tuple[int, int], ScanInfoData],
+    functions: Optional[Iterable[int]] = None,
+) -> ImagingGrid:
+    """Fit a grid to the stage readings already collected in ``scan_map``.
+
+    Split out of :func:`build_imaging_grid` so the reader can re-fit the
+    raster to the functions it actually converts without touching the DLL
+    again. Deriving the pitch from every function -- including the ones
+    function selection then excludes -- let one off-raster reference spot
+    turn a 10x5 image at 30 um into an 11x6 one at 1097 x 440 um
+    (issue #232).
+    """
+    census = _census(scan_map, functions)
+
+    if census.non_finite:
+        logger.warning(
+            "%d Waters scan(s) report a non-finite stage position (NaN or "
+            "infinity) and are treated as unpositioned. A non-finite "
+            "reading used to be admitted as its own column, making the "
+            "reported pixel size NaN or infinite.",
+            census.non_finite,
+        )
+    if census.partial_sentinel:
+        logger.warning(
+            "%d Waters scan(s) report the no-position sentinel (%.1f mm) on "
+            "one axis and a real reading on the other. They are kept at "
+            "face value, so a genuine stage position at %.1f mm on both "
+            "axes would be dropped instead; check the raster origin if the "
+            "image looks shifted.",
+            census.partial_sentinel,
+            NO_POSITION,
+            NO_POSITION,
+        )
+
+    if not census.x_positions or not census.y_positions:
         raise ValueError("No valid laser positions found in Waters imaging data")
 
-    # Build sorted index maps (position_um -> 0-based index)
-    sorted_x = sorted(x_positions)
-    sorted_y = sorted(y_positions)
-    x_index_map = {val: idx for idx, val in enumerate(sorted_x)}
-    y_index_map = {val: idx for idx, val in enumerate(sorted_y)}
+    x_lattice = _fit_axis(census.x_positions, "x")
+    y_lattice = _fit_axis(census.y_positions, "y")
 
-    pixel_count_x = len(sorted_x)
-    pixel_count_y = len(sorted_y)
+    # The no-position sentinel is a coordinate a stage can really visit, and
+    # a raster that passes through it loses that pixel with no message. Only
+    # worth saying when the raster actually reaches -1.0 mm on both axes,
+    # which is why this is checked against the fitted lattice rather than
+    # warned about on every file: the registry's DESI runs do use negative
+    # stage millimetres (x from -11.4 mm, y from -6.0 mm), so this is not
+    # hypothetical for them (issue #231).
+    sentinel_um = _mm_to_um_key(NO_POSITION)
+    if (
+        census.unpositioned
+        and x_lattice.holds(sentinel_um)
+        and y_lattice.holds(sentinel_um)
+        and 0 <= x_lattice.index(sentinel_um) < x_lattice.count
+        and 0 <= y_lattice.index(sentinel_um) < y_lattice.count
+    ):
+        logger.warning(
+            "This raster passes through (%.1f, %.1f) mm, which is also the "
+            "no-position sentinel, so the %d scan(s) reporting it were "
+            "dropped as unpositioned. Pixel (%d, %d) may be empty because "
+            "of that rather than because nothing was acquired there.",
+            NO_POSITION,
+            NO_POSITION,
+            census.unpositioned,
+            x_lattice.index(sentinel_um),
+            y_lattice.index(sentinel_um),
+        )
 
     # A stage that never moved is not a raster. The check above only catches
     # the total absence of positions; a *constant* position passes it, and
@@ -147,14 +390,15 @@ def build_imaging_grid(
     # Real DESI images on that same share do carry stage coordinates in
     # these fields and grid normally (401x401, 247x140, ...), so this
     # refuses the non-images without costing anything real. See issue #213.
-    if pixel_count_x == 1 and pixel_count_y == 1:
+    if x_lattice.count == 1 and y_lattice.count == 1:
         raise ValueError(
             f"Every positioned scan reports the same stage position "
-            f"(x={sorted_x[0]:.1f} um, y={sorted_y[0]:.1f} um), so this "
-            f"acquisition has a single pixel: {total_scans} positioned scans "
-            f"in {len(scan_map)} total. A one-pixel raster with a 0.0 um "
-            f"pitch is a spot, calibration or tuning acquisition, not an "
-            f"image -- Thyra has no raster to build from it."
+            f"(x={x_lattice.origin:.1f} um, y={y_lattice.origin:.1f} um), so "
+            f"this acquisition has a single pixel: {census.positioned} "
+            f"positioned scans in {len(scan_map)} total. A one-pixel raster "
+            f"with a 0.0 um pitch is a spot, calibration or tuning "
+            f"acquisition, not an image -- Thyra has no raster to build "
+            f"from it."
         )
 
     # Laser positions are pixel *centres*, so the span from the first to the
@@ -162,39 +406,169 @@ def build_imaging_grid(
     # mixed a centre-to-centre extent with an edge-to-edge one and reported
     # a pitch low by exactly 1/N -- independently per axis, so a square
     # raster came out anisotropic: measured, a 30 um acquisition gave
-    # 29.66 x 28.93 and a 100 um one gave 99.40 x 97.83. Nothing caught it
-    # because _determine_pixel_size keeps only x, so the disagreement
-    # between the two axes never reached anywhere it would look wrong.
-    # See issue #217. (mzmine, which this file translates, computes the
-    # extent the other way round -- lateralWidth = count * pixelWidth -- and
-    # has the divide-by-count form commented out in ImagingParameters.java.)
-    #
-    # An axis with a single position has no interval to measure, and keeps
-    # 0.0: waters_extractor turns that into pixel_size=None, which becomes
-    # the actionable "Pixel size not found in metadata. Use --pixel-size"
-    # refusal rather than a fabricated number. Aborted single-line scans
-    # (the share holds 138x1 and 48x1) take that path.
-    lateral_width = sorted_x[-1] - sorted_x[0] if pixel_count_x > 1 else 0.0
-    lateral_height = sorted_y[-1] - sorted_y[0] if pixel_count_y > 1 else 0.0
+    # 29.66 x 28.93 and a 100 um one gave 99.40 x 97.83. See issue #217.
+    # (mzmine, which this file translates, computes the extent the other way
+    # round -- lateralWidth = count * pixelWidth -- and has the
+    # divide-by-count form commented out in ImagingParameters.java.)
+    x_index_map = {pos: x_lattice.index(pos) for pos in set(census.x_positions)}
+    y_index_map = {pos: y_lattice.index(pos) for pos in set(census.y_positions)}
 
-    pixel_size_x = lateral_width / (pixel_count_x - 1) if pixel_count_x > 1 else 0.0
-    pixel_size_y = lateral_height / (pixel_count_y - 1) if pixel_count_y > 1 else 0.0
+    lateral_width = x_lattice.pitch * (x_lattice.count - 1)
+    lateral_height = y_lattice.pitch * (y_lattice.count - 1)
+
+    _warn_on_shared_pixels(scan_map, functions, x_index_map, y_index_map)
 
     logger.info(
-        f"Built imaging grid: {pixel_count_x}x{pixel_count_y} pixels, "
-        f"pixel size: {pixel_size_x:.1f}x{pixel_size_y:.1f} um, "
+        f"Built imaging grid: {x_lattice.count}x{y_lattice.count} pixels, "
+        f"pixel size: {x_lattice.pitch:.1f}x{y_lattice.pitch:.1f} um, "
         f"lateral: {lateral_width:.1f}x{lateral_height:.1f} um, "
-        f"{total_scans} positioned scans in {len(scan_map)} total scans"
+        f"{census.positioned} positioned scans in {len(scan_map)} total scans"
     )
 
     return ImagingGrid(
         x_index_map=x_index_map,
         y_index_map=y_index_map,
-        pixel_count_x=pixel_count_x,
-        pixel_count_y=pixel_count_y,
-        pixel_size_x=pixel_size_x,
-        pixel_size_y=pixel_size_y,
+        pixel_count_x=x_lattice.count,
+        pixel_count_y=y_lattice.count,
+        pixel_size_x=x_lattice.pitch,
+        pixel_size_y=y_lattice.pitch,
         lateral_width=lateral_width,
         lateral_height=lateral_height,
         scan_map=scan_map,
+        x_lattice=x_lattice,
+        y_lattice=y_lattice,
     )
+
+
+def _warn_on_shared_pixels(
+    scan_map: Dict[Tuple[int, int], ScanInfoData],
+    functions: Optional[Iterable[int]],
+    x_index_map: Dict[float, int],
+    y_index_map: Dict[float, int],
+) -> None:
+    """Say so when more than one scan lands on the same pixel.
+
+    Two scans reporting the same stage position are summed into one pixel
+    by the converter, which is a defensible choice and was a silent one:
+    measured on the registry's 100 um MALDI set, function 2 holds 1275
+    positioned scans on 1274 distinct pixels, the stage having stopped
+    between two consecutive acquisitions 40 ms apart (issue #233).
+    """
+    wanted = None if functions is None else set(functions)
+    seen: Set[Tuple[int, int]] = set()
+    duplicated: Set[Tuple[int, int]] = set()
+    extra = 0
+    for (func, _scan), info in scan_map.items():
+        if wanted is not None and func not in wanted:
+            continue
+        if not info.has_position:
+            continue
+        x_idx = x_index_map.get(_mm_to_um_key(info.laser_x_pos))
+        y_idx = y_index_map.get(_mm_to_um_key(info.laser_y_pos))
+        if x_idx is None or y_idx is None:
+            continue
+        pixel = (x_idx, y_idx)
+        if pixel in seen:
+            duplicated.add(pixel)
+            extra += 1
+        else:
+            seen.add(pixel)
+
+    if not duplicated:
+        return
+
+    sample = ", ".join(f"({x}, {y})" for x, y in sorted(duplicated)[:5])
+    if len(duplicated) > 5:
+        sample += ", ..."
+    logger.warning(
+        "%d Waters scan(s) land on %d pixel(s) that another scan already "
+        "covers, so those pixels carry the SUM of every scan on them: %s. "
+        "The stage reported the same position twice; the store has "
+        "%d pixels for %d positioned scans.",
+        extra,
+        len(duplicated),
+        sample,
+        len(seen),
+        len(seen) + extra,
+    )
+
+
+def build_imaging_grid(
+    ml: MassLynxLib,
+    handle,
+    function_types: Dict[int, FunctionType],
+    include_functions: Optional[Iterable[int]] = None,
+) -> ImagingGrid:
+    """Build imaging grid by scanning all functions/scans for laser coordinates.
+
+    Translates ImagingMetadata.java constructor logic (lines 56-149).
+
+    Every function's scan records are cached in ``scan_map`` whatever
+    ``include_functions`` says, so the raster can be re-fitted later
+    (:func:`regrid_for_functions`) without touching the DLL again.
+
+    Args:
+        ml: MassLynxLib instance with open handle.
+        handle: The opaque file handle from ml.open_file().
+        function_types: Pre-classified function types for all functions.
+        include_functions: Fit the raster to these functions' stage
+            readings only. ``None`` fits it to every function, which is
+            what a caller that has not classified them yet wants.
+
+    Returns:
+        ImagingGrid with coordinate maps and pixel metadata.
+
+    Raises:
+        ValueError: If no scan carries a laser position, if the positions do
+            not lie on a regular raster, or if every positioned scan carries
+            the *same* one -- a single-pixel "raster" is a spot acquisition,
+            not an image.
+    """
+    scan_map: Dict[Tuple[int, int], ScanInfoData] = {}
+
+    n_functions = ml.get_number_of_functions(handle)
+    for func in range(n_functions):
+        n_scans = ml.get_number_of_scans_in_function(handle, func)
+        for scan in range(n_scans):
+            scan_map[(func, scan)] = ml.get_scan_info(handle, func, scan)
+
+    return _grid_from_scan_map(scan_map, include_functions)
+
+
+def regrid_for_functions(grid: ImagingGrid, functions: Iterable[int]) -> ImagingGrid:
+    """Re-fit the raster to the stage readings of ``functions`` alone.
+
+    Uses the scan records already cached on ``grid``, so this costs no
+    further DLL calls. Returns ``grid`` unchanged when the restriction
+    leaves the geometry identical, which is every acquisition whose
+    excluded functions sat on the raster with the rest, and when ``grid``
+    carries no fitted lattice -- a hand-built grid is taken on trust, the
+    same way :meth:`ImagingGrid.lies_on_raster` takes it.
+    """
+    if grid.x_lattice is None or grid.y_lattice is None:
+        return grid
+    refitted = _grid_from_scan_map(grid.scan_map, functions)
+    same = (
+        refitted.pixel_count_x == grid.pixel_count_x
+        and refitted.pixel_count_y == grid.pixel_count_y
+        and refitted.pixel_size_x == grid.pixel_size_x
+        and refitted.pixel_size_y == grid.pixel_size_y
+        and refitted.x_index_map == grid.x_index_map
+        and refitted.y_index_map == grid.y_index_map
+    )
+    if same:
+        return grid
+    logger.warning(
+        "The imaging grid was re-fitted to the converted functions alone: "
+        "%dx%d at %.4f x %.4f um, was %dx%d at %.4f x %.4f um. The excluded "
+        "functions' stage readings were part of the raster Thyra measured.",
+        refitted.pixel_count_x,
+        refitted.pixel_count_y,
+        refitted.pixel_size_x,
+        refitted.pixel_size_y,
+        grid.pixel_count_x,
+        grid.pixel_count_y,
+        grid.pixel_size_x,
+        grid.pixel_size_y,
+    )
+    return refitted

--- a/thyra/readers/waters/masslynx_lib.py
+++ b/thyra/readers/waters/masslynx_lib.py
@@ -25,6 +25,7 @@ from ctypes import (
 )
 from dataclasses import dataclass
 from enum import Enum, auto
+from math import isfinite
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -95,8 +96,21 @@ class ScanInfoData:
 
     @property
     def has_position(self) -> bool:
-        """True if this scan has valid laser position (not sentinel -1.0)."""
-        return not (self.laser_x_pos == NO_POSITION and self.laser_y_pos == NO_POSITION)
+        """True if this scan has a usable laser position.
+
+        Two ways to fail. The documented one is the -1.0 mm sentinel on
+        both axes. The other is a non-finite reading: NaN is not equal to
+        anything including itself, so it passed the sentinel test, and
+        every NaN then became its own column in the grid -- one of them
+        made the reported pixel size NaN, two of them changed the pitch of
+        the real axis, and the converter's ``pixel_size_um <= 0`` guards
+        are False for NaN and infinity, so such a pitch reached the store
+        (issue #231).
+        """
+        x, y = self.laser_x_pos, self.laser_y_pos
+        if not (isfinite(x) and isfinite(y)):
+            return False
+        return not (x == NO_POSITION and y == NO_POSITION)
 
 
 class WatersLibError(Exception):

--- a/thyra/readers/waters/waters_reader.py
+++ b/thyra/readers/waters/waters_reader.py
@@ -24,7 +24,7 @@ from ...core.msms import (
 )
 from ...core.registry import register_reader
 from ...metadata.extractors.waters_extractor import WatersMetadataExtractor
-from .imaging_grid import ImagingGrid, build_imaging_grid
+from .imaging_grid import ImagingGrid, build_imaging_grid, regrid_for_functions
 from .instrument import WatersInstrument, identify_waters_instrument
 from .masslynx_lib import FunctionType, MassLynxLib, ScanInfoData
 
@@ -133,6 +133,9 @@ class WatersReader(BaseMSIReader):
         self._excluded_functions: Dict[int, Dict[str, Any]] = {}
         #: Raster chunks MassLynx refuses to centroid: index -> pixels lost.
         self._uncentroidable_functions: Dict[int, int] = {}
+        #: Functions covering their own pixels off the raster the MS
+        #: functions describe: index -> pixels they held.
+        self._off_raster_functions: Dict[int, int] = {}
         self._common_mass_axis_cache: Optional[NDArray[np.float64]] = None
         self._use_centroid = use_centroid
         self._closed = False
@@ -159,6 +162,48 @@ class WatersReader(BaseMSIReader):
                 f"No _FUNC*.DAT files found in {self.data_path}. "
                 "Is this a valid Waters .raw directory?"
             )
+
+    def _function_dat_files(self) -> Dict[int, Path]:
+        """The ``_FUNC*.DAT`` files present, keyed by 0-based function index.
+
+        MassLynx numbers the files from one, so ``_FUNC001.DAT`` holds
+        function 0.
+        """
+        found: Dict[int, Path] = {}
+        for path in self.data_path.iterdir():
+            name = path.name.upper()
+            if not (name.startswith("_FUNC") and name.endswith(".DAT")):
+                continue
+            stem = name[len("_FUNC") : -len(".DAT")]
+            if stem.isdigit():
+                found[int(stem) - 1] = path
+        return found
+
+    def _validate_function_files(self, n_functions: int) -> None:
+        """Refuse a .raw directory that has lost one of its function files.
+
+        The DLL keeps reporting a function whose ``_FUNC*.DAT`` is gone --
+        with 0 scans, no error and no warning -- so the only symptom is a
+        smaller scan total than the acquisition had. Measured on a 16
+        function file with ``_FUNC001.DAT`` deleted: still 16 functions,
+        scans [0, 50, 55, ...], 820 positioned scans instead of 848, and
+        the reader opened it without a word. On a raster MassLynx split
+        across functions (functions 0/1/2 holding rows 0-19 / 19-38 /
+        38-45) the same damage drops 20 rows of the image (issue #229).
+        """
+        present = self._function_dat_files()
+        missing = [f for f in range(n_functions) if f not in present]
+        if not missing:
+            return
+        raise ValueError(
+            f"{self.data_path.name} declares {n_functions} function(s) but "
+            f"{len(missing)} of them have no data file: "
+            f"{', '.join(f'_FUNC{f + 1:03d}.DAT' for f in missing)}. "
+            f"MassLynx still reports those functions, with 0 scans, so "
+            f"converting this directory would silently drop whatever they "
+            f"held -- on a raster split across functions, entire rows of "
+            f"the image. Restore the missing file(s) from the acquisition."
+        )
 
     def _ensure_initialized(self) -> None:
         """Lazy initialization: load DLL, open file, build imaging grid.
@@ -211,9 +256,24 @@ class WatersReader(BaseMSIReader):
                 f"Function types: {self._function_types}"
             )
 
-        # Build the imaging grid (scans all functions/scans for laser coordinates)
+        # Refuse a file whose functions have lost their data. The DLL
+        # reports a function whose _FUNC*.DAT is gone, with 0 scans, so
+        # nothing downstream notices: on a raster MassLynx split across
+        # functions, one missing chunk file silently drops its rows of the
+        # image (issue #229).
+        self._validate_function_files(n_funcs)
+
+        # Build the imaging grid from the MS functions alone. They are what
+        # defines the raster; everything else is measured against it. The
+        # pitch used to come from every function including the ones
+        # selection then excluded, so one reference spot parked off the
+        # raster turned a 10x5 image at 30 um into an 11x6 one at
+        # 1097 x 440 um (issue #232).
         self._imaging_grid = build_imaging_grid(
-            self._ml, self._handle, self._function_types
+            self._ml,
+            self._handle,
+            self._function_types,
+            include_functions=ms_functions,
         )
 
         # Which functions hold the image: the raster chunks MassLynx named
@@ -225,6 +285,14 @@ class WatersReader(BaseMSIReader):
         )
         self._ms_functions = self._select_converted_functions(
             candidates, self._imaging_grid
+        )
+
+        # Re-fit the raster to what is actually converted. A rescued chunk
+        # extends the image past the extent of the MS functions, so the
+        # grid has to grow to hold it; an excluded function's readings must
+        # not leave their pitch behind in a grid it contributes no pixel to.
+        self._imaging_grid = regrid_for_functions(
+            self._imaging_grid, self._ms_functions
         )
 
         # A single-pixel grid is refused by build_imaging_grid() above rather
@@ -244,12 +312,16 @@ class WatersReader(BaseMSIReader):
 
     @staticmethod
     def _positioned_scans(func: int, grid: "ImagingGrid") -> List["ScanInfoData"]:
-        """The scan records of one function that carry a laser position."""
-        return [
-            info
-            for (f, _scan), info in sorted(grid.scan_map.items())
-            if f == func and info.has_position
-        ]
+        """The scan records of one function that carry a laser position.
+
+        Reads the per-function index the grid builds once. This used to
+        sort and filter the whole scan map on every call, and function
+        selection asks five different questions of each function's scans:
+        O(F x N log N) over the file, measured at 87 s of selection against
+        a 29 s grid build on a single-function 25 M scan raster, and a
+        25-function Synapt G1 run pays it 25 times over (issue #235).
+        """
+        return grid.scans_by_function.get(func, [])
 
     @classmethod
     def _function_pixels(
@@ -301,9 +373,24 @@ class WatersReader(BaseMSIReader):
         for f in ms_functions:
             covered |= self._function_pixels(f, grid)
 
-        extra, uncentroidable = [], []
+        extra, uncentroidable, off_raster = [], [], []
         for f, ft in sorted(function_types.items()):
             if ft is not FunctionType.LOCKMASS:
+                continue
+            # The rescue rule reads "covers pixels no MS function covers"
+            # as "is the tail of a split raster". A reference spot parked
+            # away from the sample covers a pixel no MS function covers
+            # too, and used to be converted as an image pixel on that
+            # basis. The tail of a split raster continues the raster, so
+            # it lands on the same lattice; a spot does not (issue #232).
+            #
+            # Tested before the pixel count, not after: an off-raster
+            # reading has no pixel in this grid at all, so it would
+            # otherwise fall out as "covers nothing new" and never be
+            # named.
+            scans = self._positioned_scans(f, grid)
+            if scans and not all(grid.lies_on_raster(s) for s in scans):
+                off_raster.append(f)
                 continue
             new_pixels = self._function_pixels(f, grid) - covered
             if not new_pixels:
@@ -312,6 +399,19 @@ class WatersReader(BaseMSIReader):
                 uncentroidable.append((f, len(new_pixels)))
             else:
                 extra.append(f)
+
+        for f in off_raster:
+            self._off_raster_functions[f] = len(self._positioned_scans(f, grid))
+        if off_raster:
+            logger.warning(
+                "Function(s) %s cover pixels no MS function covers, but "
+                "their stage positions do not lie on the raster the MS "
+                "functions describe, so they are not the tail of a split "
+                "raster. They are excluded: a reference or calibration "
+                "spot converted as an image pixel would stretch the grid "
+                "around it.",
+                ", ".join(str(f) for f in off_raster),
+            )
 
         if uncentroidable:
             lost = sum(n for _f, n in uncentroidable)
@@ -389,6 +489,18 @@ class WatersReader(BaseMSIReader):
             }
             for f, n_pixels in self._uncentroidable_functions.items()
         }
+        # No n_unique_pixels: an off-raster reading has no pixel in this
+        # grid, which is the point. _function_summary's n_scans says how
+        # much was left out.
+        self._excluded_functions.update(
+            {
+                f: {
+                    **self._function_summary(f, grid),
+                    "reason": "stage positions do not lie on the imaging raster",
+                }
+                for f in self._off_raster_functions
+            }
+        )
         kept: List[int] = []
         for group in self._pixel_groups(ms_functions, grid):
             kept.extend(self._select_within_group(group, grid))


### PR DESCRIPTION
Batch 1 of the 2026-09-08 robustness sweep. Closes #227, #229, #230, #231, #232, #233, #235, #236, #237.

## The one change most of these are

The imaging grid was a **ranking of the distinct stage positions** per axis, with the pitch as `extent / (n_distinct - 1)`. That is exact for a complete raster and wrong for everything else. It is now a **lattice** — origin, pitch and count per axis — with the pitch seeded from the median neighbour interval and the index taken as `round((pos - origin) / pitch)`.

The median interval is what makes it gap-robust: one missing row among ten turns a single interval into a double one and leaves the median at the true pitch. The pitch is then refined to `extent / (count - 1)` so the end positions land exactly on lattice points, which is what keeps a complete raster on the integers it was acquired at — the four registry acquisitions still fit **30.0000, 50.0000, 100.0000 and 500.0000 um exactly**, pinned as a regression test against #217.

Two guards decide when the fit is not a raster at all:

| Guard | Catches | Registry sets |
|---|---|---|
| max residual > 0.25 pitch | a reading nowhere near a raster line | 0 % — all land on exact multiples |
| lattice occupancy < 50 % | sub-pitch jitter read as the pitch | 100 % occupancy |

## Per issue

**#227** — a missing interior row left the extent spanning nine pitches while only eight intervals were counted, so a 30 um raster reported 33.75, and every row past the gap was stored one row up. The gap is now empty pixels, and named.

**#231** — three input-validation gaps, one guard:
- ±1 % jitter turned a 20×10 raster into a 187×171 store with a 3 × 1.6 um "pitch" and 200 of 31,977 pixels filled, silently. The occupancy guard refuses it.
- `has_position` now requires finite readings. NaN is not equal to itself, so it passed the sentinel test, became its own column, and reached the store as a NaN pixel size — every guard downstream reads `<= 0`, which is False for NaN and for infinity. The CLI and `convert_msi` now reject non-finite numbers **before a file is opened**, rather than after a 47 s metadata scan as a traceback.
- A raster passing through the −1.0 mm sentinel now says which pixel that costs it. Checked against the fitted lattice, so it stays quiet on every raster that does not reach −1.0 mm.

**#232** — the pitch came from every function, including ones selection later excluded, so a reference spot off the raster made a 10×5 image at 30 um into an 11×6 one at 1097 × 440 um. The lattice is fitted to the MS functions, then re-fitted to whatever is converted. The #210 rescue rule now also requires the candidate's pixels to **lie on the raster**: the tail of a split raster continues it, a spot does not.

> One thing worth a reviewer's eye: fitting to the MS functions alone silently **broke the #210 rescue** — a tail contributes no key to a grid fitted before it is accepted, so it covered "no new pixels" and was never rescued. The existing chunked-raster tests did not catch it because they inject a hand-built grid whose index map already covers every function. `get_coordinates` now falls back to the lattice on a map miss, and there is a test that builds the grid for real.

**#233** — two scans on one stage position are summed into one pixel; that was silent while `n_spectra` counted both and `peak_counts_per_pixel` kept only the last. Counts accumulate, `n_spectra` counts pixels, `sum(peak_counts) == total_peaks`.

**#235** — function selection asked five questions of each function's scans and re-sorted the whole scan map for each: O(F × N log N). One cached per-function index instead.

**#229** — the DLL keeps reporting a function whose `_FUNC*.DAT` is gone, with 0 scans and no error. A directory declaring more functions than it has data files is refused, naming them.

**#230** — the Xevo DESI runs overshoot their declared 100–1200 range by 0.01–0.25 Da, so the shared axis from #207 was never once used on them, and the fallback logged "using the stored span so nothing is dropped" in the same run the axis builder then dropped the edge peaks in. The declared range is widened to cover the stored span, and the message no longer claims what the axis builder contradicts. Note this makes the axis run-specific where a purely declared one is not — the issue sanctions that trade explicitly, and folding edge peaks into the edge bins instead is #239, in batch 5.

**#236** — Rapiflex fell back to a 20 um raster step when the acquisition declared none, which `convert.py` recorded as `pixel_size_source: automatic` with `detection_successful: True` while `raster_step_um` sat empty. It now returns no pixel size, so the CLI refuses with the `--pixel-size` hint like every other reader.

**#237** — the `.dat` header's raster origin was discarded for a hard-coded `(0, 0, 0)`. It now reaches `coordinate_offsets_px`, and `stage_offset_um` through it, so a Rapiflex store can be placed against its optical image the way a solariX one can. Stored pixel coordinates stay 0-based.

## Tests

96 new tests across four files. The mock `.raw` fixtures now write one `_FUNC*.DAT` per mocked function — a test asserting against a directory MassLynx could not have produced was asserting against nothing.

Local: **2274 unit passed**, **54 integration passed**, black/isort/flake8/mypy/bandit/pydocstyle clean. The two mypy errors in `rapiflex_reader.py` and `__main__.py` are pre-existing — verified against the clean tree.

## Not addressed here

No behaviour change to resampling edge bins (#239, batch 5) and none to what a store records for excluded functions beyond the new `reason`.
