### PR TITLE
Batch 2: the CLI surface

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,6 +27,12 @@ thyra [OPTIONS] INPUT OUTPUT
 | `1` | Conversion failed |
 | `2` | Invalid command-line arguments (click usage error) |
 
+A refusal Thyra planned for -- a `.d` directory with no analysis files, a
+Waters raster whose stage never moved, a mass range with no extent -- prints
+its message once at `ERROR` and nothing else. The traceback behind it is kept
+for `-v DEBUG`, and a traceback at `ERROR` now means an exception nobody
+planned for, which is worth reporting as a bug.
+
 A failed conversion renames any partially written store to
 `<output>.zarr.failed`, so the output path stays free for a retry and an
 incomplete store is never left where a finished one is expected. This makes
@@ -44,7 +50,7 @@ thyra input.imzML output.zarr && python analyse.py output.zarr
 |--------|---------|-------------|
 | `--format [spatialdata]` | `spatialdata` | Output format |
 | `--pixel-size FLOAT` | auto-detect | Pixel size in micrometers |
-| `--region TEXT` | all | Convert one region, by `.mis` Area Name or by DB RegionNumber |
+| `--region TEXT` | all | Convert one region, by `.mis` Area Name or by DB RegionNumber. Checked against the dataset's own region list whether it has one region or several; a value that matches no Area Name is read as a RegionNumber, and says so |
 | `--resample / --no-resample` | enabled | Mass axis resampling |
 | `--include-optical / --no-optical` | enabled | Include optical images in output |
 | `--mobility-table / --no-mobility-table` | enabled | Also write the mobility-resolved sibling table when the source shares one set of (m/z, ion mobility) features across pixels (see [Output Format](output-format.md#ion-mobility)) |
@@ -114,12 +120,13 @@ thyra input.imzML output.zarr --log-file conversion.log
 
 ## Ion Mobility Grid (Advanced)
 
-These size the grid `--mobility-grid` bins onto. They do nothing without it.
+These size the grid `--mobility-grid` bins onto. They do nothing without it,
+and passing one without it is logged at `WARNING`.
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--mobility-bins INTEGER` | `256` | Mobility channels the grid divides the range into |
-| `--mobility-min FLOAT` | axis minimum | Lower edge of the grid, in the axis unit (1/K0 for TIMS) |
+| `--mobility-bins INTEGER` | `256` | Mobility channels the grid divides the range into. At least 1 |
+| `--mobility-min FLOAT` | axis minimum | Lower edge of the grid, in the axis unit (1/K0 for TIMS). May be zero or negative -- it is a position on an axis, not a quantity -- but must be below `--mobility-max` |
 | `--mobility-max FLOAT` | axis maximum | Upper edge of the grid |
 
 ### Examples
@@ -309,9 +316,17 @@ flags that used to live here select nothing.
 
 ## imzML-Specific
 
+!!! note "A vendor option on another vendor's file is logged as ignored"
+    Each of the format-specific groups below -- imzML, Bruker, Waters -- and
+    the ion mobility grid options are accepted on any input and do nothing on
+    a source they do not apply to. Passing one on another format is now
+    logged at `WARNING`, naming the option and both formats, so a script that
+    has been carrying a dead flag says so on the next run rather than
+    producing a store byte-identical to the plain one in silence.
+
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--spectrum-type TYPE` | `auto` | `auto`, `profile`, or `centroid` -- declare the spectrum representation instead of detecting it |
+| `--spectrum-type TYPE` | `auto` | `auto`, `profile`, or `centroid` -- declare the spectrum representation instead of detecting it. imzML only |
 
 By default Thyra reads the representation the file declares (`MS:1000127`
 centroid / `MS:1000128` profile), wherever in the document it is written, and
@@ -345,14 +360,17 @@ thyra input.imzML output.zarr -v INFO
 
 ## Bruker-Specific
 
-These options only apply when converting Bruker `.d` directories.
+Grouped here because this is where they are reached for. All but
+`--intensity-threshold` only apply when converting Bruker `.d` directories;
+that one is honoured by every reader, and is here because continuous-mode
+Bruker data is what usually needs it.
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--use-recalibrated / --no-recalibrated` | enabled | Use recalibrated m/z state |
-| `--interactive-calibration` | off | Display available calibration states |
-| `--intensity-threshold FLOAT` | none | Minimum intensity filter |
-| `--tdf-spectrum {scan_sum,vendor_centroid}` | `scan_sum` | How a TDF (TIMS) frame's mobility scans collapse into one spectrum per pixel |
+| `--use-recalibrated / --no-recalibrated` | enabled | Use recalibrated m/z state. Bruker `.d` only |
+| `--interactive-calibration` | off | Display available calibration states. Bruker `.d` only |
+| `--intensity-threshold FLOAT` | none | Minimum intensity filter. **Every format** |
+| `--tdf-spectrum {scan_sum,vendor_centroid}` | `scan_sum` | How a TDF (TIMS) frame's mobility scans collapse into one spectrum per pixel. Bruker TDF only |
 
 ### Examples
 
@@ -389,7 +407,8 @@ thyra tims_data.d output.zarr --tdf-spectrum vendor_centroid
 
 ## Waters-Specific
 
-This option only applies when converting Waters `.raw` directories.
+This option only applies when converting Waters `.raw` directories; on any
+other input it is logged as ignored.
 
 | Option | Default | Description |
 |--------|---------|-------------|
@@ -437,7 +456,7 @@ thyra synapt_run.raw output.zarr --waters-spectrum profile
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--dataset-id TEXT` | `msi_dataset` | Dataset identifier used in element keys |
+| `--dataset-id TEXT` | `msi_dataset` | Dataset identifier used in element keys. Letters, digits, underscores, dots and hyphens only, and not `.`, `..` or a leading `__`: it names every element in the store, so SpatialData's naming rule applies to it. Checked before any pass over the source |
 | `--handle-3d` | off | Process as 3D volume instead of 2D slices |
 | `--z-spacing FLOAT` | in-plane pixel size | Distance between consecutive slices, in um. Only used with `--handle-3d` |
 
@@ -476,6 +495,12 @@ the number has to come from whoever cut them.
     Without 3D handling each slice is written as its own 2D image and there is
     no z axis to space out. Passing `--z-spacing` on its own is logged as
     ignored rather than silently accepted.
+
+!!! warning "`--handle-3d` on a single-slice acquisition"
+    One plane has no slice-to-slice distance, so no `z_spacing_um` is applied
+    or recorded and a `--z-spacing` given alongside is logged as ignored. The
+    store is still written as a volume of one plane, which changes the element
+    keys -- the table is `{id}`, not `{id}_z0` -- but not the values.
 
 ---
 

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -195,6 +195,35 @@ print(f"Non-zero: {X.nnz:,} ({X.nnz / (X.shape[0] * X.shape[1]) * 100:.2f}%)")
     consumer can binary-search a column's indices directly, and scipy reports
     `has_sorted_indices` as true without a `sort_indices()` pass.
 
+!!! note "Every stored intensity is a real, non-negative number"
+    Non-finite and negative intensities are dropped from a spectrum before it
+    is resampled, and the conversion says how many at `WARNING` the first time
+    it happens.
+
+    A NaN is not a measurement, and one of them makes every aggregate over its
+    column NaN -- the average spectrum, the TIC image, any ion image. A
+    negative value is a baseline subtraction that overshot rather than a
+    smaller measurement, and nothing that reads a store treats it as signal: a
+    TIC, an ion image and a mean spectrum all read it as removing current that
+    was never there.
+
+    Dropping them before either resampling method runs is also what makes the
+    two agree. Given a negative value, `nearest_neighbor` stored it (leaving
+    the pixel with a TIC of 0) while `tic_preserving` found a non-positive
+    total for the spectrum and zeroed the whole thing, so the same file
+    converted two ways gave two different stores with nothing in either saying
+    why.
+
+    The sibling tables built from the raw scans -- the mobility grid, the
+    demultiplexed MS/MS split -- drop the same points by the same rule, so a
+    grid's marginal over channels still reproduces the summed table's column
+    on a source that carries them.
+
+    Zero is not affected by this; the sparse write drops explicit zeros as it
+    always did. A source whose m/z values are non-finite is refused outright
+    instead, since those values *are* `var["mz"]` and dropping them would
+    desynchronise every index paired with them.
+
 ### Ion Images
 
 To visualise the spatial distribution of a specific m/z value:
@@ -283,6 +312,7 @@ panel draws.
 | `mz_edges` | `float64[m + 1]`: bin edges on the common m/z axis, which is coarsened by an integer factor to about 4,000 bins (`m` is the axis length itself when it is shorter) |
 | `mobility_edges` | `float64[k + 1]`, **`k = 256`**: equal-width bins in the axis unit, ascending, spanning the axis `values` |
 | `counts` | `float32[m, k]`: mean intensity per bin over pixels |
+| `current_ratio` | `float`: what fraction of `uns["average_spectrum"]`'s ion current the heatmap holds -- 1.0 under `scan_sum`, about 0.85 under `vendor_centroid` |
 
 `k = 256` is fixed on purpose: the mobility grid table below defaults to the
 same 256 channels over the same edges -- literally the same constant and the
@@ -294,7 +324,7 @@ mobility, `counts.sum(axis=1)`, equals `uns["average_spectrum"]` coarsened to
 `mz_edges`. Under `vendor_centroid` it does not: the centroid keeps only the current
 inside the peaks its picker assigns (87 to 96 percent on the acquisitions
 measured, see [Design Decisions](design-decisions.md#d1-which-spectrum-a-reader-takes))
-and merges bins, while the heatmap is built from every raw point. On a Bruker source the heatmap costs one extra
+and merges bins, while the heatmap is built from every raw point. Which case a given store is in is recorded rather than left to be found by subtraction: `current_ratio` is the heatmap's total over the stored mean spectrum's, the same number `uns["mobility_marginal"]` carries for the grid table, and the conversion says it at `WARNING` when it is not 1. On a Bruker source the heatmap costs one extra
 library call per frame (about a millisecond); `--no-mobility-heatmap` skips
 it.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,11 @@
 Common test fixtures for thyra tests.
 """
 
+import logging
 import tempfile
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Iterator, List
 
 import numpy as np
 import pytest
@@ -13,6 +16,51 @@ from pyimzml.ImzMLWriter import ImzMLWriter
 TEST_DIR = Path(__file__).parent.resolve()
 # Test data directory
 DATA_DIR = TEST_DIR / "data"
+
+
+@pytest.fixture
+def thyra_logs():
+    """A context manager collecting records from a named Thyra logger.
+
+    Deliberately not ``caplog``. ``setup_logging`` sets
+    ``propagate = False`` on the ``thyra`` logger and that is
+    process-global: once any test in the session has invoked the CLI,
+    caplog's root handler never sees another Thyra record. A caplog
+    assertion on Thyra's own logging therefore passes alone and fails in
+    the full suite, which is the worst way for a test to be wrong.
+    Attaching a handler to the named logger sidesteps propagation, so the
+    result does not depend on which tests ran first.
+
+    Usage::
+
+        with thyra_logs("thyra.cli", logging.WARNING) as records:
+            ...
+        assert [r.getMessage() for r in records] == [...]
+    """
+
+    @contextmanager
+    def capture(
+        logger_name: str = "thyra", level: int = logging.INFO
+    ) -> Iterator[List[logging.LogRecord]]:
+        collected: List[logging.LogRecord] = []
+
+        class _Collector(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                collected.append(record)
+
+        logger = logging.getLogger(logger_name)
+        handler = _Collector(level=level)
+        previous = logger.level
+        logger.addHandler(handler)
+        if previous > level or previous == logging.NOTSET:
+            logger.setLevel(level)
+        try:
+            yield collected
+        finally:
+            logger.removeHandler(handler)
+            logger.setLevel(previous)
+
+    return capture
 
 
 @pytest.fixture

--- a/tests/integration/test_bruker_tdf_synthetic.py
+++ b/tests/integration/test_bruker_tdf_synthetic.py
@@ -329,7 +329,12 @@ class TestSyntheticFixture:
         assert "resolved_table" not in axis
 
         heat = table.uns["mobility_heatmap"]
-        assert set(heat) == {"mz_edges", "mobility_edges", "counts"}
+        assert set(heat) == {
+            "mz_edges",
+            "mobility_edges",
+            "counts",
+            "current_ratio",
+        }
         counts = np.asarray(heat["counts"])
         mz_edges = np.asarray(heat["mz_edges"])
         mobility_edges = np.asarray(heat["mobility_edges"])
@@ -349,11 +354,17 @@ class TestSyntheticFixture:
         if mode == "scan_sum":
             # Lossless sum: the heatmap over mobility IS the mean spectrum.
             np.testing.assert_allclose(marginal, mean_spectrum, rtol=1e-6)
+            assert heat["current_ratio"] == pytest.approx(1.0, abs=1e-6)
         else:
             # The vendor centroid discards part of the current the raw
             # cloud carries; the heatmap is built from the cloud.
             assert marginal.sum() >= mean_spectrum.sum() * (1 - 1e-6)
             assert marginal.sum() > 0
+        # Either way the store says which case it is, rather than leaving
+        # it to be found by subtraction (issue #253).
+        assert heat["current_ratio"] == pytest.approx(
+            marginal.sum() / mean_spectrum.sum(), rel=1e-6
+        )
 
     def test_heatmap_can_be_switched_off(self, tmp_path):
         _open("scan_sum").close()

--- a/tests/unit/converters/test_mobility_heatmap.py
+++ b/tests/unit/converters/test_mobility_heatmap.py
@@ -468,7 +468,12 @@ class TestStoredBlock:
         table = _read(out).tables["stub_z0"]
 
         block = table.uns["mobility_heatmap"]
-        assert set(block) == {"mz_edges", "mobility_edges", "counts"}
+        assert set(block) == {
+            "mz_edges",
+            "mobility_edges",
+            "counts",
+            "current_ratio",
+        }
         counts = np.asarray(block["counts"])
         assert counts.dtype == np.float32 and counts.shape == (4, 256)
         assert np.asarray(block["mz_edges"]).shape == (5,)
@@ -480,6 +485,10 @@ class TestStoredBlock:
         np.testing.assert_allclose(
             counts.sum(axis=1), np.asarray(table.uns["average_spectrum"]), rtol=1e-6
         )
+        # ...and the block says so, so a consumer plotting the two
+        # together can tell a lossless store from a vendor-centroid one
+        # without recomputing the sum (issue #253).
+        assert block["current_ratio"] == pytest.approx(1.0, abs=1e-6)
         # Built exactly once, however many uns blocks asked for it.
         assert reader.mobility_passes == 1
 
@@ -501,7 +510,12 @@ class TestStoredBlock:
             str(prepare_zarr_read_path(out) / "tables" / "stub_z0")
         )
         block = lazy.uns["mobility_heatmap"]
-        assert set(block) == {"mz_edges", "mobility_edges", "counts"}
+        assert set(block) == {
+            "mz_edges",
+            "mobility_edges",
+            "counts",
+            "current_ratio",
+        }
         assert np.asarray(block["counts"]).shape == (4, 256)
 
     def test_opt_out_leaves_the_axis_and_drops_the_heatmap(self, tmp_path):

--- a/tests/unit/converters/test_unusable_intensities.py
+++ b/tests/unit/converters/test_unusable_intensities.py
@@ -1,0 +1,179 @@
+"""What a store does with values that are not measurements (issue #248).
+
+Nothing on the read path tested finiteness. Ten NaN intensities reached
+``X.data``, turned ``uns["average_spectrum"]`` into NaN and passed
+``thyra validate``; a source with NaN m/z converted at exit 0 and was
+then refused by that same validator, so the converter wrote a store its
+own validator rejects.
+
+Negative intensities needed a decision rather than a guard: they were
+stored under ``nearest_neighbor`` (giving the pixel a TIC of 0) while
+``tic_preserving`` found a non-positive total and zeroed the whole
+spectrum, so the two methods disagreed in kind and neither said so.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from thyra.converters.spatialdata.base_spatialdata_converter import (
+    BaseSpatialDataConverter,
+)
+from thyra.errors import ConversionRefused
+
+_MODULE_LOGGER = "thyra.converters.spatialdata.base_spatialdata_converter"
+
+
+def _stub():
+    """The converter reduced to what the drop reads and writes."""
+    stub = SimpleNamespace(
+        _unusable_intensities=0,
+        _unusable_intensities_warned=False,
+    )
+    stub._count_unusable_intensities = (
+        lambda *args: BaseSpatialDataConverter._count_unusable_intensities(stub, *args)
+    )
+    return stub
+
+
+def _drop(stub, mzs, intensities):
+    return BaseSpatialDataConverter._drop_unusable_intensities(
+        stub, np.asarray(mzs, dtype=np.float64), np.asarray(intensities, np.float64)
+    )
+
+
+class TestTheAxisIsRefusedRatherThanWritten:
+    def _refuse(self, axis):
+        stub = SimpleNamespace(_common_mass_axis=np.asarray(axis, dtype=np.float64))
+        BaseSpatialDataConverter._refuse_non_finite_axis(stub)
+
+    @pytest.mark.parametrize("bad", [np.nan, np.inf, -np.inf])
+    def test_a_non_finite_axis_value_is_refused(self, bad):
+        with pytest.raises(ConversionRefused, match="non-finite"):
+            self._refuse([100.0, bad, 300.0])
+
+    def test_the_message_names_var_mz_and_the_count(self):
+        with pytest.raises(ConversionRefused) as excinfo:
+            self._refuse([np.nan, np.nan, 300.0])
+        message = str(excinfo.value)
+        assert "2" in message and "var['mz']" in message
+
+    def test_a_real_axis_passes(self):
+        self._refuse([100.0, 200.0, 300.0])
+
+    def test_an_empty_axis_is_left_to_the_check_that_owns_it(self):
+        self._refuse([])
+
+
+class TestNonFiniteIntensities:
+    def test_they_are_dropped_with_their_m_z(self):
+        mzs, intensities = _drop(_stub(), [1.0, 2.0, 3.0], [10.0, np.nan, 30.0])
+        np.testing.assert_array_equal(mzs, [1.0, 3.0])
+        np.testing.assert_array_equal(intensities, [10.0, 30.0])
+
+    @pytest.mark.parametrize("bad", [np.nan, np.inf, -np.inf])
+    def test_every_kind_goes(self, bad):
+        _, intensities = _drop(_stub(), [1.0, 2.0], [bad, 5.0])
+        np.testing.assert_array_equal(intensities, [5.0])
+
+    def test_an_ordinary_spectrum_is_returned_untouched(self):
+        """Same objects, so the shared-axis identity fast path survives."""
+        stub = _stub()
+        mzs = np.asarray([1.0, 2.0])
+        intensities = np.asarray([10.0, 20.0])
+        out_mz, out_int = BaseSpatialDataConverter._drop_unusable_intensities(
+            stub, mzs, intensities
+        )
+        assert out_mz is mzs and out_int is intensities
+        assert stub._unusable_intensities == 0
+
+
+class TestNegativeIntensities:
+    def test_they_are_dropped_too(self):
+        _, intensities = _drop(_stub(), [1.0, 2.0, 3.0], [10.0, -5.0, 30.0])
+        np.testing.assert_array_equal(intensities, [10.0, 30.0])
+
+    def test_zero_is_kept_here(self):
+        """Zeros are a separate matter; the sparse write drops them."""
+        _, intensities = _drop(_stub(), [1.0, 2.0], [0.0, 3.0])
+        np.testing.assert_array_equal(intensities, [0.0, 3.0])
+
+    def test_both_methods_now_see_the_same_spectrum(self):
+        """The whole point: neither method decides for itself what a
+        negative value means, because neither one ever sees one."""
+        mzs, intensities = _drop(_stub(), [1.0, 2.0, 3.0], [-1.0, -2.0, 30.0])
+        assert intensities.min() >= 0
+        np.testing.assert_array_equal(mzs, [3.0])
+
+
+class TestTheCount:
+    def test_the_first_affected_spectrum_warns_once(self, thyra_logs):
+        stub = _stub()
+        with thyra_logs(_MODULE_LOGGER, logging.WARNING) as records:
+            _drop(stub, [1.0, 2.0, 3.0], [np.nan, -5.0, 30.0])
+            _drop(stub, [1.0, 2.0], [np.nan, 30.0])
+
+        warnings = [r.getMessage() for r in records]
+        assert len(warnings) == 1
+        assert "2 of 3" in warnings[0]
+        assert "1 non-finite, 1 negative" in warnings[0]
+
+    def test_the_running_total_accumulates(self):
+        stub = _stub()
+        _drop(stub, [1.0, 2.0], [np.nan, 30.0])
+        _drop(stub, [1.0, 2.0], [-1.0, 30.0])
+        assert stub._unusable_intensities == 2
+
+
+class TestTheSiblingTablesUseTheSameRule:
+    """A grid's marginal reproduces the summed column only if it drops the
+    same points, so the raw-scan mapper applies the rule too."""
+
+    def _axis(self):
+        return np.asarray([100.0, 200.0, 300.0], dtype=np.float64)
+
+    def test_map_points_drops_them(self):
+        from thyra.converters.spatialdata.mobility_heatmap import map_points_to_axis
+
+        bins, mobility, intensities, n_dropped = map_points_to_axis(
+            self._axis(),
+            np.asarray([100.0, 200.0, 300.0]),
+            np.asarray([1.0, 1.1, 1.2]),
+            np.asarray([5.0, np.nan, -3.0]),
+        )
+        np.testing.assert_array_equal(bins, [0])
+        np.testing.assert_array_equal(mobility, [1.0])
+        np.testing.assert_array_equal(intensities, [5.0])
+        # Not an out-of-range drop; that count means something else.
+        assert n_dropped == 0
+
+    def test_the_indexed_mapper_agrees_point_for_point(self):
+        """The two mappers are pinned against each other; so is this rule."""
+        from thyra.converters.spatialdata.mobility_heatmap import (
+            map_indexed_points_to_axis,
+            map_points_to_axis,
+        )
+
+        axis = self._axis()
+        mzs = np.asarray([100.0, 200.0, 200.0, 300.0, 400.0])
+        mobility = np.asarray([1.0, 1.1, 1.2, 1.3, 1.4])
+        intensities = np.asarray([5.0, np.nan, 7.0, -3.0, 9.0])
+        unique_mz, inverse = np.unique(mzs, return_inverse=True)
+
+        plain = map_points_to_axis(axis, mzs, mobility, intensities)
+        indexed = map_indexed_points_to_axis(
+            axis, unique_mz, inverse, mobility, intensities
+        )
+
+        for a, b in zip(plain[:3], indexed[:3]):
+            np.testing.assert_array_equal(a, b)
+        assert plain[3] == indexed[3] == 1  # the m/z 400 point, out of range
+
+    def test_an_ordinary_pixel_is_unchanged(self):
+        from thyra.converters.spatialdata.mobility_heatmap import usable_intensities
+
+        assert usable_intensities(np.asarray([1.0, 0.0, 3.0])) is None

--- a/tests/unit/metadata/schema/test_cli_metadata.py
+++ b/tests/unit/metadata/schema/test_cli_metadata.py
@@ -1,12 +1,17 @@
 ﻿"""The `thyra validate` / `thyra export-metaspace` subcommands."""
 
 import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
 
 from thyra.metadata.schema import build_msi_metadata
 from thyra.metadata.schema.cli import export_metaspace_command, validate_command
+from thyra.utils.windows_paths import WINDOWS_MAX_PATH, to_extended_length_path
 
 
 def _make_runner() -> CliRunner:
@@ -159,3 +164,79 @@ class TestDispatcher:
         out = capsys.readouterr().out
         assert "INPUT" in out and "OUTPUT" in out
         assert "export-metaspace" in out
+
+
+class TestTheStorePathIsPreparedInsideTheCommand:
+    """Issue #257: click's existence check ran before the path was prepared.
+
+    The converter writes a store to a deep Windows path through an
+    extended-length path, so ``os.path.exists`` on the plain spelling is
+    False and ``click.Path(exists=True)`` refused a store the CLI itself
+    had just written -- while ``validate_store`` on the prepared path
+    validated it fine.
+    """
+
+    def test_a_missing_path_is_still_a_usage_error(self, runner, tmp_path):
+        result = runner.invoke(validate_command, [str(tmp_path / "nope.zarr")])
+        assert result.exit_code == 2
+
+    def test_the_prepared_path_is_what_gets_read(self, tmp_path, monkeypatch):
+        """Proven by preparation that redirects: the command must follow it."""
+        from thyra.metadata.schema import cli as cli_module
+
+        real = _write_doc(tmp_path, name="real.json")
+        typed = tmp_path / "typed.json"
+
+        monkeypatch.setattr(
+            cli_module, "prepare_zarr_read_path", lambda path: real, raising=True
+        )
+        assert cli_module._resolve_store_path(typed) == real
+
+    def test_export_prepares_it_too(self, runner, tmp_path, monkeypatch):
+        from thyra.metadata.schema import cli as cli_module
+
+        real = _write_doc(tmp_path, name="real.json")
+        monkeypatch.setattr(
+            cli_module, "prepare_zarr_read_path", lambda path: real, raising=True
+        )
+
+        result = runner.invoke(
+            export_metaspace_command, [str(tmp_path / "typed.json"), "-o", "-"]
+        )
+        assert result.exit_code == 0, result.output
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="the 260 character limit")
+class TestAPathPastTheWindowsLimit:
+    """The case the issue reproduced: a path click cannot even stat."""
+
+    @pytest.fixture
+    def deep_document(self):
+        base = Path(tempfile.mkdtemp(prefix="thyra_deep_cli_"))
+        try:
+            deep = base
+            while len(str(deep / "metadata.json")) <= WINDOWS_MAX_PATH:
+                deep = deep / "nested_directory_segment"
+                to_extended_length_path(deep).mkdir()
+            document = deep / "metadata.json"
+            to_extended_length_path(document).write_text(
+                json.dumps(
+                    build_msi_metadata(
+                        None, pixel_size_um=(20.0, 20.0), source_format="imzml"
+                    ).to_uns_dict()
+                ),
+                encoding="utf-8",
+            )
+            if document.exists():
+                # A machine with LongPathsEnabled=1 -- the GitHub Windows
+                # runner is one -- resolves the plain path fine, so the
+                # case this reproduces cannot occur on it.
+                pytest.skip("Windows long-path support is on; the limit does not apply")
+            yield document
+        finally:
+            shutil.rmtree(to_extended_length_path(base), ignore_errors=True)
+
+    def test_validate_reaches_it(self, runner, deep_document):
+        result = runner.invoke(validate_command, [str(deep_document)])
+        assert result.exit_code == 0, result.output
+        assert "OK" in result.output

--- a/tests/unit/readers/test_bruker_region_selection.py
+++ b/tests/unit/readers/test_bruker_region_selection.py
@@ -55,6 +55,8 @@ class _NameResolutionHarness:
     _get_region_name_map = BrukerReader._get_region_name_map
     _log_region_mapping = BrukerReader._log_region_mapping
     _resolve_requested_region = BrukerReader._resolve_requested_region
+    _check_region_on_single_region_set = BrukerReader._check_region_on_single_region_set
+    _select_region = BrukerReader._select_region
 
 
 def _harness(
@@ -135,3 +137,64 @@ def test_log_region_mapping_skips_when_no_areas() -> None:
     with _capture_module_logs() as records:
         h._log_region_mapping()
     assert all("Region mapping" not in line for line in records)
+
+
+class TestTheIntegerFallbackIsLogged:
+    """Issue #252: '02' matches no Area Name and selects a different area.
+
+    The name path has always logged what it resolved. The fallback said
+    nothing at all, so a run that meant Area '02' and got Area '04' left
+    only ``Region 2: 736 frames selected`` behind.
+    """
+
+    def test_the_failed_name_lookup_is_named(self) -> None:
+        h = _harness(["01", "03", "04"], [(0, 10), (1, 20), (2, 30)], "02")
+        with _capture_module_logs() as records:
+            assert h._resolve_requested_region() == 2
+        text = "\n".join(records)
+        assert "matches no .mis Area Name" in text
+        assert "RegionNumber 2" in text
+        assert "01, 03, 04" in text
+
+    def test_the_name_path_still_logs_what_it_resolved(self) -> None:
+        h = _harness(["01", "03", "04"], [(0, 10), (1, 20), (2, 30)], "03")
+        with _capture_module_logs() as records:
+            assert h._resolve_requested_region() == 1
+        assert any("Area Name" in line for line in records)
+
+
+class TestASingleRegionSetStillChecksTheRequest:
+    """Issue #252: ``_select_region`` returned before the request was read.
+
+    On a single-area set ``--region foo`` converted everything at exit 0,
+    while the same word on a three-area set was refused.
+    """
+
+    def test_an_unparseable_request_is_refused(self) -> None:
+        h = _harness(["01"], [(0, 713)], "foo")
+        with pytest.raises(ValueError, match="not a recognised .mis Area Name"):
+            h._select_region()
+
+    def test_a_region_that_is_not_there_is_refused(self) -> None:
+        h = _harness(["01"], [(0, 713)], "3")
+        with pytest.raises(ValueError, match="Region 3 not found"):
+            h._select_region()
+
+    def test_the_only_region_is_accepted_and_converts_everything(self) -> None:
+        h = _harness(["01"], [(0, 713)], "01")
+        with _capture_module_logs() as records:
+            assert h._select_region() == (None, None)
+        assert any("only region" in line for line in records)
+
+    def test_no_request_is_still_silent_and_unfiltered(self) -> None:
+        h = _harness(["01"], [(0, 713)], None)
+        assert h._select_region() == (None, None)
+
+    def test_a_request_with_no_region_information_is_refused(self) -> None:
+        h = _harness([], [], "01")
+        with pytest.raises(ValueError, match="no region information"):
+            h._select_region()
+
+    def test_no_request_with_no_region_information_still_converts(self) -> None:
+        h = _harness([], [], None)
+        assert h._select_region() == (None, None)

--- a/tests/unit/test_cli_ignored_flags.py
+++ b/tests/unit/test_cli_ignored_flags.py
@@ -1,0 +1,137 @@
+"""An option given on a source that ignores it says so (issue #260).
+
+Every vendor and mobility-grid option was accepted on an imzML input and
+produced a store byte-identical to the plain run, with no log line.
+docs/cli.md documents that the vendor groups are "ignored on other
+formats"; the silence was never documented, and ``--tof-law`` on a
+non-tof axis and ``--msms-table`` on imzML already warned when ignored.
+
+The grid's own numbers are checked here too: ``--mobility-bins 0`` and
+``--mobility-min 2 --mobility-max 1`` reached the grid builder unexamined
+even on a source where the options do apply.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import click
+import pytest
+
+from thyra.__main__ import (
+    GRID_SIZING_FLAGS,
+    IGNORED_ELSEWHERE,
+    _validate_mobility_grid_params,
+    _warn_ignored_flags,
+)
+
+
+class _Ctx:
+    """A click context stand-in that answers where a value came from."""
+
+    def __init__(self, *given: str):
+        self._given = set(given)
+
+    def get_parameter_source(self, name: str):
+        if name in self._given:
+            return click.core.ParameterSource.COMMANDLINE
+        return click.core.ParameterSource.DEFAULT
+
+
+@pytest.fixture
+def warnings(thyra_logs):
+    """What the CLI logged, read off its own logger rather than caplog."""
+    with thyra_logs("thyra.cli", logging.WARNING) as records:
+        yield SimpleNamespace(records=records)
+
+
+class TestIgnoredOnAnotherFormat:
+    @pytest.mark.parametrize("name", sorted(IGNORED_ELSEWHERE))
+    def test_every_listed_option_warns_where_it_does_not_apply(self, name, warnings):
+        spelling, formats = IGNORED_ELSEWHERE[name]
+        elsewhere = next(f for f in ("imzml", "waters", "phi") if f not in formats)
+
+        _warn_ignored_flags(_Ctx(name), elsewhere, mobility_grid=False)
+
+        messages = [r.getMessage() for r in warnings.records]
+        assert any(spelling in m and "ignored" in m for m in messages), messages
+
+    @pytest.mark.parametrize("name", sorted(IGNORED_ELSEWHERE))
+    def test_no_option_warns_where_it_does_apply(self, name, warnings):
+        _, formats = IGNORED_ELSEWHERE[name]
+        _warn_ignored_flags(_Ctx(name), formats[0], mobility_grid=True)
+        assert not warnings.records
+
+    def test_an_option_left_at_its_default_is_quiet(self, warnings):
+        """Reading click's parameter source, not comparing to the default.
+
+        ``--use-recalibrated`` defaults to on and ``--mobility-bins`` to
+        the value it takes, so a value comparison would warn about every
+        imzML conversion ever run.
+        """
+        _warn_ignored_flags(_Ctx(), "imzml", mobility_grid=False)
+        assert not warnings.records
+
+    def test_the_message_names_the_source_and_the_format_it_needs(self, warnings):
+        _warn_ignored_flags(_Ctx("tdf_spectrum"), "imzml", mobility_grid=False)
+
+        message = warnings.records[0].getMessage()
+        assert "--tdf-spectrum" in message
+        assert "imzML" in message and "Bruker timsTOF" in message
+
+    def test_no_context_is_not_an_error(self, warnings):
+        """The API has no click context, and calls nothing here."""
+        _warn_ignored_flags(None, "imzml", mobility_grid=False)
+        assert not warnings.records
+
+
+class TestGridSizingWithoutAGrid:
+    """docs/cli.md: "They do nothing without it." Now the log says it too."""
+
+    @pytest.mark.parametrize("name", GRID_SIZING_FLAGS)
+    def test_sizing_without_the_grid_warns(self, name, warnings):
+        _warn_ignored_flags(_Ctx(name), "bruker", mobility_grid=False)
+
+        messages = [r.getMessage() for r in warnings.records]
+        assert any("--mobility-grid" in m for m in messages), messages
+
+    @pytest.mark.parametrize("name", GRID_SIZING_FLAGS)
+    def test_sizing_with_the_grid_is_quiet(self, name, warnings):
+        _warn_ignored_flags(_Ctx(name), "bruker", mobility_grid=True)
+        assert not warnings.records
+
+    def test_it_is_not_said_twice_on_a_format_that_ignores_them(self, warnings):
+        """On imzML the option is already reported as ignored outright."""
+        _warn_ignored_flags(_Ctx("mobility_bins"), "imzml", mobility_grid=False)
+        assert len(warnings.records) == 1
+
+
+class TestGridNumbers:
+    def test_zero_channels_is_refused(self):
+        with pytest.raises(click.BadParameter, match="at least one channel"):
+            _validate_mobility_grid_params(0, None, None)
+
+    def test_negative_channels_are_refused(self):
+        with pytest.raises(click.BadParameter):
+            _validate_mobility_grid_params(-4, None, None)
+
+    def test_an_inverted_range_is_refused(self):
+        with pytest.raises(click.BadParameter, match="below"):
+            _validate_mobility_grid_params(256, 2.0, 1.0)
+
+    def test_an_empty_range_is_refused(self):
+        with pytest.raises(click.BadParameter):
+            _validate_mobility_grid_params(256, 1.0, 1.0)
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf")])
+    def test_a_non_finite_edge_is_refused(self, value):
+        with pytest.raises(click.BadParameter, match="finite"):
+            _validate_mobility_grid_params(256, value, None)
+
+    def test_the_edges_may_be_zero_or_negative(self):
+        """They are positions on an axis, not quantities."""
+        _validate_mobility_grid_params(256, -1.0, 0.0)
+
+    def test_the_defaults_pass(self):
+        _validate_mobility_grid_params(256, None, None)

--- a/tests/unit/test_cli_logging_reaches_the_log.py
+++ b/tests/unit/test_cli_logging_reaches_the_log.py
@@ -1,0 +1,121 @@
+"""The CLI's own log lines reach the CLI's own handlers.
+
+``thyra/__main__.py`` logged to ``getLogger(__name__)``, which under
+``python -m thyra`` is ``"__main__"`` while ``setup_logging`` configures
+``"thyra"`` with ``propagate=False``. "Conversion completed successfully"
+appeared in 0 of 67 successful ``python -m thyra`` runs and never in
+``--log-file`` (issue #258).
+
+The console handler is here too: on a Windows console encoding in cp1252,
+one character outside it turned every write of that line into a logging
+traceback on stderr while the conversion itself was fine (issue #259).
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import sys
+
+import pytest
+
+from thyra.utils.logging_config import _console_stream, setup_logging
+
+
+class TestTheCliLoggerIsUnderThyra:
+    def test_the_module_logger_is_configured_by_setup_logging(self):
+        """Whatever the module is called, its logger has to be a "thyra" child."""
+        import thyra.__main__ as cli
+
+        assert cli.logger.name.startswith("thyra.")
+
+    def test_its_records_reach_the_configured_handlers(self, tmp_path):
+        import thyra.__main__ as cli
+
+        log_file = tmp_path / "run.log"
+        setup_logging(log_level=logging.INFO, log_file=str(log_file))
+        try:
+            cli.logger.info("Conversion completed successfully. Output stored at x")
+        finally:
+            for handler in logging.getLogger("thyra").handlers:
+                handler.close()
+            logging.getLogger("thyra").handlers.clear()
+
+        assert "Conversion completed successfully" in log_file.read_text(
+            encoding="utf-8"
+        )
+
+
+class _Cp1252Stream(io.TextIOWrapper):
+    """A stdout that only speaks cp1252, like a redirected Windows console."""
+
+
+class TestTheConsoleStream:
+    def test_a_stream_that_cannot_encode_gets_replacement(self, monkeypatch):
+        buffer = io.BytesIO()
+        stream = _Cp1252Stream(buffer, encoding="cp1252")
+        monkeypatch.setattr(sys, "stdout", stream)
+
+        console = _console_stream()
+        console.write("path: uni 日本 ö\n")
+        console.flush()
+
+        assert console.errors == "replace"
+        assert b"path: uni" in buffer.getvalue()
+
+    def test_a_stream_without_reconfigure_is_left_alone(self, monkeypatch):
+        class Bare:
+            def write(self, _text):  # pragma: no cover - never called
+                return 0
+
+        bare = Bare()
+        monkeypatch.setattr(sys, "stdout", bare)
+        assert _console_stream() is bare
+
+    def test_a_non_ascii_message_does_not_raise(self, monkeypatch):
+        buffer = io.BytesIO()
+        monkeypatch.setattr(
+            sys, "stdout", _Cp1252Stream(buffer, encoding="cp1252", errors="strict")
+        )
+        setup_logging(log_level=logging.INFO)
+        logger = logging.getLogger("thyra")
+        try:
+            logger.info("Successfully saved SpatialData to out/uni 日本 ö.zarr")
+            for handler in logger.handlers:
+                handler.flush()
+        finally:
+            logger.handlers.clear()
+
+        written = buffer.getvalue()
+        assert b"Successfully saved SpatialData" in written
+
+
+class TestTheLogFile:
+    def test_it_is_written_as_utf8(self, tmp_path):
+        """A path the platform encoding cannot spell must not cost the line."""
+        log_file = tmp_path / "run.log"
+        setup_logging(log_level=logging.INFO, log_file=str(log_file))
+        logger = logging.getLogger("thyra")
+        try:
+            logger.info("saved to 日本.zarr")
+        finally:
+            for handler in logger.handlers:
+                handler.close()
+            logger.handlers.clear()
+
+        assert "日本.zarr" in log_file.read_text(encoding="utf-8")
+
+
+@pytest.fixture(autouse=True)
+def _restore_thyra_logger():
+    logger = logging.getLogger("thyra")
+    handlers = list(logger.handlers)
+    propagate = logger.propagate
+    level = logger.level
+    yield
+    for handler in logger.handlers:
+        if handler not in handlers:
+            handler.close()
+    logger.handlers = handlers
+    logger.propagate = propagate
+    logger.setLevel(level)

--- a/tests/unit/test_cli_refusals.py
+++ b/tests/unit/test_cli_refusals.py
@@ -1,0 +1,254 @@
+"""A refusal Thyra planned for reads as a refusal, not as a crash.
+
+``convert_msi`` and ``BaseMSIConverter.convert`` both wrapped everything
+in one ``except Exception`` that logged the message *and* a full
+traceback at ERROR, so every carefully written ``ValueError`` reached the
+user as roughly thirty lines that read like a crash (issue #234). The
+front-door checks that used to fail late -- an output path whose parent
+is a file (#255), a dataset id SpatialData cannot name an element with
+and a mass range with no extent (#250) -- are here too, because the
+defect in each was when and how the refusal arrived.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from thyra.__main__ import _validate_basic_params, _validate_output_path, main
+from thyra.convert import convert_msi, dataset_id_problem
+from thyra.errors import ConversionRefused
+
+_CONVERTER_MODULE = "thyra.converters.spatialdata.base_spatialdata_converter"
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+class TestTheRefusalType:
+    def test_a_refusal_is_still_a_value_error(self):
+        """Everything that raises one used to raise ValueError; callers catch it."""
+        with pytest.raises(ValueError):
+            raise ConversionRefused("nope")
+
+
+class TestPresentation:
+    """The message once, at ERROR; the traceback only at DEBUG."""
+
+    def _convert(self, tmp_path, monkeypatch, thyra_logs, exc):
+        def boom(*_args, **_kwargs):
+            raise exc
+
+        monkeypatch.setattr("thyra.convert.detect_format", boom)
+        with thyra_logs("thyra.convert", logging.DEBUG) as records:
+            result = convert_msi(tmp_path, tmp_path / "out.zarr")
+        return result, records
+
+    def test_a_refusal_logs_its_message_without_a_traceback(
+        self, tmp_path, monkeypatch, thyra_logs
+    ):
+        result, records = self._convert(
+            tmp_path,
+            monkeypatch,
+            thyra_logs,
+            ConversionRefused("this file is a spot run"),
+        )
+        assert result is False
+
+        errors = [r for r in records if r.levelno == logging.ERROR]
+        assert [r.getMessage() for r in errors] == ["this file is a spot run"]
+        assert not any("Traceback" in r.getMessage() for r in errors)
+
+    def test_the_traceback_is_still_available_at_debug(
+        self, tmp_path, monkeypatch, thyra_logs
+    ):
+        _, records = self._convert(
+            tmp_path, monkeypatch, thyra_logs, ConversionRefused("a spot run")
+        )
+
+        debug = [r.getMessage() for r in records if r.levelno == logging.DEBUG]
+        assert any("Traceback" in message for message in debug)
+
+    def test_an_unexpected_exception_keeps_its_traceback_at_error(
+        self, tmp_path, monkeypatch, thyra_logs
+    ):
+        """The traceback is the explanation for anything nobody planned for."""
+        result, records = self._convert(
+            tmp_path, monkeypatch, thyra_logs, KeyError("frame")
+        )
+        assert result is False
+
+        errors = [r.getMessage() for r in records if r.levelno == logging.ERROR]
+        assert any("Traceback" in message for message in errors)
+
+    def test_a_plain_value_error_is_not_treated_as_a_refusal(
+        self, tmp_path, monkeypatch, thyra_logs
+    ):
+        """numpy raises ValueError too, and those really are surprises.
+
+        ``np.min`` on an empty array raises ``ValueError`` with a message
+        nobody wrote for a user ("zero-size array to reduction operation
+        minimum which has no identity"), which is exactly why the
+        refusals are marked by type rather than matched on ValueError.
+        """
+        _, records = self._convert(
+            tmp_path, monkeypatch, thyra_logs, ValueError("zero-size array")
+        )
+
+        errors = [r.getMessage() for r in records if r.levelno == logging.ERROR]
+        assert any("Traceback" in message for message in errors)
+
+
+class TestOutputPathParent:
+    """Issue #255: refuse before the reader is opened, naming the cause."""
+
+    def test_a_parent_that_is_a_file_is_refused(self, tmp_path):
+        blocker = tmp_path / "afile.txt"
+        blocker.write_text("not a directory", encoding="utf-8")
+
+        with pytest.raises(click.BadParameter) as excinfo:
+            _validate_output_path(blocker / "out.zarr")
+
+        message = str(excinfo.value)
+        assert "afile.txt" in message and "is a file, not a directory" in message
+
+    def test_an_ancestor_that_is_a_file_is_refused(self, tmp_path):
+        blocker = tmp_path / "afile.txt"
+        blocker.write_text("not a directory", encoding="utf-8")
+
+        with pytest.raises(click.BadParameter):
+            _validate_output_path(blocker / "deeper" / "out.zarr")
+
+    def test_a_missing_parent_is_still_accepted(self, tmp_path):
+        """Directories on the way are created at write time, as they were."""
+        _validate_output_path(tmp_path / "not" / "there" / "yet" / "out.zarr")
+
+    def test_an_ordinary_output_path_is_accepted(self, tmp_path):
+        _validate_output_path(tmp_path / "out.zarr")
+
+    def test_the_cli_refuses_it_before_opening_the_reader(
+        self, create_minimal_imzml, tmp_path, monkeypatch, runner
+    ):
+        imzml_path, _, _, _ = create_minimal_imzml
+        blocker = tmp_path / "afile.txt"
+        blocker.write_text("not a directory", encoding="utf-8")
+
+        def never(*_args, **_kwargs):  # pragma: no cover - must not run
+            raise AssertionError("the conversion started")
+
+        monkeypatch.setattr("thyra.__main__.convert_msi", never)
+        result = runner.invoke(main, [str(imzml_path), str(blocker / "out.zarr")])
+
+        assert result.exit_code == 2, result.output
+        assert "is a file, not a directory" in result.output
+        assert "Traceback" not in result.output
+
+
+class TestDatasetId:
+    """Issue #250: the id names every element, so SpatialData's rule applies."""
+
+    @pytest.mark.parametrize("bad", ["has space", "a/b", "a\\b", ".", "..", "__x", ""])
+    def test_an_unusable_id_is_named(self, bad):
+        assert dataset_id_problem(bad) is not None
+
+    @pytest.mark.parametrize("good", ["msi_dataset", "brain-1", "run.2", "cerveau"])
+    def test_a_usable_id_passes(self, good):
+        assert dataset_id_problem(good) is None
+
+    def test_the_cli_refuses_before_any_pass(self):
+        with pytest.raises(click.BadParameter) as excinfo:
+            _validate_basic_params(None, "has space")
+        assert "letters, digits" in str(excinfo.value)
+
+    def test_the_api_refuses_it_too(self, tmp_path):
+        assert convert_msi(tmp_path, tmp_path / "out.zarr", dataset_id="a/b") is False
+
+
+def _plan_stub(min_mz, max_mz, target_bins):
+    """A stand-in for the converter, carrying only what the plan reads."""
+    from thyra.resampling.types import AxisType
+
+    return SimpleNamespace(
+        _essential_metadata_cached=SimpleNamespace(mass_range=(100.0, 1000.0)),
+        _min_mz=min_mz,
+        _max_mz=max_mz,
+        _manual_axis_type=AxisType.CONSTANT,
+        _width_at_mz=None,
+        _target_bins=target_bins,
+    )
+
+
+class TestTheResamplingPlan:
+    """Issue #250: the range and the bin count, checked before any pass."""
+
+    def _resolve(self, stub):
+        from thyra.converters.spatialdata.base_spatialdata_converter import (
+            BaseSpatialDataConverter,
+        )
+
+        return BaseSpatialDataConverter._resolve_resampling_plan(stub)
+
+    def test_an_inverted_range_is_refused(self):
+        """It used to build a descending axis, drop every peak against it,
+        report "4 of 3 ... affected" from a negative count, and succeed."""
+        with pytest.raises(ConversionRefused, match="empty"):
+            self._resolve(_plan_stub(600.0, 300.0, 4000))
+
+    def test_an_empty_range_is_refused(self):
+        with pytest.raises(ConversionRefused, match="empty"):
+            self._resolve(_plan_stub(500.0, 500.0, 4000))
+
+    def test_one_bin_is_refused_rather_than_crashing(self):
+        """``np.min(np.diff(axis))`` on a one-point axis is not a message."""
+        with pytest.raises(ConversionRefused, match="at least 2 bins"):
+            self._resolve(_plan_stub(None, None, 1))
+
+    def test_two_bins_and_a_real_range_still_plan(self):
+        min_mz, max_mz, _axis, bins = self._resolve(_plan_stub(300.0, 600.0, 2))
+        assert (min_mz, max_mz, bins) == (300.0, 600.0, 2)
+
+
+class TestUnknownResamplingConfigKeys:
+    """Issue #250: a typo in the dict is warned about, not swallowed."""
+
+    def test_an_unknown_key_is_named(self, thyra_logs):
+        from thyra.converters.spatialdata.base_spatialdata_converter import (
+            _normalize_resampling_config,
+        )
+
+        with thyra_logs(_CONVERTER_MODULE, logging.WARNING) as records:
+            _normalize_resampling_config(
+                {"method": "nearest_neighbor", "target_bin": 10}
+            )
+
+        assert any("'target_bin'" in r.getMessage() for r in records)
+
+    def test_the_keys_it_reads_are_quiet(self, thyra_logs):
+        from thyra.converters.spatialdata.base_spatialdata_converter import (
+            _normalize_resampling_config,
+        )
+
+        with thyra_logs(_CONVERTER_MODULE, logging.WARNING) as records:
+            _normalize_resampling_config(
+                {
+                    "method": "nearest_neighbor",
+                    "axis_type": "constant",
+                    "target_bins": 10,
+                    "min_mz": None,
+                    "max_mz": None,
+                    "width_at_mz": None,
+                    "reference_mz": 1000.0,
+                    "gap_tolerance_da": None,
+                    "tof_a": None,
+                    "tof_b": None,
+                    "bins_per_fwhm": None,
+                }
+            )
+
+        assert not records

--- a/tests/unit/test_sibling_table_mismatch.py
+++ b/tests/unit/test_sibling_table_mismatch.py
@@ -1,0 +1,217 @@
+"""What is said when a sibling table will not add up to the summed one.
+
+Two halves of issue #253.
+
+``--msms-table`` defaults to on (design decision D2), but the CLI passes
+the keyword only when the flag is given, and ``_lossless_spectrum_for``
+read it as off-by-default -- so the common path, the default-on table,
+never reached the warning that says a ``vendor_centroid`` summed
+spectrum will not add up to it.
+
+And the same disagreement between the same two tables was a WARNING for
+the mobility grid and an INFO for the MS/MS split.
+
+Issue #256 rides along here: ``--handle-3d`` and ``--z-spacing`` on a
+single-slice acquisition skipped both promises docs/cli.md makes, because
+``_is_volume`` is false for one plane and the log line was at DEBUG.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Iterator, List
+
+import numpy as np
+import pytest
+
+from thyra.convert import _force_scan_sum, _lossless_spectrum_for
+
+
+@contextmanager
+def _records(logger_name: str, level: int = logging.INFO) -> Iterator[List]:
+    """Collect records from a named logger, whatever the logging state.
+
+    Deliberately not ``caplog``: ``setup_logging`` sets
+    ``propagate = False`` on the ``thyra`` logger process-wide, so a
+    caplog assertion here passes alone and fails in the full suite.
+    """
+    collected: List[logging.LogRecord] = []
+
+    class _Collector(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            collected.append(record)
+
+    logger = logging.getLogger(logger_name)
+    handler = _Collector(level=level)
+    previous = logger.level
+    logger.addHandler(handler)
+    if previous > level or previous == logging.NOTSET:
+        logger.setLevel(level)
+    try:
+        yield collected
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(previous)
+
+
+class TestWhichTablesNeedTheLosslessSpectrum:
+    def test_the_default_on_msms_table_counts_as_asked_for(self):
+        """The CLI omits the keyword unless the flag was typed."""
+        assert _lossless_spectrum_for({}) == ["demultiplexed MS/MS"]
+
+    def test_opting_out_takes_it_off_the_list(self):
+        assert _lossless_spectrum_for({"msms_table": False}) == []
+
+    def test_the_grid_is_off_by_default(self):
+        assert "mobility grid" not in _lossless_spectrum_for({})
+
+    def test_both_can_be_wanted_at_once(self):
+        assert _lossless_spectrum_for({"mobility_grid": True}) == [
+            "mobility grid",
+            "demultiplexed MS/MS",
+        ]
+
+
+class TestTheStartupWarning:
+    def test_scan_sum_says_nothing(self):
+        with _records("thyra.convert", logging.WARNING) as records:
+            _force_scan_sum("bruker", {"tdf_spectrum": "scan_sum"}, ["mobility grid"])
+        assert not records
+
+    def test_the_vendor_centroid_warns(self):
+        with _records("thyra.convert", logging.WARNING) as records:
+            _force_scan_sum(
+                "bruker", {"tdf_spectrum": "vendor_centroid"}, ["mobility grid"]
+            )
+        assert len(records) == 1
+        message = records[0].getMessage()
+        assert message.startswith("A mobility grid table is written")
+
+    def test_two_tables_agree_with_their_verb(self):
+        """ "A mobility grid and demultiplexed MS/MS table was asked for"."""
+        with _records("thyra.convert", logging.WARNING) as records:
+            _force_scan_sum(
+                "bruker",
+                {"tdf_spectrum": "vendor_centroid"},
+                ["mobility grid", "demultiplexed MS/MS"],
+            )
+        message = records[0].getMessage()
+        assert message.startswith(
+            "A mobility grid table and a demultiplexed MS/MS table are written"
+        )
+
+    def test_a_format_that_ignores_the_mode_is_not_warned_about(self):
+        """The CLI already says --tdf-spectrum is ignored on imzML (#260)."""
+        with _records("thyra.convert", logging.WARNING) as records:
+            _force_scan_sum(
+                "imzml", {"tdf_spectrum": "vendor_centroid"}, ["demultiplexed MS/MS"]
+            )
+        assert not records
+
+
+def _table(rows):
+    """An AnnData stand-in: a matrix whose row sums are the ion current."""
+    table = SimpleNamespace(X=np.asarray(rows, dtype=np.float64))
+    table.uns = {}
+    return table
+
+
+class TestTheMismatchIsAWarningForEverySibling:
+    """The grid says it at WARNING; the split said the same thing at INFO."""
+
+    _MODULE = "thyra.converters.spatialdata.base_spatialdata_converter"
+
+    def _record(self, split_rows, summed_rows):
+        from thyra.converters.spatialdata.base_spatialdata_converter import (
+            BaseSpatialDataConverter,
+        )
+
+        table = _table(split_rows)
+        with _records(self._MODULE, logging.INFO) as records:
+            BaseSpatialDataConverter._record_demultiplexed_current(
+                table, _table(summed_rows), "msi_z0"
+            )
+        return table, records
+
+    def test_a_disagreement_is_a_warning(self):
+        table, records = self._record([[11.0, 0.0]], [[10.0, 0.0]])
+
+        assert [r.levelno for r in records] == [logging.WARNING]
+        assert "1.1000x" in records[0].getMessage()
+        assert table.uns["demultiplexed_current"]["current_ratio"] == pytest.approx(1.1)
+
+    def test_an_exact_split_is_silent_and_still_recorded(self):
+        table, records = self._record([[10.0, 0.0]], [[10.0, 0.0]])
+
+        assert not records
+        assert table.uns["demultiplexed_current"]["current_ratio"] == pytest.approx(1.0)
+
+    def test_the_grid_reports_the_same_disagreement_the_same_way(self):
+        from thyra.converters.spatialdata.base_spatialdata_converter import (
+            BaseSpatialDataConverter,
+        )
+
+        table = _table([[11.0, 0.0]])
+        with _records(self._MODULE, logging.INFO) as records:
+            BaseSpatialDataConverter._record_mobility_marginal(
+                table, _table([[10.0, 0.0]]), "msi_z0"
+            )
+
+        assert [r.levelno for r in records] == [logging.WARNING]
+
+
+class TestASinglePlaneVolume:
+    """Issue #256: docs/cli.md promises both of these lines."""
+
+    def _converter(self, z_arg, handle_3d=True, n_z=1):
+        from thyra.core.base_converter import BaseMSIConverter, ZSpacingSource
+
+        stub = SimpleNamespace(
+            handle_3d=handle_3d,
+            _dimensions=(4, 4, n_z),
+            _z_spacing_um_arg=z_arg,
+            z_spacing_um=10.0,
+            z_spacing_source=ZSpacingSource.USER_PROVIDED,
+            pixel_size_um=10.0,
+        )
+        stub._log_single_plane_volume = (
+            lambda: BaseMSIConverter._log_single_plane_volume(stub)
+        )
+        # A property, so it cannot be inherited by a namespace stand-in.
+        stub._is_volume = bool(handle_3d and n_z > 1)
+        return BaseMSIConverter, stub
+
+    def test_handle_3d_alone_says_the_volume_has_one_plane(self):
+        cls, stub = self._converter(None)
+        with _records("thyra.core.base_converter", logging.INFO) as records:
+            cls._log_z_spacing(stub)
+        assert any("1 plane" in r.getMessage() for r in records)
+
+    def test_a_z_spacing_is_logged_as_ignored(self):
+        cls, stub = self._converter(20.0)
+        with _records("thyra.core.base_converter", logging.WARNING) as records:
+            cls._log_z_spacing(stub)
+        message = records[0].getMessage()
+        assert "20 um is ignored" in message
+
+    def test_a_plain_2d_conversion_stays_quiet(self):
+        cls, stub = self._converter(None, handle_3d=False)
+        with _records("thyra.core.base_converter", logging.INFO) as records:
+            cls._log_z_spacing(stub)
+        assert not records
+
+    def test_a_real_volume_still_reports_its_spacing(self):
+        cls, stub = self._converter(20.0, n_z=3)
+        with _records("thyra.core.base_converter", logging.INFO) as records:
+            cls._log_z_spacing(stub)
+        assert any("z spacing" in r.getMessage() for r in records)
+        assert not any("1 plane" in r.getMessage() for r in records)
+
+
+@pytest.mark.parametrize("wanted", [["mobility grid"], ["demultiplexed MS/MS"]])
+def test_no_mode_at_all_says_nothing(wanted):
+    with _records("thyra.convert", logging.WARNING) as records:
+        _force_scan_sum("bruker", {}, wanted)
+    assert not records

--- a/thyra/__main__.py
+++ b/thyra/__main__.py
@@ -12,12 +12,18 @@ from typing import Literal, Optional, Tuple  # noqa: E402
 import click  # noqa: E402
 
 from thyra import __version__  # noqa: E402
-from thyra.convert import convert_msi  # noqa: E402
+from thyra.convert import convert_msi, dataset_id_problem  # noqa: E402
 from thyra.core.registry import detect_format  # noqa: E402
 from thyra.resampling.mobility_grid import MOBILITY_CHANNELS  # noqa: E402
 from thyra.utils.logging_config import setup_logging  # noqa: E402
 
-logger = logging.getLogger(__name__)
+# Not ``__name__``: under ``python -m thyra`` that is "__main__", and
+# setup_logging configures the "thyra" logger with propagate=False, so
+# every line the CLI itself logged went to Python's last-resort handler
+# instead -- absent from --log-file entirely, and "Conversion completed
+# successfully" appeared in 0 of 67 successful runs (issue #258). The
+# console-script entry point was unaffected, which is why it survived.
+logger = logging.getLogger("thyra.cli")
 
 # Configure Dask to use new query planning (silences legacy DataFrame warning)
 os.environ["DASK_DATAFRAME__QUERY_PLANNING"] = "True"
@@ -97,8 +103,12 @@ def _validate_basic_params(pixel_size: Optional[float], dataset_id: str) -> None
         raise click.BadParameter(
             "Pixel size must be a finite positive number", param_hint="pixel_size"
         )
-    if not dataset_id.strip():
-        raise click.BadParameter("Dataset ID cannot be empty", param_hint="dataset_id")
+    # Emptiness used to be the whole check, so an id with a space or a
+    # slash was refused by SpatialData only at the write, after both
+    # passes over the source (issue #250).
+    problem = dataset_id_problem(dataset_id)
+    if problem is not None:
+        raise click.BadParameter(problem, param_hint="dataset_id")
 
 
 def _validate_positive_int(value: Optional[int], param_name: str, label: str) -> None:
@@ -150,6 +160,40 @@ def _validate_resampling_params(
         )
 
 
+def _validate_mobility_grid_params(
+    mobility_bins: int,
+    mobility_min: Optional[float],
+    mobility_max: Optional[float],
+) -> None:
+    """Validate the mobility grid's own numbers.
+
+    Unchecked, ``--mobility-bins 0`` reached the grid builder and
+    ``--mobility-min 2 --mobility-max 1`` an empty range, both on a
+    source where the flags do apply (issue #260). The edges are
+    positions on the mobility axis rather than quantities, so unlike
+    every other float option here they may be zero or negative; only
+    their order and finiteness are checked.
+    """
+    if mobility_bins <= 0:
+        raise click.BadParameter(
+            "A mobility grid needs at least one channel", param_hint="mobility_bins"
+        )
+    for value, hint in ((mobility_min, "mobility_min"), (mobility_max, "mobility_max")):
+        if value is not None and not isfinite(value):
+            raise click.BadParameter(
+                "Mobility grid edges must be finite numbers", param_hint=hint
+            )
+    if (
+        mobility_min is not None
+        and mobility_max is not None
+        and mobility_min >= mobility_max
+    ):
+        raise click.BadParameter(
+            "--mobility-min must be below --mobility-max: the grid bins the "
+            "range between them"
+        )
+
+
 def _validate_tof_law(tof_law: Optional[Tuple[float, float]]) -> None:
     """Validate ``--tof-law A B``: both non-negative, not both zero.
 
@@ -198,9 +242,30 @@ def _validate_input_path(input: Path) -> None:
 
 
 def _validate_output_path(output: Path) -> None:
-    """Validate output path."""
+    """Validate output path.
+
+    The existence check alone let an output whose parent is a regular
+    file through: the reader was opened and the mass axis built before
+    the scratch directory's ``mkdir`` failed with a raw ``WinError 183``
+    that named a file the user had not asked about (issue #255). The
+    store is a directory tree, so the deepest ancestor that exists has
+    to be a directory Thyra may write into; the ones above it are
+    created on the way, as they always were.
+    """
     if output.exists():
         raise click.BadParameter(f"Output path already exists: {output}")
+
+    ancestor = next((p for p in output.parents if p.exists()), None)
+    if ancestor is None:
+        return
+    if not ancestor.is_dir():
+        raise click.BadParameter(
+            f"Cannot write {output}: {ancestor} is a file, not a directory. "
+            "The output is a Zarr store, which is a directory tree, so every "
+            "part of its path above it has to be a directory."
+        )
+    if not os.access(ancestor, os.W_OK):
+        raise click.BadParameter(f"Cannot write {output}: {ancestor} is not writable")
 
 
 def _display_calibration_info(input: Path, use_recalibrated: bool) -> None:
@@ -341,6 +406,102 @@ def _build_reader_options(
     if waters_spectrum is not None:
         options["use_centroid"] = waters_spectrum == "centroid"
     return options
+
+
+#: How each detected format is spelled in a message. ``detect_format``
+#: returns a registry key, and "a imzml source" is not what anyone calls
+#: the file they handed over.
+FORMAT_NAMES = {
+    "imzml": "imzML",
+    "mzpeak": "mzPeak",
+    "bruker": "Bruker timsTOF (.d)",
+    "solarix": "Bruker solariX (.d)",
+    "rapiflex": "Bruker Rapiflex",
+    "waters": "Waters .raw",
+    "phi": "PHI SmartSoft-TOF",
+}
+
+#: Options that only reach one family of sources, and the detected
+#: formats each does reach. docs/cli.md has always said the vendor groups
+#: are "ignored on other formats", but nothing said so at the time: every
+#: one of these was accepted on an imzML input and produced a store
+#: byte-identical to the plain run, with no log line (issue #260).
+#: ``--tof-law`` on a non-tof axis and ``--msms-table`` on imzML already
+#: set the precedent of saying it out loud; these follow.
+IGNORED_ELSEWHERE: dict[str, Tuple[str, Tuple[str, ...]]] = {
+    "region": ("--region", ("bruker",)),
+    "tdf_spectrum": ("--tdf-spectrum", ("bruker",)),
+    "waters_spectrum": ("--waters-spectrum", ("waters",)),
+    "use_recalibrated": ("--use-recalibrated/--no-recalibrated", ("bruker",)),
+    "interactive_calibration": ("--interactive-calibration", ("bruker", "solarix")),
+    "spectrum_type": ("--spectrum-type", ("imzml",)),
+    "mobility_grid": ("--mobility-grid/--no-mobility-grid", ("bruker",)),
+    "mobility_bins": ("--mobility-bins", ("bruker",)),
+    "mobility_min": ("--mobility-min", ("bruker",)),
+    "mobility_max": ("--mobility-max", ("bruker",)),
+}
+
+#: The three options that size the grid ``--mobility-grid`` builds. They
+#: do nothing without it, which docs/cli.md says and nothing else did.
+GRID_SIZING_FLAGS = ("mobility_bins", "mobility_min", "mobility_max")
+
+
+def _format_name(input_format: str) -> str:
+    """How to spell a detected format in a message."""
+    return FORMAT_NAMES.get(input_format, input_format)
+
+
+def _given_on_the_command_line(ctx: Optional[click.Context], name: str) -> bool:
+    """Whether ``name`` was typed, rather than left at its default.
+
+    Reads click's parameter source rather than comparing against the
+    default, so ``--use-recalibrated`` (whose default is on) and
+    ``--mobility-bins 256`` (whose default is the value) are recognised
+    as given while an untouched option stays quiet.
+    """
+    if ctx is None:
+        return False
+    source = ctx.get_parameter_source(name)
+    return source is click.core.ParameterSource.COMMANDLINE
+
+
+def _warn_ignored_flags(
+    ctx: Optional[click.Context], input_format: str, mobility_grid: bool
+) -> None:
+    """Name every option given on a source, or in a run, that ignores it.
+
+    Args:
+        ctx: The click context of the running command, or ``None`` when
+            the function is called outside one (a direct unit test).
+        input_format: What ``detect_format`` said the source is.
+        mobility_grid: Whether a mobility grid table was asked for, which
+            is what the three grid-sizing options size.
+    """
+    if ctx is None:
+        return
+    source_name = _format_name(input_format)
+    for name, (spelling, formats) in IGNORED_ELSEWHERE.items():
+        if input_format in formats or not _given_on_the_command_line(ctx, name):
+            continue
+        logger.warning(
+            "%s is ignored on %s input: it only applies to %s. The store is "
+            "written as though it had not been given.",
+            spelling,
+            source_name,
+            " or ".join(_format_name(f) for f in formats),
+        )
+
+    if mobility_grid:
+        return
+    for name in GRID_SIZING_FLAGS:
+        spelling, formats = IGNORED_ELSEWHERE[name]
+        if input_format not in formats or not _given_on_the_command_line(ctx, name):
+            continue
+        logger.warning(
+            "%s is ignored without --mobility-grid: it sizes the mobility "
+            "grid, and no grid table is being written.",
+            spelling,
+        )
 
 
 def _parse_streaming_option(streaming: str) -> bool | Literal["auto"]:
@@ -892,6 +1053,7 @@ def main(
         intensity_threshold, "intensity_threshold", "Intensity threshold"
     )
     _validate_positive_float(z_spacing, "z_spacing", "Z spacing")
+    _validate_mobility_grid_params(mobility_bins, mobility_min, mobility_max)
     _validate_input_path(input)
     _validate_output_path(output)
 
@@ -911,6 +1073,18 @@ def main(
 
     # If input folder has multiple .d datasets, let the user choose
     input = _select_bruker_dataset(input)
+
+    # Before any work: say which of the given options this source ignores.
+    # Detection failures are left to the conversion, which reports them
+    # with the guidance the registry writes for each format.
+    try:
+        detected_format = detect_format(input)
+    except Exception:
+        detected_format = ""
+    if detected_format:
+        _warn_ignored_flags(
+            click.get_current_context(silent=True), detected_format, mobility_grid
+        )
 
     # Display calibration info if requested (Bruker datasets only)
     if interactive_calibration and input.is_dir() and input.suffix.lower() == ".d":

--- a/thyra/convert.py
+++ b/thyra/convert.py
@@ -4,10 +4,11 @@ import traceback
 import warnings
 from math import isfinite
 from pathlib import Path
-from typing import Any, Dict, Literal, Optional, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 from .core.base_converter import PixelSizeSource
 from .core.registry import detect_format, get_converter_class, get_reader_class
+from .errors import ConversionRefused
 from .utils.windows_paths import prepare_zarr_output_path
 
 logger = logging.getLogger(__name__)
@@ -35,14 +36,55 @@ def _validate_paths_parameters(
     return True
 
 
+#: Characters SpatialData allows in an element name, besides letters and
+#: digits. Its rule (``spatialdata._core.validation.check_valid_name``) is
+#: not part of the public API, so it is restated here rather than imported:
+#: a private import that moves would take the front-door check down with
+#: it, and the only cost of the two drifting is that SpatialData refuses a
+#: name Thyra let through -- which is exactly today's behaviour.
+_ELEMENT_NAME_EXTRA_CHARS = "_-."
+
+
+def dataset_id_problem(dataset_id: Any) -> Optional[str]:
+    """Why ``dataset_id`` cannot name SpatialData elements, or ``None``.
+
+    Every element key in the store is built from this id -- ``<id>_z0``,
+    ``<id>_z0_tic``, ``<id>_pixels`` -- so SpatialData's naming rule
+    applies to it. It used to be checked for emptiness only, and an id
+    with a space or a slash was refused by SpatialData at ``_save_output``,
+    after both passes over the source had run (issue #250). The suffixes
+    Thyra appends are all legal characters, so an id that passes here
+    yields keys that pass there.
+    """
+    if not isinstance(dataset_id, str):
+        return f"Dataset ID must be a string, not {type(dataset_id).__name__}"
+    if not dataset_id.strip():
+        return "Dataset ID must be a non-empty string"
+    if dataset_id in (".", ".."):
+        return f"Dataset ID cannot be {dataset_id!r}"
+    if dataset_id.startswith("__"):
+        return "Dataset ID cannot start with '__'"
+    bad = sorted(
+        {c for c in dataset_id if not (c.isalnum() or c in _ELEMENT_NAME_EXTRA_CHARS)}
+    )
+    if bad:
+        return (
+            "Dataset ID names every element in the store, so it may hold only "
+            "letters, digits, underscores, dots and hyphens; "
+            f"{dataset_id!r} also holds " + ", ".join(repr(c) for c in bad)
+        )
+    return None
+
+
 def _validate_string_parameters(format_type: str, dataset_id: str) -> bool:
     """Validate string parameters."""
     if not isinstance(format_type, str) or not format_type.strip():
         logger.error("Format type must be a non-empty string")
         return False
 
-    if not isinstance(dataset_id, str) or not dataset_id.strip():
-        logger.error("Dataset ID must be a non-empty string")
+    problem = dataset_id_problem(dataset_id)
+    if problem is not None:
+        logger.error(problem)
         return False
 
     return True
@@ -107,17 +149,17 @@ def _validate_paths(input_path: Path, output_path: Path) -> bool:
 def _create_reader(
     input_path: Path,
     reader_options: Optional[Dict[str, Any]] = None,
-    lossless_spectrum: str = "",
+    lossless_tables: Optional[List[str]] = None,
 ) -> Tuple[Any, str]:
     """Create and return a reader for the input format.
 
     Args:
         input_path: Path to the input MSI data
         reader_options: Optional format-specific reader options (e.g., calibration settings)
-        lossless_spectrum: Names the sibling table being written that
-            needs the summed spectrum to keep all of the ion current
-            (``"mobility grid"``, ``"demultiplexed MS/MS"``), so that
-            table adds back up to the summed one exactly; empty when none.
+        lossless_tables: Names the sibling tables being written that need
+            the summed spectrum to keep all of the ion current
+            (``"mobility grid"``, ``"demultiplexed MS/MS"``), so each of
+            them adds back up to the summed one exactly; empty when none.
 
     Returns:
         Tuple of (reader instance, detected format string)
@@ -129,12 +171,14 @@ def _create_reader(
 
     # Pass reader options to the reader if provided
     options = dict(reader_options or {})
-    if lossless_spectrum:
-        _force_scan_sum(reader_class, options, lossless_spectrum)
+    if lossless_tables:
+        _force_scan_sum(input_format, options, lossless_tables)
     return reader_class(input_path, **options), input_format
 
 
-def _force_scan_sum(reader_class: Any, options: Dict[str, Any], what: str) -> None:
+def _force_scan_sum(
+    input_format: str, options: Dict[str, Any], wanted: List[str]
+) -> None:
     """Say out loud when a sibling table will not add up to the summed one.
 
     A sibling table -- the mobility grid, the demultiplexed MS/MS table --
@@ -147,27 +191,48 @@ def _force_scan_sum(reader_class: Any, options: Dict[str, Any], what: str) -> No
     acquisitions), so an explicit ``--tdf-spectrum vendor_centroid`` is
     the caller saying they want the mismatch, which the sibling's ``uns``
     block then records. It is said at WARNING rather than overridden.
+
+    Said before the reader is opened, because the spectrum mode binds
+    into the vendor handle -- which is also why it cannot yet know
+    whether the source is a PASEF acquisition at all. So it names the
+    tables that *would* carry the mismatch; whether each is written is
+    then said by name when the converter plans it.
     """
     mode = options.get("tdf_spectrum")
     if mode is None or mode == "scan_sum":
         return
+    if input_format != "bruker":
+        # The option reaches no other reader, so nothing about the summed
+        # spectrum changed and there is no mismatch to announce. The CLI
+        # has already said the flag is ignored here (issue #260).
+        return
+    subject = " and ".join(f"a {name} table" for name in wanted)
     logger.warning(
-        "A %s table was asked for with --tdf-spectrum %s. The table reads "
-        "raw scans, so it will not add back up to the summed table; its "
-        "uns block records by how much.",
-        what,
+        "%s %s written with --tdf-spectrum %s. Such a table reads raw "
+        "scans, so it will not add back up to the summed table; its uns "
+        "block records by how much.",
+        subject[0].upper() + subject[1:],
+        "is" if len(wanted) == 1 else "are",
         mode,
     )
 
 
-def _lossless_spectrum_for(kwargs: Dict[str, Any]) -> str:
-    """Which sibling table, if any, needs the lossless summed spectrum."""
+def _lossless_spectrum_for(kwargs: Dict[str, Any]) -> List[str]:
+    """Which sibling tables, if any, need the lossless summed spectrum.
+
+    ``msms_table`` defaults to *on* in the converter (design decision D2),
+    and the CLI forwards the keyword only when the flag was given, so
+    reading it as off-by-default meant the common path -- the default-on
+    table -- never reached :func:`_force_scan_sum` and the mismatch it
+    warns about went unsaid (issue #253). The default here is the
+    converter's own.
+    """
     wanted = []
     if kwargs.get("mobility_grid", False):
         wanted.append("mobility grid")
-    if kwargs.get("msms_table", False):
+    if kwargs.get("msms_table", True):
         wanted.append("demultiplexed MS/MS")
-    return " and ".join(wanted)
+    return wanted
 
 
 def _determine_pixel_size(
@@ -191,7 +256,7 @@ def _determine_pixel_size(
     if essential_metadata.pixel_size is None:
         logger.error("Pixel size not found in metadata")
         logger.error("Use --pixel-size parameter (e.g., --pixel-size 25)")
-        raise ValueError("Pixel size not found in metadata")
+        raise ConversionRefused("Pixel size not found in metadata")
 
     final_pixel_size = essential_metadata.pixel_size[0]  # Use X size
     logger.info(f"Detected pixel size: {final_pixel_size:.1f} um")
@@ -281,7 +346,7 @@ def _resolve_converter_class(format_type: str) -> Any:
             logger.error("Try upgrading your dependencies:")
             logger.error("  pip install --upgrade anndata spatialdata zarr")
             logger.error("Or create a fresh environment with compatible versions.")
-            raise ValueError("SpatialData converter unavailable") from e
+            raise ConversionRefused("SpatialData converter unavailable") from e
         else:
             raise e
 
@@ -454,6 +519,7 @@ def convert_msi(
         reader_options = dict(reader_options or {})
         reader_options["region"] = region
 
+    reader = None
     try:
         # Create reader with format-specific options. A mobility grid
         # table decides the summed spectrum's semantics, so it has to be
@@ -462,7 +528,7 @@ def convert_msi(
         reader, input_format = _create_reader(
             input_path,
             reader_options,
-            lossless_spectrum=_lossless_spectrum_for(kwargs),
+            lossless_tables=_lossless_spectrum_for(kwargs),
         )
 
         # Determine pixel size
@@ -491,7 +557,34 @@ def convert_msi(
         # Perform conversion with cleanup
         return _perform_conversion_with_cleanup(converter, reader)
 
+    except ConversionRefused as e:
+        # A refusal Thyra wrote: the message is the whole explanation, and
+        # a traceback in front of it reads like a crash the code did not
+        # plan for. The traceback is still there under --log-level DEBUG,
+        # for the cases where the refusal itself is the surprise (#234).
+        #
+        # ``str(e)``, never ``e``: a log handler that retains records --
+        # pytest's capture, Ousia's per-session log -- would otherwise hold
+        # the exception, its traceback and every frame in it, which pins
+        # the reader and leaves its file open (see issue #249).
+        logger.error("%s", str(e))
+        logger.debug("Refusal raised at:\n%s", traceback.format_exc())
+        return False
+
     except Exception as e:
         logger.error(f"Error during conversion: {e}")
         logger.error(f"Detailed traceback:\n{traceback.format_exc()}")
         return False
+
+    finally:
+        # Only the conversion itself closed the reader, so anything that
+        # failed before it -- "Pixel size not found in metadata" is the
+        # common one -- left the source open until the garbage collector
+        # happened to reach it. On Windows that holds a lock on the file
+        # the user is about to retry with. Every reader's close() is
+        # idempotent, so the conversion's own close is not disturbed.
+        if reader is not None and hasattr(reader, "close"):
+            try:
+                reader.close()
+            except Exception as close_error:  # pragma: no cover - defensive
+                logger.debug("Could not close the reader: %s", str(close_error))

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -15,6 +15,7 @@ from numpy.typing import NDArray
 from ...alignment import AreaAlignmentResult, TeachingPointAlignment
 from ...core.base_converter import BaseMSIConverter, PixelSizeSource
 from ...core.base_reader import BaseMSIReader
+from ...errors import ConversionRefused
 from ...metadata.types import ComprehensiveMetadata, EssentialMetadata
 from ...resampling import ResamplingDecisionTree, ResamplingMethod
 from ...resampling.gaps import zero_across_gaps
@@ -129,7 +130,7 @@ def _resolve_config_enum(raw: Any, by_name: Dict[str, Any], key: str) -> Any:
         if raw in ("auto", ""):
             return None
         if raw not in by_name:
-            raise ValueError(
+            raise ConversionRefused(
                 f"Unknown resampling_config[{key!r}] value {raw!r}. "
                 f"Valid values are: {valid}."
             )
@@ -138,10 +139,30 @@ def _resolve_config_enum(raw: Any, by_name: Dict[str, Any], key: str) -> Any:
     if raw in by_name.values():
         return raw
 
-    raise ValueError(
+    raise ConversionRefused(
         f"Unsupported resampling_config[{key!r}] value {raw!r}. "
         f"Pass one of {valid}, or the matching enum member."
     )
+
+
+#: Every key :func:`_normalize_resampling_config` reads out of a
+#: ``resampling_config`` dict. Anything else in the dict is a typo or a
+#: leftover, and is warned about rather than ignored.
+_RESAMPLING_CONFIG_KEYS = frozenset(
+    {
+        "method",
+        "axis_type",
+        "target_bins",
+        "width_at_mz",
+        "reference_mz",
+        "min_mz",
+        "max_mz",
+        "gap_tolerance_da",
+        "tof_a",
+        "tof_b",
+        "bins_per_fwhm",
+    }
+)
 
 
 def _normalize_resampling_config(
@@ -159,6 +180,23 @@ def _normalize_resampling_config(
     """
     if isinstance(config, ResamplingConfig):
         return config
+
+    # A key this function does not read changes nothing, and used to
+    # change nothing silently: ``{"target_bin": 4000}`` was accepted and
+    # the axis built from the default (issue #250). Said once, with the
+    # keys that would have worked, rather than refused -- a caller
+    # passing an extra key is not necessarily wrong, but a caller with a
+    # typo always is.
+    unknown = sorted(set(config) - _RESAMPLING_CONFIG_KEYS)
+    if unknown:
+        logger.warning(
+            "resampling_config holds %s, which %s not read and %s no effect. "
+            "Known keys: %s.",
+            ", ".join(repr(key) for key in unknown),
+            "is" if len(unknown) == 1 else "are",
+            "has" if len(unknown) == 1 else "have",
+            ", ".join(sorted(_RESAMPLING_CONFIG_KEYS)),
+        )
 
     from ...resampling.types import DEFAULT_REFERENCE_MZ, AxisType
 
@@ -277,6 +315,15 @@ def _calc_optical_scale_factors(
         cur /= factor
     return factors
 
+
+#: How far the heatmap's total may sit from the stored mean spectrum's and
+#: still be called equal. Looser than :data:`_MARGINAL_TOLERANCE` because
+#: the two are not the same sum reordered: the heatmap coarsens the mass
+#: axis by an integer factor and clips mobility into the edge channels, so
+#: float32 storage of the counts sets the floor. Measured at 4e-8 under
+#: scan_sum and 0.15 under the vendor centroid, so the gap either side of
+#: this is four orders of magnitude wide.
+_HEATMAP_TOLERANCE = 1e-4
 
 #: How far a marginal may sit from the column it mirrors, relative to the
 #: largest value in the summed table, and still be called exact. Summing
@@ -448,7 +495,7 @@ def _tof_plan(converter: Any) -> Tuple[float, float, float]:
     if a is None or b is None:
         law = getattr(converter, "_detected_tof_law", None)
         if law is None:
-            raise ValueError(
+            raise ConversionRefused(
                 "A 'tof' mass axis needs the width law's coefficients: pass "
                 "--tof-law A B, or convert a run whose instrument declares "
                 "them (SELECT SERIES MRT centroid, timsTOF)."
@@ -749,7 +796,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         # caller who asked for CSR would get CSC and no signal. That is the
         # failure this removal was meant to end, so say it instead.
         if "sparse_format" in kwargs:
-            raise ValueError(
+            raise ConversionRefused(
                 "sparse_format was removed: every converter writes CSC, which "
                 "is the layout an ion image reads down. Drop the argument; for "
                 "row-wise access call X.tocsr() on the matrix you read back."
@@ -773,9 +820,11 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
 
         # Validate inputs
         if pixel_size_um <= 0:
-            raise ValueError(f"pixel_size_um must be positive, got {pixel_size_um}")
+            raise ConversionRefused(
+                f"pixel_size_um must be positive, got {pixel_size_um}"
+            )
         if not dataset_id.strip():
-            raise ValueError("dataset_id cannot be empty")
+            raise ConversionRefused("dataset_id cannot be empty")
 
         # Extract pixel_size_detection_info from kwargs if provided
         kwargs_filtered = dict(kwargs)
@@ -802,6 +851,10 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         # _count_out_of_range().
         self._out_of_range_peaks: int = 0
         self._out_of_range_warned: bool = False
+        # Intensities dropped for being non-finite or negative, and
+        # whether that has been said yet. See _count_unusable_intensities().
+        self._unusable_intensities: int = 0
+        self._unusable_intensities_warned: bool = False
         self._pixel_size_detection_info = pixel_size_detection_info
         self._resampling_config = (
             _normalize_resampling_config(resampling_config)
@@ -1778,7 +1831,11 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             return
         table.uns["demultiplexed_current"] = block
         if abs(float(block["current_ratio"]) - 1.0) > _MARGINAL_TOLERANCE:
-            logger.info(
+            # WARNING, not INFO. It is the same disagreement between the
+            # same two tables that the mobility grid reports at WARNING,
+            # and a reader who has to know about one has to know about
+            # the other (issue #253).
+            logger.warning(
                 "The demultiplexed table holds %.4fx the summed table's ion "
                 "current (per pixel %.4f to %.4f). Above 1 under an explicit "
                 "--tdf-spectrum vendor_centroid, which discards counts the "
@@ -1944,7 +2001,57 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         """Apply :meth:`build_uns_metadata` to an AnnData about to be written."""
         uns = self.build_uns_metadata()
         adata.uns.update(uns)
+        self._record_heatmap_current(adata)
         logger.debug("Added MSI metadata to AnnData .uns: %s", sorted(uns))
+
+    @staticmethod
+    def _record_heatmap_current(adata) -> None:
+        """Say how much of the stored mean spectrum the heatmap holds.
+
+        The heatmap's marginal over mobility is the stored mean spectrum
+        coarsened to its own m/z bins -- exactly, under the default
+        ``--tdf-spectrum scan_sum``, and not at all under the vendor
+        centroid, which is a peak-picked spectrum over the same scans
+        while the heatmap is built from the raw points. Measured at 15%
+        off on every vendor_centroid store.
+
+        docs/output-format.md says the identity holds only under
+        scan_sum, but nothing in the store said which case a given store
+        was, so a consumer plotting the heatmap next to the mean spectrum
+        had no way to tell the 15% from a bug (issue #253). The grid's
+        ``uns["mobility_marginal"]`` has recorded its ratio since it
+        existed; this is the same number for the heatmap.
+
+        Both quantities are per-pixel means over the same pixels, so
+        their totals compare directly: the ratio is one scalar and needs
+        nothing materialised.
+        """
+        block = adata.uns.get("mobility_heatmap")
+        spectrum = adata.uns.get("average_spectrum")
+        if not isinstance(block, dict) or spectrum is None:
+            return
+        try:
+            stored = float(np.asarray(spectrum, dtype=np.float64).sum())
+            held = float(np.asarray(block["counts"], dtype=np.float64).sum())
+        except Exception as e:  # pragma: no cover - defensive
+            # str(e), not e: this is the finalize path, where a retained
+            # record pins the memmaps the table is built on (issue #249).
+            logger.debug("Could not compare the mobility heatmap: %s", str(e))
+            return
+        if stored <= 0:
+            return
+        ratio = held / stored
+        block["current_ratio"] = ratio
+        if abs(ratio - 1.0) > _HEATMAP_TOLERANCE:
+            logger.warning(
+                "The mass-mobility heatmap holds %.4fx the stored mean "
+                "spectrum's ion current. Its marginal over mobility is that "
+                "spectrum only under --tdf-spectrum scan_sum; the vendor "
+                "centroid keeps only the current inside the peaks it picks, "
+                "while the heatmap reads raw points. "
+                'uns["mobility_heatmap"]["current_ratio"] records it.',
+                ratio,
+            )
 
     def _serialize_for_zarr(self, obj):
         """Recursively convert tuples to lists for Zarr serialization.
@@ -2078,6 +2185,21 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         min_mz = mass_range[0] if self._min_mz is None else self._min_mz
         max_mz = mass_range[1] if self._max_mz is None else self._max_mz
 
+        # An inverted range has no axis to lay. Unchecked, it built a
+        # descending one, dropped every peak against it, reported "4 of 3
+        # in the first spectrum affected" from a negative count, and
+        # succeeded with an empty store (issue #250).
+        if not (min_mz < max_mz):
+            raise ConversionRefused(
+                f"The resampling mass range [{min_mz:g}, {max_mz:g}] m/z is "
+                "empty: the minimum has to be below the maximum. "
+                + (
+                    "Both come from the source's own mass range."
+                    if self._min_mz is None and self._max_mz is None
+                    else "Check --resample-min-mz / --resample-max-mz."
+                )
+            )
+
         tree = ResamplingDecisionTree()
         if hasattr(self, "_manual_axis_type") and self._manual_axis_type is not None:
             axis_type = self._manual_axis_type
@@ -2115,6 +2237,17 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             target_bins = self._calculate_bins_from_width(min_mz, max_mz, axis_type)
         else:
             target_bins = self._target_bins
+
+        # A one-point axis has no bin width, and the log line that
+        # reports one reduced an empty array: "zero-size array to
+        # reduction operation minimum which has no identity", raised out
+        # of initialization rather than said as a refusal (issue #250).
+        if target_bins < 2:
+            raise ConversionRefused(
+                f"A mass axis needs at least 2 bins, got {target_bins}. "
+                "One point is a single m/z value, not an axis: it has no bin "
+                "width and nothing can be resampled onto it."
+            )
 
         return min_mz, max_mz, axis_type, target_bins
 
@@ -2210,7 +2343,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
 
             self._dimensions = essential.dimensions
             if any(d <= 0 for d in self._dimensions):
-                raise ValueError(
+                raise ConversionRefused(
                     f"Invalid dimensions: {self._dimensions}. All dimensions "
                     f"must be positive."
                 )
@@ -2285,6 +2418,10 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             if self._common_mass_axis is None:
                 raise RuntimeError("Common mass axis is None after initialization")
             logger.info(f"Common mass axis length: {len(self._common_mass_axis)}")
+        except ConversionRefused:
+            # Said once, by whoever catches it. Re-prefixing a refusal
+            # with the stage it came from adds nothing a user can act on.
+            raise
         except Exception as e:
             logger.error(f"Error during initialization: {e}")
             raise
@@ -2322,13 +2459,121 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 )
             self._common_mass_axis = self.reader.get_common_mass_axis()
             if len(self._common_mass_axis) == 0:
-                raise ValueError(
+                raise ConversionRefused(
                     "Common mass axis is empty. Cannot proceed with conversion."
                 )
             logger.info(
                 f"Using raw mass axis with "
                 f"{len(self._common_mass_axis)} unique m/z values"
             )
+
+        self._refuse_non_finite_axis()
+
+    def _refuse_non_finite_axis(self) -> None:
+        """Refuse a mass axis carrying NaN or infinity.
+
+        ``var.mz`` is this axis. Nothing on the way here tested it for
+        finiteness, so a source with NaN m/z converted at exit 0 and
+        ``thyra validate`` then refused the result with
+        ``ERROR var.mz: 'mz' contains non-finite values``: the converter
+        wrote a store its own validator rejects (issue #248). Dropping
+        the values instead is not an option on the raw path -- the axis
+        *is* the source's m/z values, and every spectrum's indices are
+        paired with a full intensity array -- so this is a refusal.
+
+        One pass over the axis, which is at most a few million float64s
+        and is walked several times either way.
+        """
+        axis = self._common_mass_axis
+        if axis is None or len(axis) == 0:
+            return
+        finite = np.isfinite(axis)
+        if bool(finite.all()):
+            return
+        n_bad = int(axis.size - finite.sum())
+        raise ConversionRefused(
+            f"The common mass axis holds {n_bad:,} non-finite value(s) out of "
+            f"{axis.size:,} (NaN or infinity). It becomes var['mz'], where "
+            "every value has to be a real mass, so this store would be "
+            "written and then refused by `thyra validate`. On a resampled "
+            "conversion, check --resample-min-mz / --resample-max-mz; on "
+            "--no-resample, the axis is the source's own m/z values and the "
+            "source is what carries them."
+        )
+
+    def _drop_unusable_intensities(
+        self, mzs: NDArray[np.float64], intensities: NDArray[np.float64]
+    ) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
+        """Drop intensities that are not a measurement, before resampling.
+
+        Two kinds, one rule (issue #248):
+
+        *Non-finite.* A NaN intensity reached ``X.data`` unchallenged,
+        turned ``uns["average_spectrum"]`` into NaN, and passed
+        validation -- one unusable value poisoning every aggregate over
+        the column it sits in.
+
+        *Negative.* An intensity is a count of ions, or an ADC reading
+        proportional to one. A negative value is not a smaller
+        measurement; it is a baseline subtraction that overshot, and no
+        consumer of a converted store reads it as signal -- a TIC, an ion
+        image and a mean spectrum all take it as removing current that
+        was never there. Keeping it also made the two resampling methods
+        disagree in kind rather than in detail: nearest_neighbor stored
+        it (giving a pixel a TIC of 0), while tic_preserving found a
+        non-positive total for the spectrum and zeroed the whole thing.
+
+        Dropped here, before either method runs, so both see the same
+        spectrum and produce the same store. Dropping rather than
+        refusing, because baseline-subtracted profile data really does
+        carry small negatives and refusing it would leave no way to
+        convert those files at all; the count says how much went.
+
+        The arrays are returned unchanged -- the same objects -- when
+        there is nothing to drop, which is every ordinary spectrum, so
+        the shared-axis identity fast path downstream is untouched.
+        """
+        if intensities.size == 0:
+            return mzs, intensities
+        keep = np.isfinite(intensities) & (intensities >= 0)
+        if bool(keep.all()):
+            return mzs, intensities
+        self._count_unusable_intensities(
+            int(intensities.size - keep.sum()),
+            int(intensities.size),
+            intensities[~keep],
+        )
+        return mzs[keep], intensities[keep]
+
+    def _count_unusable_intensities(
+        self, n_dropped: int, n_total: int, dropped: NDArray[np.float64]
+    ) -> None:
+        """Record intensities dropped as unusable, warning once.
+
+        Once per conversion rather than once per spectrum, for the reason
+        :meth:`_count_out_of_range` gives: a source with negatives usually
+        has them in every spectrum. ``_unusable_intensities`` keeps the
+        running total, and like that counter it counts *calls*, so it
+        double-counts a two-pass conversion; read the warning for the
+        per-spectrum figure.
+        """
+        self._unusable_intensities += n_dropped
+        if self._unusable_intensities_warned:
+            return
+        self._unusable_intensities_warned = True
+        n_nan = int(np.count_nonzero(~np.isfinite(dropped)))
+        logger.warning(
+            "Dropping intensities that are not a measurement -- %d of %d in "
+            "the first spectrum affected (%d non-finite, %d negative). A NaN "
+            "would make every aggregate over its column NaN, and a negative "
+            "value is a baseline subtraction that overshot, not signal. Both "
+            "resampling methods see the spectrum without them, so they agree "
+            "on what is stored.",
+            n_dropped,
+            n_total,
+            n_nan,
+            n_dropped - n_nan,
+        )
 
     @staticmethod
     def _coalesce_duplicate_bins(

--- a/thyra/converters/spatialdata/mobility_heatmap.py
+++ b/thyra/converters/spatialdata/mobility_heatmap.py
@@ -43,6 +43,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from ...core.base_reader import BaseMSIReader
+from ...errors import ConversionRefused
 from ...resampling.mobility_grid import (
     MOBILITY_CHANNELS,
     build_mobility_grid,
@@ -91,7 +92,7 @@ def mz_bin_edges(
     axis = np.asarray(axis, dtype=np.float64)
     n = int(axis.size)
     if n == 0:
-        raise ValueError("The mass axis is empty")
+        raise ConversionRefused("The mass axis is empty")
     if n == 1:
         axis_edges = np.array([axis[0] - 0.5, axis[0] + 0.5])
     else:
@@ -116,6 +117,24 @@ def mobility_bin_edges(
     return build_mobility_grid(lower, upper, channels).edges
 
 
+def usable_intensities(intensities: NDArray[np.float64]) -> Optional[NDArray[np.bool_]]:
+    """Which points carry a measurement, or ``None`` when they all do.
+
+    The same rule the summed table applies before resampling (see
+    ``BaseSpatialDataConverter._drop_unusable_intensities``): a NaN is
+    not a measurement and a negative value is an overshot baseline
+    subtraction, and neither is signal. It has to be the same rule here
+    or a grid table's marginal over channels would stop reproducing the
+    summed table's column on exactly the sources that carry them
+    (issue #248).
+
+    ``None`` for the ordinary spectrum, so the callers can skip masking
+    entirely rather than allocating a copy of every array per pixel.
+    """
+    usable = np.isfinite(intensities) & (intensities >= 0)
+    return None if bool(usable.all()) else usable
+
+
 def map_points_to_axis(
     axis: NDArray[np.float64],
     mzs: NDArray[np.float64],
@@ -127,21 +146,33 @@ def map_points_to_axis(
     "In range" is the strict axis span, and a point outside it is dropped
     rather than folded onto an edge bin -- the summed table drops it, so
     a marginal over mobility that kept it would exceed the column it
-    mirrors. Points in range go to their nearest axis entry through the
-    converter's own rule (ties to the right). This is the one place the
-    mapping is written: the heatmap, the grid's discovery pass and the
-    grid's scatter pass all go through it, so they cannot disagree.
+    mirrors. A point whose intensity is not a measurement goes for the
+    same reason, by the same rule (:func:`usable_intensities`). Points in
+    range go to their nearest axis entry through the converter's own rule
+    (ties to the right). This is the one place the mapping is written: the
+    heatmap, the grid's discovery pass and the grid's scatter pass all go
+    through it, so they cannot disagree.
 
     Returns:
         ``(bins, mobility, intensities, n_dropped)`` -- the axis index of
         every kept point, the two other arrays masked to match, and how
-        many points were dropped.
+        many points were dropped for lying outside the axis.
     """
     mzs = np.asarray(mzs, dtype=np.float64)
     mobility = np.asarray(mobility, dtype=np.float64)
     intensities = np.asarray(intensities, dtype=np.float64)
     if mzs.size == 0:
         return np.zeros(0, dtype=np.int64), mobility, intensities, 0
+    # Not counted in ``n_dropped``: these points were not outside the
+    # axis, they were never measurements. The summed table's own path
+    # counts them and says so once.
+    usable = usable_intensities(intensities)
+    if usable is not None:
+        mzs = mzs[usable]
+        mobility = mobility[usable]
+        intensities = intensities[usable]
+        if mzs.size == 0:
+            return np.zeros(0, dtype=np.int64), mobility, intensities, 0
     in_range = (mzs >= axis[0]) & (mzs <= axis[-1])
     n_dropped = 0
     if not in_range.all():
@@ -185,6 +216,16 @@ def map_indexed_points_to_axis(
     intensities = np.asarray(intensities, dtype=np.float64)
     if inverse.size == 0:
         return np.zeros(0, dtype=np.int64), mobility, intensities, 0
+    # Applied to the points, not to the unique m/z values: the rule is
+    # about the intensity a point carries, and two points sharing an m/z
+    # need not share a fate.
+    usable = usable_intensities(intensities)
+    if usable is not None:
+        inverse = inverse[usable]
+        mobility = mobility[usable]
+        intensities = intensities[usable]
+        if inverse.size == 0:
+            return np.zeros(0, dtype=np.int64), mobility, intensities, 0
     bins = _nn_map_to_bins(axis, unique_mz).astype(np.int64)
     in_range = (unique_mz >= axis[0]) & (unique_mz <= axis[-1])
     if in_range.all():

--- a/thyra/converters/spatialdata/mobility_table.py
+++ b/thyra/converters/spatialdata/mobility_table.py
@@ -52,6 +52,7 @@ from numpy.typing import NDArray
 from scipy import sparse
 
 from ...core.base_reader import BaseMSIReader
+from ...errors import ConversionRefused
 from ...resampling.mobility_grid import MobilityGrid
 from .csc_assembly import (
     CscAssembly,
@@ -300,7 +301,7 @@ class _SharedFeatureAxis:
         )
         if not on_axis.all():
             first = int(np.flatnonzero(~on_axis)[0])
-            raise ValueError(
+            raise ConversionRefused(
                 f"Pixel {coords}: (m/z {mzs[first]}, mobility {mobility[first]}) "
                 "is not on the shared feature axis"
             )

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -21,6 +21,7 @@ import pandas as pd
 from numpy.typing import NDArray
 from tqdm import tqdm
 
+from ...errors import ConversionRefused
 from ...resampling import ResamplingMethod
 from .base_spatialdata_converter import SPATIALDATA_AVAILABLE, BaseSpatialDataConverter
 from .csc_assembly import CscAssembly
@@ -194,7 +195,7 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         super().__init__(*args, **kwargs)
 
         if use_csc is False:
-            raise ValueError(
+            raise ConversionRefused(
                 "use_csc=False selected the streaming COO route, which has been "
                 "removed: the PCS route was faster and lighter at every size "
                 "measured. Pass use_csc=True or leave it out."
@@ -291,6 +292,10 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         Returns:
             Tuple of (mz_indices, resampled_intensities) with zeros filtered out
         """
+        # Before either resampling method, so both are handed the same
+        # spectrum and cannot disagree about it (issue #248).
+        mzs, intensities = self._drop_unusable_intensities(mzs, intensities)
+
         if not self._resampling_config:
             # No resampling - map m/z values to indices directly. Entries
             # that share a bin (a repeated m/z) are summed so the CSC never

--- a/thyra/core/base_converter.py
+++ b/thyra/core/base_converter.py
@@ -12,6 +12,7 @@ from pandas import DataFrame
 from scipy import sparse
 from tqdm import tqdm
 
+from ..errors import ConversionRefused
 from .base_reader import BaseMSIReader
 
 if TYPE_CHECKING:
@@ -90,7 +91,9 @@ class BaseMSIConverter(ABC):
         if z_spacing_um is not None and (
             not isinstance(z_spacing_um, (int, float)) or z_spacing_um <= 0
         ):
-            raise ValueError(f"z_spacing_um must be positive, got {z_spacing_um}")
+            raise ConversionRefused(
+                f"z_spacing_um must be positive, got {z_spacing_um}"
+            )
 
         self.reader = reader
         self.output_path = Path(output_path)
@@ -141,6 +144,21 @@ class BaseMSIConverter(ABC):
             success = self._save_output(data_structures)
 
             return success
+        except ConversionRefused as e:
+            # The other half of issue #234: convert_msi's catch-all was
+            # not the only one. This one runs first for anything raised
+            # inside the workflow -- the axis plan, the reader's refusal
+            # of a frame -- so a refusal reaching it has to be presented
+            # as a refusal here too, or nothing downstream ever sees it.
+            #
+            # ``str(e)`` rather than ``e`` for the reason issue #249 gives:
+            # a retained log record would hold the exception's traceback
+            # and through it the reader, whose files then stay open.
+            import traceback
+
+            logger.error("%s", str(e))
+            logger.debug("Refusal raised at:\n%s", traceback.format_exc())
+            return False
         except Exception as e:
             logger.error(f"Error during conversion: {e}")
             import traceback
@@ -159,7 +177,7 @@ class BaseMSIConverter(ABC):
 
             self._dimensions = essential.dimensions
             if any(d <= 0 for d in self._dimensions):
-                raise ValueError(
+                raise ConversionRefused(
                     f"Invalid dimensions: {self._dimensions}. All dimensions "
                     f"must be positive."
                 )
@@ -191,7 +209,7 @@ class BaseMSIConverter(ABC):
             # Load mass axis separately (still expensive operation)
             self._common_mass_axis = self.reader.get_common_mass_axis()
             if len(self._common_mass_axis) == 0:
-                raise ValueError(
+                raise ConversionRefused(
                     "Common mass axis is empty. Cannot proceed with " "conversion."
                 )
 
@@ -203,6 +221,10 @@ class BaseMSIConverter(ABC):
             logger.info(f"Total spectra: {self._n_spectra}")
             logger.info(f"Estimated memory: {self._estimated_memory_gb:.2f} GB")
             logger.info(f"Common mass axis length: {len(self._common_mass_axis)}")
+        except ConversionRefused:
+            # Said once, by whoever catches it. Re-prefixing a refusal
+            # with the stage it came from adds nothing a user can act on.
+            raise
         except Exception as e:
             logger.error(f"Error during initialization: {e}")
             raise
@@ -256,17 +278,29 @@ class BaseMSIConverter(ABC):
     def _log_z_spacing(self) -> None:
         """Report the resolved z spacing, warning when it was assumed.
 
-        Silent for anything that is not a volume: a 2D conversion has no
+        Quiet for a 2D conversion nobody asked to make 3D: it has no
         slice-to-slice distance to get wrong, and warning about one on
         every ordinary dataset would train people to ignore the message
         on the datasets where it matters.
+
+        A single-slice acquisition converted *with* ``--handle-3d`` is
+        the exception. It is not a volume either -- one plane has no
+        spacing -- but the flags were given, and docs/cli.md promises
+        that ``--handle-3d`` says what it recorded and that a
+        ``--z-spacing`` doing nothing "is logged as ignored rather than
+        silently accepted". Both promises were skipped here, because
+        ``_is_volume`` is false for ``n_z == 1`` and this method returned
+        at DEBUG (issue #256).
         """
         if not self._is_volume:
-            logger.debug(
-                "Not a multi-slice volume; z spacing (%g um, %s) is unused.",
-                self.z_spacing_um,
-                self.z_spacing_source.value,
-            )
+            if self.handle_3d:
+                self._log_single_plane_volume()
+            else:
+                logger.debug(
+                    "Not a multi-slice volume; z spacing (%g um, %s) is unused.",
+                    self.z_spacing_um,
+                    self.z_spacing_source.value,
+                )
             return
 
         if self.z_spacing_source is ZSpacingSource.ASSUMED_ISOTROPIC:
@@ -288,6 +322,36 @@ class BaseMSIConverter(ABC):
                 self.z_spacing_source.value,
                 self.z_spacing_um,
                 self.pixel_size_um,
+            )
+
+    def _log_single_plane_volume(self) -> None:
+        """Say that 3D handling found one plane, and what that costs.
+
+        The conversion is not refused: a one-plane volume is a legal
+        store and the flag is often part of a batch script that also
+        converts real stacks. What changes is that it says so, and names
+        the ``--z-spacing`` it is dropping, instead of writing a store
+        whose keys differ from the 2D run's with nothing in the log.
+        """
+        planes = self._dimensions[2] if self._dimensions else 0
+        if self._z_spacing_um_arg is not None:
+            logger.warning(
+                "3D handling was asked for and this acquisition has %d plane, "
+                "so the volume has no z extent and the z spacing of %g um is "
+                "ignored: it is neither applied nor recorded. The store is "
+                "written as a volume of one plane, which changes the element "
+                "keys (no _z0 suffix) but not the values.",
+                planes,
+                self._z_spacing_um_arg,
+            )
+        else:
+            logger.info(
+                "3D handling was asked for and this acquisition has %d plane. "
+                "One plane has no slice-to-slice distance, so no z spacing is "
+                "recorded. The store is written as a volume of one plane, "
+                "which changes the element keys (no _z0 suffix) but not the "
+                "values.",
+                planes,
             )
 
     @abstractmethod
@@ -632,7 +696,7 @@ class BaseMSIConverter(ABC):
         bad = diffs > max_diff
         if np.any(bad):
             worst = int(np.argmax(diffs))
-            raise ValueError(
+            raise ConversionRefused(
                 f"{int(np.count_nonzero(bad))} of {mzs.size} m/z values have "
                 f"no common mass axis entry within {max_diff:g} (worst: m/z "
                 f"{mzs[worst]!r} is {diffs[worst]:.6g} from nearest axis "

--- a/thyra/core/mobility.py
+++ b/thyra/core/mobility.py
@@ -21,6 +21,8 @@ from typing import Any, Dict, Optional, Tuple
 import numpy as np
 from numpy.typing import NDArray
 
+from ..errors import ConversionRefused
+
 #: The two mobility quantities an instrument records, as PSI-MS terms.
 INVERSE_REDUCED_MOBILITY_ACCESSION = "MS:1002815"
 DRIFT_TIME_ACCESSION = "MS:1002476"
@@ -272,7 +274,7 @@ def _checked_charge(charge: Any) -> int:
     if isinstance(charge, bool) or not isinstance(charge, (int, np.integer)):
         raise TypeError(f"charge must be an integer charge state, got {charge!r}")
     if int(charge) < 1:
-        raise ValueError(
+        raise ConversionRefused(
             f"charge must be a positive charge state (the absolute value), "
             f"got {int(charge)}"
         )

--- a/thyra/core/registry.py
+++ b/thyra/core/registry.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from threading import RLock
 from typing import Dict, NoReturn, Type
 
+from ..errors import ConversionRefused
 from .base_converter import BaseMSIConverter
 from .base_reader import BaseMSIReader
 
@@ -149,7 +150,7 @@ class MSIRegistry:
         - .raw files (PHI SmartSoft-TOF ToF-SIMS)
         """
         if not input_path.exists():
-            raise ValueError(f"Input path does not exist: {input_path}")
+            raise ConversionRefused(f"Input path does not exist: {input_path}")
 
         format_name = self._detect_format_name(input_path)
         self._validate_format(format_name, input_path)
@@ -175,7 +176,7 @@ class MSIRegistry:
     def _detect_bruker_d_format(self, input_path: Path) -> str:
         """Validate and detect Bruker format from .d directory."""
         if not input_path.is_dir():
-            raise ValueError(
+            raise ConversionRefused(
                 "Bruker format requires .d directory, " f"got file: {input_path}"
             )
         bruker_format = self._detect_bruker_format(input_path)
@@ -183,14 +184,16 @@ class MSIRegistry:
             return bruker_format
         BrukerFolderStructure, _ = _get_bruker_folder_structure()
         if BrukerFolderStructure.is_solarix_without_peaks(input_path):
-            raise ValueError(
+            raise ConversionRefused(
                 f"solariX .d directory without peaks.sqlite: {input_path}. "
                 "The acquisition holds raw transients (ser) but no processed "
                 "peak store, which is what Thyra reads. Export the dataset "
                 "as imzML from the Bruker software (DataAnalysis, SCiLS Lab, "
                 "or flexImaging) and convert the imzML file instead."
             )
-        raise ValueError("Bruker .d directory missing analysis " f"files: {input_path}")
+        raise ConversionRefused(
+            "Bruker .d directory missing analysis " f"files: {input_path}"
+        )
 
     def _detect_mzpeak_format(self, input_path: Path) -> str:
         """Validate that a ``.mzpeak`` path really is an mzPeak archive.
@@ -212,7 +215,7 @@ class MSIRegistry:
             ValueError: If the file is not a ZIP or carries no index member.
         """
         if input_path.is_dir():
-            raise ValueError(
+            raise ConversionRefused(
                 f"mzPeak format requires a .mzpeak archive file, got "
                 f"directory: {input_path}"
             )
@@ -220,20 +223,20 @@ class MSIRegistry:
             with input_path.open("rb") as handle:
                 magic = handle.read(4)
         except (OSError, PermissionError) as exc:
-            raise ValueError(f"Cannot read {input_path}: {exc}") from exc
+            raise ConversionRefused(f"Cannot read {input_path}: {exc}") from exc
 
         if magic != b"PK\x03\x04":
-            raise ValueError(
+            raise ConversionRefused(
                 f"Not an mzPeak archive (missing ZIP signature): {input_path}"
             )
 
         if not zipfile.is_zipfile(input_path):
-            raise ValueError(
+            raise ConversionRefused(
                 f"Not an mzPeak archive (unreadable ZIP container): " f"{input_path}"
             )
         with zipfile.ZipFile(input_path) as archive:
             if "mzpeak_index.json" not in archive.namelist():
-                raise ValueError(
+                raise ConversionRefused(
                     f"Not an mzPeak archive (no mzpeak_index.json member): "
                     f"{input_path}"
                 )
@@ -249,12 +252,12 @@ class MSIRegistry:
         if input_path.is_dir():
             if self._detect_waters_format(input_path):
                 return "waters"
-            raise ValueError(
+            raise ConversionRefused(
                 "Waters .raw directory missing " f"_FUNC*.DAT files: {input_path}"
             )
         if self._detect_phi_format(input_path):
             return "phi"
-        raise ValueError(
+        raise ConversionRefused(
             f"Unrecognised .raw file: {input_path}. Expected either a Waters "
             "directory containing _FUNC*.DAT files, or a PHI SmartSoft-TOF "
             "file beginning with the SOFH magic."
@@ -277,7 +280,7 @@ class MSIRegistry:
         development. Until it lands, IMAGEREVEAL MS can export the data
         as imzML, which Thyra converts today.
         """
-        raise ValueError(
+        raise ConversionRefused(
             f"Shimadzu imaging data detected: {input_path}. Native support "
             "for Shimadzu formats (.imdx, .kbd) is in development. In the "
             "meantime, export the dataset as imzML from IMAGEREVEAL MS and "
@@ -295,7 +298,7 @@ class MSIRegistry:
             ".raw directory (Waters)",
             ".raw file (PHI SmartSoft-TOF)",
         ]
-        raise ValueError(
+        raise ConversionRefused(
             f"Unsupported format for '{input_path}'. "
             f"Supported: {', '.join(available)}"
         )
@@ -305,7 +308,7 @@ class MSIRegistry:
         if format_name == "imzml":
             ibd_path = input_path.with_suffix(".ibd")
             if not ibd_path.exists():
-                raise ValueError(
+                raise ConversionRefused(
                     f"ImzML file requires corresponding .ibd file: {ibd_path}"
                 )
         elif format_name == "bruker":
@@ -320,7 +323,7 @@ class MSIRegistry:
         BrukerFolderStructure, BrukerFormat = _get_bruker_folder_structure()
 
         if not input_path.is_dir():
-            raise ValueError(
+            raise ConversionRefused(
                 f"Bruker format requires .d directory, got file: {input_path}"
             )
 
@@ -329,7 +332,7 @@ class MSIRegistry:
             folder = BrukerFolderStructure(input_path)
             info = folder.analyze()
             if info.format == BrukerFormat.UNKNOWN:
-                raise ValueError(
+                raise ConversionRefused(
                     f"Bruker .d directory missing analysis files: {input_path}"
                 )
         except Exception as e:
@@ -339,7 +342,7 @@ class MSIRegistry:
             has_tsf = (input_path / "analysis.tsf").exists()
             has_tdf = (input_path / "analysis.tdf").exists()
             if not has_tsf and not has_tdf:
-                raise ValueError(
+                raise ConversionRefused(
                     f"Bruker .d directory missing analysis files: {input_path}"
                 ) from e
 
@@ -348,7 +351,7 @@ class MSIRegistry:
         with self._lock:
             if format_name not in self._readers:
                 available = list(self._readers.keys())
-                raise ValueError(
+                raise ConversionRefused(
                     f"No reader for format "
                     f"'{format_name}'. "
                     f"Available: {available}"
@@ -360,7 +363,7 @@ class MSIRegistry:
         with self._lock:
             if format_name not in self._converters:
                 available = list(self._converters.keys())
-                raise ValueError(
+                raise ConversionRefused(
                     f"No converter for format '{format_name}'. Available: "
                     f"{available}"
                 )

--- a/thyra/errors.py
+++ b/thyra/errors.py
@@ -1,0 +1,38 @@
+"""The exception a refusal is spelled with.
+
+Thyra refuses a great deal on purpose: a ``.d`` directory with no
+analysis files, a Waters raster whose stage never moved, a ``tof`` axis
+with no width law, an output path that already holds a store. Each of
+those refusals is a sentence someone wrote for the person who hit it,
+and each used to reach that person as a thirty-line traceback --
+``convert_msi`` caught every exception alike and logged the message
+*and* the traceback at ERROR, so a refusal Thyra planned for was
+presented exactly like a crash it did not (issue #234).
+
+:class:`ConversionRefused` is how the two are told apart. Raising it
+says "this is the whole explanation": the CLI prints the message once at
+ERROR and keeps the traceback for ``--log-level DEBUG``. Anything else
+reaching the same handler is unexpected, and keeps its traceback at
+ERROR, because for those the traceback *is* the explanation.
+
+It subclasses :class:`ValueError` because every one of these sites
+raised a ``ValueError`` before, and callers -- Thyra's own tests
+included -- catch that. Nothing that used to work stops working.
+
+The distinction is about who the message is for, not about where it is
+raised. An internal invariant ("Common mass axis is not initialized")
+stays a plain ``ValueError``: nobody can act on it, and its traceback is
+the only useful part.
+"""
+
+
+class ConversionRefused(ValueError):
+    """Thyra declined to do something, and the message says why.
+
+    The message is addressed to the person who ran the conversion and is
+    expected to name what to do about it. No traceback is shown for it
+    at the default log level.
+    """
+
+
+__all__ = ["ConversionRefused"]

--- a/thyra/metadata/schema/cli.py
+++ b/thyra/metadata/schema/cli.py
@@ -18,12 +18,33 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import click
 
+from ...utils.windows_paths import prepare_zarr_read_path
 from .metaspace import to_metaspace
 from .models import MSI_METADATA_UNS_KEY, MSIMetadata
 from .store_io import deep_merge, read_msi_metadata_blocks
 from .validate import ValidationIssue, check_store_var_conventions, validate_document
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_store_path(path: Path) -> Path:
+    r"""The path to read ``path`` through, refusing a missing one first.
+
+    ``click.Path(exists=True)`` cannot be used for these arguments. The
+    converter writes a store to a deep Windows path through an
+    extended-length (``\\?\``) path, and click's existence check runs
+    before anything can prepare the path the same way -- so the CLI
+    refused to validate a store the CLI had just written, with
+    ``Path '...deep.zarr' does not exist`` while the API validated it
+    fine (issue #257). Existence is checked here instead, on the
+    prepared path, and the same preparation is what the read then uses.
+    """
+    prepared = prepare_zarr_read_path(path)
+    if not prepared.exists():
+        raise click.BadParameter(
+            f"Path {str(path)!r} does not exist.", param_hint="PATH"
+        )
+    return prepared
 
 
 def _load_json(path: Path) -> Dict[str, Any]:
@@ -87,7 +108,7 @@ def _echo_issues(label: str, issues: List[ValidationIssue]) -> None:
 
 
 @click.command("validate")
-@click.argument("path", type=click.Path(exists=True, path_type=Path))
+@click.argument("path", type=click.Path(exists=False, path_type=Path))
 @click.option(
     "--merge",
     "merge_path",
@@ -110,6 +131,7 @@ def validate_command(path: Path, merge_path: Optional[Path], as_json: bool) -> N
     is 0 when every document conforms (warnings allowed), 1 otherwise,
     so it can gate CI.
     """
+    path = _resolve_store_path(path)
     documents = _apply_merge(_load_documents(path), merge_path)
     var_issues = _store_var_issues(path)
 
@@ -187,7 +209,7 @@ def _validated_model(label: str, document: Dict[str, Any]) -> MSIMetadata:
 
 
 @click.command("export-metaspace")
-@click.argument("path", type=click.Path(exists=True, path_type=Path))
+@click.argument("path", type=click.Path(exists=False, path_type=Path))
 @click.option(
     "--merge",
     "merge_path",
@@ -222,6 +244,7 @@ def export_metaspace_command(
     empty and reported as warnings on stderr; fill them via --merge or
     on the METASPACE submission form.
     """
+    path = _resolve_store_path(path)
     documents = _apply_merge(_load_documents(path), merge_path)
     label, document = _select_document(documents, table)
     meta = _validated_model(label, document)

--- a/thyra/readers/bruker/folder_structure.py
+++ b/thyra/readers/bruker/folder_structure.py
@@ -17,6 +17,8 @@ from enum import Enum
 from pathlib import Path
 from typing import List, Optional, Tuple
 
+from ...errors import ConversionRefused
+
 logger = logging.getLogger(__name__)
 
 
@@ -115,7 +117,7 @@ class BrukerFolderStructure:
             ValueError: If path doesn't exist
         """
         if not self.path.exists():
-            raise ValueError(f"Path does not exist: {self.path}")
+            raise ConversionRefused(f"Path does not exist: {self.path}")
 
         # Cache the result
         if self._info is None:

--- a/thyra/readers/bruker/rapiflex/rapiflex_reader.py
+++ b/thyra/readers/bruker/rapiflex/rapiflex_reader.py
@@ -42,6 +42,7 @@ from tqdm import tqdm
 
 from ....core.base_extractor import MetadataExtractor
 from ....core.registry import register_reader
+from ....errors import ConversionRefused
 from ....metadata.types import ComprehensiveMetadata, EssentialMetadata
 from ..base_bruker_reader import BrukerBaseMSIReader
 
@@ -264,12 +265,12 @@ class RapiflexReader(BrukerBaseMSIReader):
         folder = self.data_path
 
         if not folder.is_dir():
-            raise ValueError(f"Rapiflex path must be a directory: {folder}")
+            raise ConversionRefused(f"Rapiflex path must be a directory: {folder}")
 
         # Find .dat file
         dat_files = list(folder.glob("*.dat"))
         if not dat_files:
-            raise ValueError(f"No .dat file found in {folder}")
+            raise ConversionRefused(f"No .dat file found in {folder}")
         if len(dat_files) > 1:
             logger.warning(f"Multiple .dat files found, using first: {dat_files[0]}")
         self._dat_path = dat_files[0]
@@ -279,14 +280,14 @@ class RapiflexReader(BrukerBaseMSIReader):
         if info_files:
             self._info_path = info_files[0]
         else:
-            raise ValueError(f"No *_info.txt file found in {folder}")
+            raise ConversionRefused(f"No *_info.txt file found in {folder}")
 
         # Find _poslog.txt file
         poslog_files = list(folder.glob("*_poslog.txt"))
         if poslog_files:
             self._poslog_path = poslog_files[0]
         else:
-            raise ValueError(f"No *_poslog.txt file found in {folder}")
+            raise ConversionRefused(f"No *_poslog.txt file found in {folder}")
 
         # Find .mis file (optional)
         mis_files = list(folder.glob("*.mis"))
@@ -457,7 +458,7 @@ class RapiflexReader(BrukerBaseMSIReader):
     def _parse_positions(self) -> None:
         """Parse coordinate information from _poslog.txt file."""
         if not self._poslog_path:
-            raise ValueError("Position log file not found")
+            raise ConversionRefused("Position log file not found")
 
         self._positions = []
 
@@ -494,13 +495,13 @@ class RapiflexReader(BrukerBaseMSIReader):
     def _parse_dat_header(self) -> None:
         """Parse the .dat file header and offset table."""
         if not self._dat_path:
-            raise ValueError("Data file not found")
+            raise ConversionRefused("Data file not found")
 
         with open(self._dat_path, "rb") as f:
             # Read fixed 48-byte header
             header_data = f.read(48)
             if len(header_data) < 48:
-                raise ValueError("Invalid .dat file: header too short")
+                raise ConversionRefused("Invalid .dat file: header too short")
 
             # Parse header fields
             vals = struct.unpack("<12I", header_data)
@@ -526,7 +527,7 @@ class RapiflexReader(BrukerBaseMSIReader):
                     f.read(n_raster_positions * 4), dtype=np.uint32
                 ).copy()
             else:
-                raise ValueError("Invalid raster dimensions in header")
+                raise ConversionRefused("Invalid raster dimensions in header")
 
         logger.debug(
             f"Parsed .dat header: {self._header['n_datapoints']} datapoints, "
@@ -582,9 +583,11 @@ class RapiflexReader(BrukerBaseMSIReader):
             n_points = self.n_datapoints
 
             if n_points == 0:
-                raise ValueError("Cannot create mass axis: n_datapoints is 0")
+                raise ConversionRefused("Cannot create mass axis: n_datapoints is 0")
             if mass_start >= mass_end:
-                raise ValueError(f"Invalid mass range: {mass_start} to {mass_end}")
+                raise ConversionRefused(
+                    f"Invalid mass range: {mass_start} to {mass_end}"
+                )
 
             self._mz_axis = np.linspace(mass_start, mass_end, n_points)
 

--- a/thyra/readers/bruker/solarix/solarix_reader.py
+++ b/thyra/readers/bruker/solarix/solarix_reader.py
@@ -40,6 +40,7 @@ from tqdm import tqdm
 
 from ....core.base_extractor import MetadataExtractor
 from ....core.registry import register_reader
+from ....errors import ConversionRefused
 from ..base_bruker_reader import BrukerBaseMSIReader
 from ..mis_parser import parse_mis_file
 
@@ -147,7 +148,7 @@ class SolarixReader(BrukerBaseMSIReader):
     def _validate_layout(self) -> None:
         """Refuse anything that is not a solariX imaging .d directory."""
         if not self.data_path.is_dir():
-            raise ValueError(
+            raise ConversionRefused(
                 f"solariX format requires a .d directory, got: {self.data_path}"
             )
         peaks = self.data_path / "peaks.sqlite"
@@ -155,7 +156,7 @@ class SolarixReader(BrukerBaseMSIReader):
             if (self.data_path / "ser").exists() and (
                 self.data_path / "ImagingInfo.xml"
             ).exists():
-                raise ValueError(
+                raise ConversionRefused(
                     f"solariX .d directory without peaks.sqlite: "
                     f"{self.data_path}. The acquisition holds raw transients "
                     "(ser) but no processed peak store, which is what Thyra "
@@ -163,7 +164,7 @@ class SolarixReader(BrukerBaseMSIReader):
                     "software (DataAnalysis, SCiLS Lab, or flexImaging) and "
                     "convert the imzML file instead."
                 )
-            raise ValueError(
+            raise ConversionRefused(
                 f"Not a solariX imaging .d directory (no peaks.sqlite): "
                 f"{self.data_path}"
             )
@@ -180,7 +181,7 @@ class SolarixReader(BrukerBaseMSIReader):
         try:
             return sqlite3.connect(uri, uri=True)
         except sqlite3.Error as exc:
-            raise ValueError(
+            raise ConversionRefused(
                 f"Cannot open {self._peaks_path} read-only: {exc}"
             ) from exc
 
@@ -189,7 +190,7 @@ class SolarixReader(BrukerBaseMSIReader):
         try:
             rows = self._conn.execute("SELECT Key, Value FROM Properties").fetchall()
         except sqlite3.Error as exc:
-            raise ValueError(
+            raise ConversionRefused(
                 f"peaks.sqlite has no readable Properties table in "
                 f"{self.data_path}: {exc}"
             ) from exc
@@ -206,7 +207,7 @@ class SolarixReader(BrukerBaseMSIReader):
         schema_type = self._properties.get("SchemaType")
         major = self._properties.get("SchemaVersionMajor")
         if str(schema_type) != "Imaging" or str(major) != "1":
-            raise ValueError(
+            raise ConversionRefused(
                 f"Unsupported peaks.sqlite schema in {self.data_path}: "
                 f"SchemaType={schema_type!r}, SchemaVersionMajor={major!r} "
                 "(this reader supports SchemaType='Imaging', "
@@ -229,7 +230,7 @@ class SolarixReader(BrukerBaseMSIReader):
                 "FROM AcquisitionKeys"
             ).fetchall()
         except sqlite3.Error as exc:
-            raise ValueError(
+            raise ConversionRefused(
                 f"peaks.sqlite has no readable AcquisitionKeys table in "
                 f"{self.data_path}: {exc}"
             ) from exc
@@ -251,7 +252,9 @@ class SolarixReader(BrukerBaseMSIReader):
         ).fetchone()
         n_spectra = int(row[0] or 0)
         if n_spectra == 0:
-            raise ValueError(f"peaks.sqlite holds no spectra in {self.data_path}")
+            raise ConversionRefused(
+                f"peaks.sqlite holds no spectra in {self.data_path}"
+            )
         return {
             "n_spectra": n_spectra,
             "x_min": int(row[1]),
@@ -271,7 +274,9 @@ class SolarixReader(BrukerBaseMSIReader):
             "COALESCE(RegionNumber, 0) FROM Spectra ORDER BY Id"
         ).fetchall()
         if not rows:
-            raise ValueError(f"peaks.sqlite holds no spectra in {self.data_path}")
+            raise ConversionRefused(
+                f"peaks.sqlite holds no spectra in {self.data_path}"
+            )
 
         arr = np.asarray(rows, dtype=np.int64)
         self._spectra_index = {
@@ -420,7 +425,7 @@ class SolarixReader(BrukerBaseMSIReader):
                 float(self._properties["MzAcqRangeUpper"]),
             )
         except (KeyError, TypeError, ValueError) as exc:
-            raise ValueError(
+            raise ConversionRefused(
                 f"peaks.sqlite Properties carry no usable MzAcqRangeLower/"
                 f"MzAcqRangeUpper in {self.data_path}: {exc}"
             ) from exc
@@ -479,7 +484,7 @@ class SolarixReader(BrukerBaseMSIReader):
                 if mzs.size:
                     chunks.append(mzs)
             if not chunks:
-                raise ValueError(
+                raise ConversionRefused(
                     f"Cannot build a mass axis: no peaks in {self.data_path}"
                 )
             self._common_mass_axis = np.unique(np.concatenate(chunks))
@@ -505,7 +510,7 @@ class SolarixReader(BrukerBaseMSIReader):
         expected = num_peaks * itemsize
         actual = len(blob) if blob is not None else 0
         if actual != expected:
-            raise ValueError(
+            raise ConversionRefused(
                 f"Corrupt {column} blob in Spectra row Id={spectrum_id} of "
                 f"{self._peaks_path}: NumPeaks={num_peaks} implies "
                 f"{expected} bytes, found {actual}"

--- a/thyra/readers/bruker/timstof/sdk/sdk_functions.py
+++ b/thyra/readers/bruker/timstof/sdk/sdk_functions.py
@@ -53,6 +53,7 @@ from typing import Any, Dict, Literal, Optional, Tuple
 import numpy as np
 from numpy.typing import NDArray
 
+from .....errors import ConversionRefused
 from .....utils.bruker_exceptions import SDKError
 from .dll_manager import DLLManager
 
@@ -141,7 +142,7 @@ class SDKFunctions:
                 TSF, whose line spectrum is already per pixel.
         """
         if tdf_spectrum not in TDF_SPECTRUM_MODES:
-            raise ValueError(
+            raise ConversionRefused(
                 f"tdf_spectrum must be one of {TDF_SPECTRUM_MODES}, "
                 f"got {tdf_spectrum!r}"
             )

--- a/thyra/readers/bruker/timstof/timstof_reader.py
+++ b/thyra/readers/bruker/timstof/timstof_reader.py
@@ -40,6 +40,7 @@ from ....core.msms import (
     IsolationWindow,
 )
 from ....core.registry import register_reader
+from ....errors import ConversionRefused
 from ....metadata.extractors.bruker_extractor import BrukerMetadataExtractor
 from ....utils.bruker_exceptions import DataError, FileFormatError, SDKError
 from ..base_bruker_reader import BrukerBaseMSIReader
@@ -416,7 +417,7 @@ class BrukerReader(BrukerBaseMSIReader):
         self._requested_region = region
         self._metadata_only = bool(metadata_only)
         if tdf_spectrum not in TDF_SPECTRUM_MODES:
-            raise ValueError(
+            raise ConversionRefused(
                 f"tdf_spectrum must be one of {TDF_SPECTRUM_MODES}, "
                 f"got {tdf_spectrum!r}"
             )
@@ -829,14 +830,29 @@ class BrukerReader(BrukerBaseMSIReader):
             )
             return resolved
         try:
-            return int(request_str)
+            resolved = int(request_str)
         except ValueError:
             available = ", ".join(sorted(name_to_num)) or "(none)"
-            raise ValueError(
+            raise ConversionRefused(
                 f"--region '{request_str}' is not a recognised .mis Area "
                 f"Name and is not a valid integer. Available area names: "
                 f"{available}"
             )
+        # Said out loud, because the two spellings look alike and pick
+        # different areas: on a three-area set '02' matches no Area Name,
+        # falls through to here as RegionNumber 2, and selects Area '04'.
+        # The name path has always logged what it resolved; this one
+        # logged nothing at all (issue #252).
+        available = ", ".join(sorted(name_to_num)) or "(none)"
+        logger.info(
+            "--region '%s' matches no .mis Area Name (found: %s), so it is "
+            "read as DB RegionNumber %d. Area Names are what flexImaging "
+            "shows; pass one of those to select by name.",
+            request_str,
+            available,
+            resolved,
+        )
+        return resolved
 
     def _select_region(self) -> Tuple[Optional[int], Optional[set]]:
         """Select region based on user request or convert all regions.
@@ -853,6 +869,11 @@ class BrukerReader(BrukerBaseMSIReader):
         self._log_region_mapping()
 
         if not self._region_info or len(self._region_info) <= 1:
+            # A request still has to be answered. Returning here first
+            # meant --region was never even parsed on a single-area set:
+            # '--region foo' converted all 713 pixels at exit 0 while the
+            # three-area set refused the same word (issue #252).
+            self._check_region_on_single_region_set()
             return (None, None)
 
         # Multiple regions exist
@@ -863,7 +884,7 @@ class BrukerReader(BrukerBaseMSIReader):
         if resolved is not None:
             # User explicitly requested a specific region
             if resolved not in valid_regions:
-                raise ValueError(
+                raise ConversionRefused(
                     f"Region {resolved} not found. "
                     f"Available regions: {valid_regions}"
                 )
@@ -888,6 +909,39 @@ class BrukerReader(BrukerBaseMSIReader):
             f"Use region= parameter to select a specific region."
         )
         return (None, None)
+
+    def _check_region_on_single_region_set(self) -> None:
+        """Answer a ``--region`` request on a set with nothing to select from.
+
+        There is no filtering to do either way -- one region is the whole
+        dataset -- so a request naming that region converts exactly as it
+        would have without it. A request naming anything else is refused,
+        in the same words the multi-region path uses, rather than being
+        dropped on the floor.
+        """
+        if self._requested_region is None:
+            return
+
+        if not self._region_info:
+            raise ConversionRefused(
+                f"--region {self._requested_region!r} was given but this "
+                "dataset carries no region information (no MaldiFrameInfo "
+                "table), so there is nothing to select. Drop the option to "
+                "convert it."
+            )
+
+        resolved = self._resolve_requested_region()
+        valid_regions = [r for r, _ in self._region_info]
+        if resolved not in valid_regions:
+            raise ConversionRefused(
+                f"Region {resolved} not found. Available regions: " f"{valid_regions}"
+            )
+        logger.info(
+            "Region %d is the only region in this dataset; all %d frames are "
+            "converted.",
+            resolved,
+            self._region_info[0][1],
+        )
 
     def get_region_map(self) -> Optional[Dict[tuple, int]]:
         """Get per-pixel region mapping from MaldiFrameInfo.

--- a/thyra/readers/imzml/imzml_reader.py
+++ b/thyra/readers/imzml/imzml_reader.py
@@ -18,6 +18,7 @@ from ...core.base_extractor import MetadataExtractor
 from ...core.base_reader import BaseMSIReader
 from ...core.mobility import MobilityAxis, classify_mobility_array
 from ...core.registry import register_reader
+from ...errors import ConversionRefused
 from ...metadata.extractors.imzml_extractor import ImzMLMetadataExtractor
 from ...resampling.constants import normalize_spectrum_type
 from ...utils.pyimzml_direct import read_spectrum_mzs_only
@@ -421,9 +422,9 @@ class _MassAxisAccumulator:
         self._buf = None
 
         if not self.saw_any or self._acc is None:
-            raise ValueError("No spectra found to build common mass axis")
+            raise ConversionRefused("No spectra found to build common mass axis")
         if self._acc.size == 0:
-            raise ValueError("Failed to extract any m/z values")
+            raise ConversionRefused("Failed to extract any m/z values")
         return self._acc
 
     def _allocate(self, m: int, dtype: Any, exact: bool = False) -> None:
@@ -478,7 +479,7 @@ class _MassAxisAccumulator:
             return
         if self._acc.size <= self._max_length:
             return
-        raise ValueError(
+        raise ConversionRefused(
             f"Common mass axis exceeded {self._max_length:,} unique m/z values "
             f"after {index + 1:,} of {self._total_spectra:,} spectra "
             f"({self._acc.size:,} so far). The peak lists in this dataset do "
@@ -625,7 +626,9 @@ class ImzMLReader(BaseMSIReader):
         self.ibd_path = imzml_path.with_suffix(".ibd")
 
         if not self.ibd_path.exists():
-            raise ValueError(f"Corresponding .ibd file not found for {imzml_path}")
+            raise ConversionRefused(
+                f"Corresponding .ibd file not found for {imzml_path}"
+            )
 
         # Open the .ibd file for reading
         self.ibd_file = open(self.ibd_path, mode="rb")
@@ -678,7 +681,7 @@ class ImzMLReader(BaseMSIReader):
             raise
 
         if self.parser.metadata is None:
-            raise ValueError("Failed to parse metadata from imzML file.")
+            raise ConversionRefused("Failed to parse metadata from imzML file.")
 
         # Determine file mode
         # Determine if file is continuous mode
@@ -691,7 +694,7 @@ class ImzMLReader(BaseMSIReader):
         )
 
         if self.is_continuous == self.is_processed:
-            raise ValueError(
+            raise ConversionRefused(
                 "Invalid file mode, expected either 'continuous' or " "'processed'."
             )
 
@@ -705,7 +708,7 @@ class ImzMLReader(BaseMSIReader):
             self._mobility = detect_mobility_array(self.parser.metadata)
             if self._mobility is not None:
                 if self._mobility.compressed:
-                    raise ValueError(
+                    raise ConversionRefused(
                         f"{imzml_path} declares zlib compression on its ion "
                         f"mobility array ({self._mobility.array_accession}); "
                         "compressed binary arrays are not supported"
@@ -826,14 +829,14 @@ class ImzMLReader(BaseMSIReader):
         groups = parser.metadata.referenceable_param_groups
         group = groups.get(group_id)
         if group is None or precision is None:
-            raise ValueError(
+            raise ConversionRefused(
                 f"imzML declares no usable referenceable param group for the "
                 f"{label} array, so pyimzml cannot know how to decode it "
                 f"(looked for {group_id!r} among {sorted(map(str, groups))})."
             )
 
         if _ZLIB_ACCESSION in group or _ZLIB_NAME in group:
-            raise ValueError(
+            raise ConversionRefused(
                 f"imzML declares zlib compression ({_ZLIB_ACCESSION}) on its "
                 f"{label} array. pyimzml 1.5.5 has no decompression path: it "
                 f"reads IMS:1000103 x itemsize raw deflate bytes and decodes "
@@ -848,7 +851,7 @@ class ImzMLReader(BaseMSIReader):
             name for name in parser.precisionDict if name in group.param_by_name
         ]
         if len(declared) != 1:
-            raise ValueError(
+            raise ConversionRefused(
                 f"imzML param group {group_id!r} declares {len(declared)} "
                 f"precision terms for the {label} array "
                 f"({', '.join(declared) if declared else 'none'}); exactly one "
@@ -858,14 +861,14 @@ class ImzMLReader(BaseMSIReader):
 
         resolved = parser.precisionDict[declared[0]]
         if resolved != precision:
-            raise ValueError(
+            raise ConversionRefused(
                 f"imzML param group {group_id!r} declares {declared[0]!r} for "
                 f"the {label} array, which is {resolved!r}, but pyimzml "
                 f"resolved {precision!r} and will decode at that width."
             )
 
         if precision in _PLATFORM_DEPENDENT_PRECISIONS:
-            raise ValueError(
+            raise ConversionRefused(
                 f"imzML declares {declared[0]!r} for its {label} array. "
                 f"pyimzml reads {parser.sizeDict[precision]} bytes per value "
                 f"but decodes them as numpy's 'l', whose itemsize is "
@@ -920,7 +923,7 @@ class ImzMLReader(BaseMSIReader):
             itemsize = parser.sizeDict[precision]
             expected = array_length * itemsize
             if encoded_length != expected:
-                raise ValueError(
+                raise ConversionRefused(
                     f"imzML spectrum 0 declares {encoded_length:,} encoded "
                     f"bytes ({_ENCODED_LENGTH_ACCESSION}) for its {label} "
                     f"array, but its {array_length:,} values at the resolved "
@@ -954,7 +957,7 @@ class ImzMLReader(BaseMSIReader):
             negative = np.flatnonzero(values < 0)
             if negative.size:
                 idx = int(negative[0])
-                raise ValueError(
+                raise ConversionRefused(
                     f"imzML spectrum {idx} declares a negative {label} of "
                     f"{int(values[idx]):,} ({negative.size:,} spectra "
                     f"affected). Offsets and lengths are byte and element "
@@ -965,7 +968,7 @@ class ImzMLReader(BaseMSIReader):
         mismatch = np.flatnonzero(arrays.mz_lengths != arrays.int_lengths)
         if mismatch.size:
             idx = int(mismatch[0])
-            raise ValueError(
+            raise ConversionRefused(
                 f"imzML spectrum {idx} declares {int(arrays.mz_lengths[idx]):,} "
                 f"m/z values but {int(arrays.int_lengths[idx]):,} intensity "
                 f"values ({mismatch.size:,} spectra disagree). A spectrum's two "
@@ -1021,7 +1024,7 @@ class ImzMLReader(BaseMSIReader):
             past = np.flatnonzero(end > ibd_size)
             if past.size:
                 idx = int(past[0])
-                raise ValueError(
+                raise ConversionRefused(
                     f"imzML spectrum {idx} declares a {label} array ending at "
                     f"byte {int(end[idx]):,}, but {self.ibd_path.name} is "
                     f"{ibd_size:,} bytes ({past.size:,} spectra are affected; "
@@ -1136,7 +1139,7 @@ class ImzMLReader(BaseMSIReader):
 
                     mzs = spectrum_data[0]
                     if mzs.size == 0:
-                        raise ValueError("First spectrum contains no m/z values")
+                        raise ConversionRefused("First spectrum contains no m/z values")
 
                     self._common_mass_axis = self._deduplicated_shared_axis(mzs)
                     if self._continuous_uniform:
@@ -1479,7 +1482,7 @@ class ImzMLReader(BaseMSIReader):
         if self._mobility_offsets is not None:
             return self._mobility_offsets
         if self._mobility is None or self.imzml_path is None:
-            raise ValueError("This imzML declares no ion mobility array")
+            raise ConversionRefused("This imzML declares no ion mobility array")
         parser = cast(ImzMLParser, self.parser)
         n_spectra = len(parser.coordinates)
         offsets, lengths, encoded = collect_array_offsets(
@@ -1487,7 +1490,7 @@ class ImzMLReader(BaseMSIReader):
         )
         missing = int(np.count_nonzero(offsets < 0))
         if missing:
-            raise ValueError(
+            raise ConversionRefused(
                 f"{missing} of {n_spectra} spectra reference no ion mobility array "
                 f"although the file declares one ({self._mobility.group_id})"
             )
@@ -1495,7 +1498,7 @@ class ImzMLReader(BaseMSIReader):
         mismatch = np.flatnonzero(lengths != mz_lengths)
         if mismatch.size:
             first = int(mismatch[0])
-            raise ValueError(
+            raise ConversionRefused(
                 f"Spectrum {first} declares {int(lengths[first])} ion mobility "
                 f"values for {int(mz_lengths[first])} m/z values; the arrays "
                 "must be parallel"
@@ -1513,7 +1516,7 @@ class ImzMLReader(BaseMSIReader):
         data = m.read(int(lengths[idx]) * spec.dtype.itemsize)
         values = np.frombuffer(data, dtype=spec.dtype)
         if values.size != int(lengths[idx]):
-            raise ValueError(
+            raise ConversionRefused(
                 f"Spectrum {idx}: ion mobility array truncated in the .ibd "
                 f"({values.size} of {int(lengths[idx])} values)"
             )
@@ -1594,7 +1597,7 @@ class ImzMLReader(BaseMSIReader):
                 self._continuous_mzs = mzs
         mobility = cast(NDArray[np.float64], self._mobility_shared)
         if mzs.size != mobility.size:
-            raise ValueError(
+            raise ConversionRefused(
                 f"Shared m/z block has {mzs.size} values but the shared mobility "
                 f"array has {mobility.size}"
             )
@@ -1641,7 +1644,7 @@ class ImzMLReader(BaseMSIReader):
                         shared if shared is not None else self._read_mobility_array(idx)
                     )
                     if mobility.size != mzs.size:
-                        raise ValueError(
+                        raise ConversionRefused(
                             f"{mobility.size} mobility values for {mzs.size} m/z values"
                         )
                     if self._intensity_threshold is not None:

--- a/thyra/readers/imzml/mobility_array.py
+++ b/thyra/readers/imzml/mobility_array.py
@@ -22,6 +22,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from ...core.mobility import MOBILITY_ARRAY_TERMS
+from ...errors import ConversionRefused
 
 _MZML_NS = "{http://psi.hupo.org/ms/mzml}"
 _OFFSET_ACCESSION = "IMS:1000102"
@@ -147,7 +148,7 @@ def collect_array_offsets(
         if elem.tag != f"{_MZML_NS}spectrum":
             continue
         if index >= n_spectra:
-            raise ValueError(
+            raise ConversionRefused(
                 f"{imzml_path} holds more <spectrum> elements than the "
                 f"{n_spectra} pyimzml reported"
             )
@@ -170,7 +171,7 @@ def collect_array_offsets(
         elem.clear()
 
     if index != n_spectra:
-        raise ValueError(
+        raise ConversionRefused(
             f"{imzml_path} holds {index} <spectrum> elements but pyimzml "
             f"reported {n_spectra}"
         )

--- a/thyra/readers/mzpeak/mzpeak_reader.py
+++ b/thyra/readers/mzpeak/mzpeak_reader.py
@@ -60,6 +60,7 @@ from numpy.typing import NDArray
 
 from ...core.base_reader import BaseMSIReader
 from ...core.registry import register_reader
+from ...errors import ConversionRefused
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from ...core.base_extractor import MetadataExtractor
@@ -196,23 +197,25 @@ class MzPeakArchive:
         self._null_count_cached = False
 
         if not zipfile.is_zipfile(self.path):
-            raise ValueError(
+            raise ConversionRefused(
                 f"Not an mzPeak archive (not a ZIP container): {self.path}"
             )
 
         self._zip = zipfile.ZipFile(self.path)
         self._members = set(self._zip.namelist())
         if INDEX_MEMBER not in self._members:
-            raise ValueError(
+            raise ConversionRefused(
                 f"Not an mzPeak archive (no {INDEX_MEMBER} member): {self.path}"
             )
 
         try:
             index = json.loads(self._zip.read(INDEX_MEMBER))
         except (json.JSONDecodeError, UnicodeDecodeError) as exc:
-            raise ValueError(f"Malformed {INDEX_MEMBER} in {self.path}: {exc}") from exc
+            raise ConversionRefused(
+                f"Malformed {INDEX_MEMBER} in {self.path}: {exc}"
+            ) from exc
         if not isinstance(index, dict):
-            raise ValueError(
+            raise ConversionRefused(
                 f"Malformed {INDEX_MEMBER} in {self.path}: expected a JSON "
                 f"object, found {type(index).__name__}"
             )
@@ -237,7 +240,7 @@ class MzPeakArchive:
         roles: Dict[Tuple[str, str], dict] = {}
         entries = index.get("files")
         if not isinstance(entries, list):
-            raise ValueError(
+            raise ConversionRefused(
                 f"Malformed {INDEX_MEMBER} in {self.path}: 'files' must be a "
                 f"list, found {type(entries).__name__}"
             )
@@ -276,7 +279,7 @@ class MzPeakArchive:
         found = self.entry(entity_type, data_kind)
         if found is None:
             available = sorted(f"{e}/{k}" for e, k in self._roles)
-            raise ValueError(
+            raise ConversionRefused(
                 f"mzPeak archive {self.path} has no "
                 f"'{entity_type}/{data_kind}' member. Present roles: "
                 f"{', '.join(available) or 'none'}"
@@ -340,7 +343,7 @@ class MzPeakArchive:
             return "point"
         if "chunk" in fields:
             return "chunk"
-        raise ValueError(
+        raise ConversionRefused(
             f"{self.path} has an unrecognised mzPeak data layout: expected a "
             f"top-level 'point' or 'chunk' column, found {fields}."
         )
@@ -389,7 +392,7 @@ class MzPeakArchive:
 
         columns = self.position_columns()
         if columns is None:
-            raise ValueError(
+            raise ConversionRefused(
                 f"{self.path} is not an imaging mzPeak archive: its scans "
                 f"member declares no {IMS_POSITION_X}/{IMS_POSITION_Y} "
                 f"position columns. Thyra converts imaging acquisitions only."
@@ -433,7 +436,7 @@ class MzPeakArchive:
             )
         spectrum_index, counts = spectrum_index[keep], counts[keep]
         if spectrum_index.size == 0:
-            raise ValueError(f"{self.path} contains no positioned spectra.")
+            raise ConversionRefused(f"{self.path} contains no positioned spectra.")
 
         rows = np.array([lookup[int(s)] for s in spectrum_index], dtype=np.int64)
         raw = np.stack([xs[rows], ys[rows]], axis=1)
@@ -687,7 +690,7 @@ class MzPeakReader(BaseMSIReader):
             axis = np.union1d(axis, np.unique(mzs))
 
         if axis.size == 0:
-            raise ValueError(
+            raise ConversionRefused(
                 f"{self.data_path} yielded no m/z values; the archive has no "
                 f"usable signal data."
             )

--- a/thyra/readers/phi/event_stream.py
+++ b/thyra/readers/phi/event_stream.py
@@ -47,6 +47,7 @@ from typing import Dict, Iterator, List, Optional, Tuple
 import numpy as np
 from numpy.typing import NDArray
 
+from ...errors import ConversionRefused
 from .phi_header import PhiHeader
 
 logger = logging.getLogger(__name__)
@@ -191,7 +192,7 @@ def _finalise_index(index: BlockIndex, path: Path, pos: int, file_size: int) -> 
             file_size - pos,
         )
     if not index.data_spans:
-        raise ValueError(
+        raise ConversionRefused(
             f"No event blocks (id {index.data_block_id}) found in {path}. "
             "Is this a PHI imaging acquisition?"
         )

--- a/thyra/readers/phi/mass_axis.py
+++ b/thyra/readers/phi/mass_axis.py
@@ -21,6 +21,8 @@ from typing import Tuple
 import numpy as np
 from numpy.typing import NDArray
 
+from ...errors import ConversionRefused
+
 logger = logging.getLogger(__name__)
 
 
@@ -117,14 +119,14 @@ def build_mass_axis(
         ValueError: If the parameters leave no usable channel.
     """
     if bin_size_ns <= 0:
-        raise ValueError(f"SpecBinSize must be positive, got {bin_size_ns}")
+        raise ConversionRefused(f"SpecBinSize must be positive, got {bin_size_ns}")
 
     bin_ps = bin_size_ns * 1000.0
     start_ps = start_flight_time_us * 1e6
     stop_ps = stop_flight_time_us * 1e6
     n_full = int(math.floor((stop_ps - start_ps) / bin_ps)) + 1
     if n_full <= 0:
-        raise ValueError(
+        raise ConversionRefused(
             f"Flight-time range {start_flight_time_us}-{stop_flight_time_us} us "
             f"yields no channels at {bin_size_ns} ns per channel"
         )
@@ -141,7 +143,7 @@ def build_mass_axis(
 
     hits = np.nonzero(usable)[0]
     if hits.size == 0:
-        raise ValueError(
+        raise ConversionRefused(
             "No time channel maps into the declared mass range "
             f"{start_mz}-{stop_mz} with slope={slope}, offset={offset}"
         )

--- a/thyra/readers/phi/phi_header.py
+++ b/thyra/readers/phi/phi_header.py
@@ -19,6 +19,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+from ...errors import ConversionRefused
+
 logger = logging.getLogger(__name__)
 
 SOFH_MAGIC = b"SOFH"
@@ -168,12 +170,12 @@ def _read_header_text(path: Path) -> str:
         probe = handle.read(_MAX_HEADER_PROBE)
 
     if not probe.startswith(SOFH_MAGIC):
-        raise ValueError(
+        raise ConversionRefused(
             f"Not a PHI SmartSoft-TOF raw file (missing SOFH magic): {path}"
         )
     end = probe.find(EOFH_MARKER)
     if end == -1:
-        raise ValueError(f"Malformed PHI header, no EOFH terminator: {path}")
+        raise ConversionRefused(f"Malformed PHI header, no EOFH terminator: {path}")
     return probe[:end].decode("latin-1")
 
 
@@ -200,11 +202,13 @@ def _parse_raster(
 def _validate_header(header: PhiHeader, path: Path) -> None:
     """Reject headers whose numbers cannot describe a real acquisition."""
     if header.image_pixels <= 0:
-        raise ValueError(f"PHI header declares a non-positive ImagePixels: {path}")
+        raise ConversionRefused(
+            f"PHI header declares a non-positive ImagePixels: {path}"
+        )
     if header.mass_slope <= 0:
-        raise ValueError(f"PHI header declares a non-positive Mass/Time: {path}")
+        raise ConversionRefused(f"PHI header declares a non-positive Mass/Time: {path}")
     if header.stop_flight_time_us <= header.start_flight_time_us:
-        raise ValueError(
+        raise ConversionRefused(
             f"PHI header flight-time range is empty: {header.start_flight_time_us} "
             f"to {header.stop_flight_time_us} us in {path}"
         )
@@ -236,7 +240,9 @@ def parse_phi_header(path: Path) -> PhiHeader:
         if name not in entries
     ]
     if missing:
-        raise ValueError(f"PHI header is missing required field '{missing[0]}': {path}")
+        raise ConversionRefused(
+            f"PHI header is missing required field '{missing[0]}': {path}"
+        )
 
     raster_um, raster_calibration = _parse_raster(entries, lmig)
 

--- a/thyra/readers/phi/phi_reader.py
+++ b/thyra/readers/phi/phi_reader.py
@@ -19,6 +19,7 @@ from numpy.typing import NDArray
 from ...core.base_extractor import MetadataExtractor
 from ...core.base_reader import BaseMSIReader
 from ...core.registry import register_reader
+from ...errors import ConversionRefused
 from .event_stream import BlockIndex, iter_event_batches, scan_blocks
 from .mass_axis import PhiMassAxis, build_mass_axis
 from .phi_header import PhiHeader, parse_phi_header
@@ -65,7 +66,7 @@ class PhiReader(BaseMSIReader):
         super().__init__(data_path, intensity_threshold=intensity_threshold, **kwargs)
 
         if not self.data_path.is_file():
-            raise ValueError(
+            raise ConversionRefused(
                 f"PHI .raw must be a file, not a directory: {self.data_path}. "
                 "Waters .raw data is a directory and is handled by WatersReader."
             )
@@ -225,7 +226,7 @@ class PhiReader(BaseMSIReader):
 
         keys = keys[:filled]
         if keys.size == 0:
-            raise ValueError(
+            raise ConversionRefused(
                 f"No usable ion events in {self.data_path}. All {dropped} records "
                 "fell outside the mass axis or the pixel grid."
             )

--- a/thyra/readers/waters/imaging_grid.py
+++ b/thyra/readers/waters/imaging_grid.py
@@ -23,6 +23,7 @@ from functools import cached_property
 from math import isfinite
 from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
+from ...errors import ConversionRefused
 from .masslynx_lib import NO_POSITION, FunctionType, MassLynxLib, ScanInfoData
 
 logger = logging.getLogger(__name__)
@@ -227,7 +228,7 @@ def _fit_axis(positions: Sequence[float], axis: str) -> AxisLattice:
     seed = statistics.median(intervals)
     span = unique[-1] - unique[0]
     if seed <= 0.0 or span <= 0.0:
-        raise ValueError(
+        raise ConversionRefused(
             f"Waters stage readings on the {axis} axis have no measurable "
             f"raster pitch ({len(unique)} distinct positions spanning "
             f"{span:.4f} um)."
@@ -240,7 +241,7 @@ def _fit_axis(positions: Sequence[float], axis: str) -> AxisLattice:
     worst = max(unique, key=lattice.offset)
     worst_offset = lattice.offset(worst)
     if worst_offset > _LATTICE_TOLERANCE * pitch:
-        raise ValueError(
+        raise ConversionRefused(
             f"Waters stage readings on the {axis} axis do not lie on a "
             f"regular raster: with a fitted pitch of {pitch:.4f} um the "
             f"reading at {worst:.2f} um sits {worst_offset:.4f} um "
@@ -251,7 +252,7 @@ def _fit_axis(positions: Sequence[float], axis: str) -> AxisLattice:
 
     occupancy = len(unique) / count
     if occupancy < _MIN_LATTICE_OCCUPANCY:
-        raise ValueError(
+        raise ConversionRefused(
             f"Waters stage readings on the {axis} axis fit a raster of "
             f"{count} lines at {pitch:.4f} um but only {len(unique)} of "
             f"them carry a reading ({100.0 * occupancy:.1f} %). That is "
@@ -347,7 +348,7 @@ def _grid_from_scan_map(
         )
 
     if not census.x_positions or not census.y_positions:
-        raise ValueError("No valid laser positions found in Waters imaging data")
+        raise ConversionRefused("No valid laser positions found in Waters imaging data")
 
     x_lattice = _fit_axis(census.x_positions, "x")
     y_lattice = _fit_axis(census.y_positions, "y")
@@ -391,7 +392,7 @@ def _grid_from_scan_map(
     # these fields and grid normally (401x401, 247x140, ...), so this
     # refuses the non-images without costing anything real. See issue #213.
     if x_lattice.count == 1 and y_lattice.count == 1:
-        raise ValueError(
+        raise ConversionRefused(
             f"Every positioned scan reports the same stage position "
             f"(x={x_lattice.origin:.1f} um, y={y_lattice.origin:.1f} um), so "
             f"this acquisition has a single pixel: {census.positioned} "

--- a/thyra/readers/waters/waters_reader.py
+++ b/thyra/readers/waters/waters_reader.py
@@ -23,6 +23,7 @@ from ...core.msms import (
     IsolationWindow,
 )
 from ...core.registry import register_reader
+from ...errors import ConversionRefused
 from ...metadata.extractors.waters_extractor import WatersMetadataExtractor
 from .imaging_grid import ImagingGrid, build_imaging_grid, regrid_for_functions
 from .instrument import WatersInstrument, identify_waters_instrument
@@ -143,7 +144,9 @@ class WatersReader(BaseMSIReader):
     def _validate_raw_directory(self) -> None:
         """Validate that data_path is a Waters .raw directory with _FUNC*.DAT files."""
         if not self.data_path.is_dir():
-            raise ValueError(f"Waters .raw path must be a directory: {self.data_path}")
+            raise ConversionRefused(
+                f"Waters .raw path must be a directory: {self.data_path}"
+            )
 
         # Check for _FUNC*.DAT files (case-insensitive)
         func_files = list(self.data_path.glob("_FUNC[0-9][0-9][0-9].DAT"))
@@ -158,7 +161,7 @@ class WatersReader(BaseMSIReader):
                 and f.name.upper().endswith(".DAT")
             ]
         if not func_files:
-            raise ValueError(
+            raise ConversionRefused(
                 f"No _FUNC*.DAT files found in {self.data_path}. "
                 "Is this a valid Waters .raw directory?"
             )
@@ -195,7 +198,7 @@ class WatersReader(BaseMSIReader):
         missing = [f for f in range(n_functions) if f not in present]
         if not missing:
             return
-        raise ValueError(
+        raise ConversionRefused(
             f"{self.data_path.name} declares {n_functions} function(s) but "
             f"{len(missing)} of them have no data file: "
             f"{', '.join(f'_FUNC{f + 1:03d}.DAT' for f in missing)}. "
@@ -226,7 +229,7 @@ class WatersReader(BaseMSIReader):
         if not self._ml.is_imaging_file(self._handle):
             self._ml.close_file(self._handle)
             self._handle = None
-            raise ValueError(
+            raise ConversionRefused(
                 f"{self.data_path} is not a Waters imaging file. "
                 "The native library reports no imaging data."
             )
@@ -251,7 +254,7 @@ class WatersReader(BaseMSIReader):
         if not self._ms_functions:
             self._ml.close_file(self._handle)
             self._handle = None
-            raise ValueError(
+            raise ConversionRefused(
                 f"No MS functions found in {self.data_path}. "
                 f"Function types: {self._function_types}"
             )
@@ -721,7 +724,7 @@ class WatersReader(BaseMSIReader):
                         )
 
         if not all_mzs:
-            raise ValueError("No spectra found to build common mass axis")
+            raise ConversionRefused("No spectra found to build common mass axis")
 
         combined = np.concatenate(all_mzs)
         self._common_mass_axis_cache = np.unique(combined)

--- a/thyra/resampling/common_axis.py
+++ b/thyra/resampling/common_axis.py
@@ -4,6 +4,7 @@ from typing import Dict, Optional, Tuple
 
 import numpy as np
 
+from ..errors import ConversionRefused
 from .mass_axis import (
     BaseAxisGenerator,
     FTICRAxisGenerator,
@@ -93,7 +94,7 @@ class CommonAxisBuilder:
         """
         if axis_type is AxisType.TOF:
             if tof_law is None:
-                raise ValueError("AxisType.TOF needs tof_law=(A, B)")
+                raise ConversionRefused("AxisType.TOF needs tof_law=(A, B)")
             generator: BaseAxisGenerator = TOFAxisGenerator(*tof_law)
         else:
             generator_map: Dict[AxisType, BaseAxisGenerator] = {
@@ -105,7 +106,7 @@ class CommonAxisBuilder:
             }
 
             if axis_type not in generator_map:
-                raise ValueError(f"Unsupported axis type: {axis_type}")
+                raise ConversionRefused(f"Unsupported axis type: {axis_type}")
 
             generator = generator_map[axis_type]
 

--- a/thyra/resampling/constants.py
+++ b/thyra/resampling/constants.py
@@ -2,6 +2,8 @@
 
 from typing import Dict, Optional
 
+from ..errors import ConversionRefused
+
 
 class ImzMLAccessions:
     """PSI-MS and imzML controlled vocabulary accession codes."""
@@ -76,7 +78,7 @@ def normalize_spectrum_type(value: Optional[object]) -> Optional[str]:
         return None
 
     if not isinstance(value, str):
-        raise ValueError(
+        raise ConversionRefused(
             f"spectrum_type must be a string or None, got {type(value).__name__}"
         )
 
@@ -85,7 +87,9 @@ def normalize_spectrum_type(value: Optional[object]) -> Optional[str]:
         return SPECTRUM_TYPE_ALIASES[key]
 
     accepted = ", ".join(repr(k) for k in sorted(SPECTRUM_TYPE_ALIASES))
-    raise ValueError(f"Unknown spectrum_type {value!r}. Accepted values: {accepted}.")
+    raise ConversionRefused(
+        f"Unknown spectrum_type {value!r}. Accepted values: {accepted}."
+    )
 
 
 class BinaryDataType:

--- a/thyra/resampling/mass_axis/tof_generator.py
+++ b/thyra/resampling/mass_axis/tof_generator.py
@@ -45,6 +45,7 @@ from typing import Tuple
 
 import numpy as np
 
+from ...errors import ConversionRefused
 from ..types import AxisType, MassAxis
 from .base_generator import BaseAxisGenerator
 
@@ -66,7 +67,7 @@ def tof_fwhm_mda(mz, a: float, b: float):
 
 def _check_law(a: float, b: float) -> None:
     if not (np.isfinite(a) and np.isfinite(b)) or a < 0 or b < 0 or (a == 0 and b == 0):
-        raise ValueError(
+        raise ConversionRefused(
             f"A TOF width law needs A >= 0 and B >= 0 with at least one of them "
             f"positive; got A={a!r}, B={b!r}"
         )

--- a/thyra/resampling/mobility_grid.py
+++ b/thyra/resampling/mobility_grid.py
@@ -43,6 +43,8 @@ from typing import Any, Dict, Optional
 import numpy as np
 from numpy.typing import NDArray
 
+from ..errors import ConversionRefused
+
 logger = logging.getLogger(__name__)
 
 #: Number of mobility channels, exactly, and the default for a grid table.
@@ -233,16 +235,16 @@ def build_mobility_grid(
             positive, or the law is unknown.
     """
     if not np.isfinite(lower) or not np.isfinite(upper) or upper <= lower:
-        raise ValueError(
+        raise ConversionRefused(
             f"The mobility range [{lower}, {upper}] has no extent to bin over"
         )
     if int(n_channels) < 1:
-        raise ValueError(
+        raise ConversionRefused(
             f"A mobility grid needs at least one channel, got {n_channels}"
         )
     generator = MOBILITY_GRID_GENERATORS.get(law)
     if generator is None:
-        raise ValueError(
+        raise ConversionRefused(
             f"Unknown mobility grid law {law!r}; known laws are "
             f"{sorted(MOBILITY_GRID_GENERATORS)}"
         )

--- a/thyra/utils/logging_config.py
+++ b/thyra/utils/logging_config.py
@@ -5,6 +5,33 @@ import sys
 from ..config import LOG_BACKUP_COUNT, LOG_FILE_MAX_SIZE_MB, MB_TO_BYTES
 
 
+def _console_stream():
+    """``sys.stdout``, told to replace what it cannot encode.
+
+    A log line carries whatever the source gave it -- an output path, a
+    dataset id -- and on Windows a redirected stdout encodes in the ANSI
+    code page. One character outside cp1252 turned every write of that
+    line into a ``--- Logging error ---`` block and a ``UnicodeEncodeError``
+    traceback on stderr, once per handler, while the conversion itself
+    ran fine (issue #259).
+
+    ``reconfigure`` changes the error handler of the stream already in
+    place rather than wrapping it, so nothing else that writes to stdout
+    (``click.echo``, a progress bar) ends up behind a second buffer. A
+    stream without it -- pytest's capture object, a caller's own file --
+    is left alone.
+    """
+    stream = sys.stdout
+    reconfigure = getattr(stream, "reconfigure", None)
+    if reconfigure is None:
+        return stream
+    try:
+        reconfigure(errors="replace")
+    except (ValueError, OSError):  # pragma: no cover - stream-defined
+        pass
+    return stream
+
+
 def setup_logging(log_level=logging.INFO, log_file=None):
     """Set up logging for the application.
 
@@ -12,7 +39,9 @@ def setup_logging(log_level=logging.INFO, log_file=None):
         log_level (int): The minimum logging level to display.
         log_file (str): Path to the log file. If None, logs are not saved to a file.
     """
-    # Get the root logger
+    # Get the root logger. Everything Thyra logs sits under this name,
+    # the CLI's own messages included -- see the note in __main__.py on
+    # why they are logged to "thyra.cli" and not to __name__.
     logger = logging.getLogger("thyra")
     logger.setLevel(log_level)
 
@@ -29,17 +58,21 @@ def setup_logging(log_level=logging.INFO, log_file=None):
     )
 
     # Create a console handler
-    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler = logging.StreamHandler(_console_stream())
     console_handler.setLevel(log_level)
     console_handler.setFormatter(formatter)
     logger.addHandler(console_handler)
 
-    # Create a file handler if a log file is specified
+    # Create a file handler if a log file is specified. UTF-8 rather than
+    # the platform's preferred encoding for the same reason as above: a
+    # log file is read later, often elsewhere, and a path it cannot spell
+    # should not cost the lines around it.
     if log_file:
         file_handler = logging.handlers.RotatingFileHandler(
             log_file,
             maxBytes=LOG_FILE_MAX_SIZE_MB * MB_TO_BYTES,
             backupCount=LOG_BACKUP_COUNT,
+            encoding="utf-8",
         )
         file_handler.setLevel(log_level)
         file_handler.setFormatter(formatter)


### PR DESCRIPTION
Batch 2 of the six release batches from the 2026-09-08 robustness sweep:
eleven issues about the command line telling the truth. Branched off `main`
after batch 1 (#263) merged, so the `_is_usable_number` guard it added is
reused rather than respelled.

Closes #234, #248, #250, #252, #253, #255, #256, #257, #258, #259, #260.

## A. Refusals read as refusals

`convert_msi` **and** `BaseMSIConverter.convert` each wrapped everything in
one `except Exception` that logged the message *and* a full traceback at
ERROR, so every deliberate `ValueError` reached the user as ~30 lines that
read like a crash.

`thyra.errors.ConversionRefused` marks the ones the code planned for. It
subclasses `ValueError`, so nothing that caught the old exceptions breaks,
and ~130 refusal sites across the readers, the registry, the resampling
plan and the converter front door now raise it. A refusal prints its
message once at ERROR; the traceback moves to DEBUG. An ERROR traceback
now means an exception nobody planned for -- including a numpy
`ValueError`, which is why the marker is a type and not a match on
`ValueError`.

Before / after, an imzML with a truncated `.ibd`:

```
ERROR - imzML spectrum 0 declares a m/z array ending at byte 1,616, but
broken.ibd is 0 bytes (48 spectra are affected...). The .ibd is truncated
or its offsets are wrong -- ...
ERROR - Conversion failed.
```

Three checks that used to fail late now fail at the front door, before the
reader is opened:

- **#255** an output whose parent is a regular file (was a raw `WinError
  183` after the axis was built)
- **#250** a `dataset_id` SpatialData cannot name an element with (was
  refused by SpatialData after both passes), and a mass range or bin count
  no axis can be laid on (`min_mz > max_mz` succeeded with an empty store
  and logged "4 of 3"; `target_bins=1` crashed inside `np.min`)
- **#250** unknown keys in a `resampling_config` dict are now warned about
  with the keys that would have worked

**#257**: `thyra validate` / `thyra export-metaspace` take
`click.Path(exists=False)` and call `prepare_zarr_read_path` themselves, so
the CLI can open every store the CLI can write.

A refusal now also closes the reader. Only the conversion itself did, so
anything failing before it -- "Pixel size not found in metadata" is the
common one -- left the source open until the garbage collector reached it,
which on Windows holds a lock on the file the user is about to retry with.
Neither new handler passes the exception *object* to a log record either:
a handler that retains records holds its traceback and every frame in it,
pinning exactly what was meant to be released. That is the trap #249 is
about, and it turned up here as a `PermissionError: [WinError 32]` on the
Windows CI runners and nowhere else.

## B. Flags that did nothing now say so

**#260**: each vendor and mobility-grid option given on a format that
ignores it is logged at WARNING naming both formats, following the
precedent `--tof-law` and `--msms-table` set. Read off click's parameter
source, so an option left at its default stays quiet:

```
WARNING - --tdf-spectrum is ignored on imzML input: it only applies to
Bruker timsTOF (.d). The store is written as though it had not been given.
```

`--mobility-bins` / `--mobility-min` / `--mobility-max` are range-checked
(the edges may be zero or negative -- they are positions on an axis -- but
not inverted or non-finite), and a grid size given without
`--mobility-grid` is logged too.

**#252**: `--region` is resolved and checked against the region list even
on a single-region set, where it used to be dropped before it was ever
parsed (`--region foo` converted everything at exit 0). The integer
fallback now says what it did, because `--region 02` matches no Area Name
and selects Area '04'.

**#256**: `--handle-3d` on a one-plane acquisition says the volume has one
plane, and a `--z-spacing` alongside is logged as ignored -- the two things
docs/cli.md has always promised and `_is_volume` skipped for `n_z == 1`.

**#253**: the default-on MS/MS table counts as asked-for in
`_lossless_spectrum_for`, so the common path reaches the `vendor_centroid`
warning; that warning's grammar is fixed and it no longer fires on a format
that ignores `--tdf-spectrum`; the 1.0149x mismatch is a WARNING for every
sibling rather than WARNING for the grid and INFO for the split; and the
heatmap records `current_ratio` against the stored mean spectrum the way
the grid's `uns["mobility_marginal"]` does.

## C. Logging that reaches the log

**#258**: the CLI logs to `thyra.cli`. Under `python -m thyra` the module
logger was `"__main__"`, which `setup_logging` does not configure, so
"Conversion completed successfully" appeared in 0 of 67 successful runs and
never in `--log-file`.

**#259**: the console stream is reconfigured with `errors="replace"`, so a
non-cp1252 output path is logged with replacement characters instead of a
`--- Logging error ---` block. The log file is opened as UTF-8 for the same
reason.

## Values a store holds change (#248)

Intensities that are not measurements are dropped from a spectrum **before
it is resampled**, with a count:

- a NaN reached `X.data`, made `uns["average_spectrum"]` NaN, and passed
  `thyra validate`
- a negative value is an overshot baseline subtraction, and it made the two
  resampling methods disagree *in kind*: `nearest_neighbor` stored it
  (leaving the pixel with a TIC of 0) while `tic_preserving` found a
  non-positive total and zeroed the whole spectrum. Dropping before either
  method runs is what makes them agree.

The sibling tables built from the raw scans (the mobility grid, the MS/MS
split) go through `map_points_to_axis`, which drops the same points by the
same rule -- otherwise a grid's marginal would stop reproducing the summed
table's column on exactly the sources that carry them.

A source whose **m/z** values are non-finite is refused instead of dropped:
those values *are* `var["mz"]`, and the converter was writing a store its
own validator then rejected with `ERROR var.mz: 'mz' contains non-finite
values`. Documented in docs/output-format.md.

## Verification

- `uv run pytest` -- same 34 failures as `main`
  (pre-existing: anndata/pandas-3 string writes and the optical-image
  streaming suite in this environment), 118 new tests passing
- `uv run pytest -m integration` -- 54 passed, 11 skipped
- `uv run pre-commit run --all-files` -- green (black also wants to
  reformat two untouched test files; that drift predates this branch and is
  left alone)
- The refusal-presentation issues were checked through the CLI, not only in
  unit tests, on a synthetic dataset from `thyra-example-data`
