### PR TITLE
Batch 3: two-pass, CSC and memory accounting

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,8 +35,12 @@ planned for, which is worth reporting as a bug.
 
 A failed conversion renames any partially written store to
 `<output>.zarr.failed`, so the output path stays free for a retry and an
-incomplete store is never left where a finished one is expected. This makes
-`thyra` safe to chain in a shell script or CI job:
+incomplete store is never left where a finished one is expected. An
+interrupted conversion is a failed one: `Ctrl-C` exits `1` and takes the
+same path, so the partial store is moved aside and the scratch directories
+the conversion built (`.thyra_summed_*` and its siblings, next to the
+output) are removed rather than left behind. This makes `thyra` safe to
+chain in a shell script or CI job:
 
 ```bash
 thyra input.imzML output.zarr && python analyse.py output.zarr
@@ -236,6 +240,18 @@ default), so there is no separate flag for that quantity.
       the two axis laws match. See
       [Resampling](resampling.md#which-detector-wins) for the full decision
       table.
+
+!!! warning "A very fine axis is refused before it is built"
+    Everything a conversion holds per m/z bin -- the axis, the `var` frame
+    with its index, the running intensity totals, the pre-scan's count array
+    and anndata's copies during the write -- comes to about 200 bytes,
+    measured. So the bin count is checked against the machine's free memory
+    before the axis is materialised: past half of it the conversion is
+    refused with the projection and the free memory printed, and past a
+    quarter it is attempted with a `WARNING`. On an 8 GB machine that is
+    around 21 million bins. `--resample-bins` and a small
+    `--resample-width-at-mz` are the two ways to ask for more than that; a
+    wide-range source at a fine width reaches it without either.
 
 !!! info "Choosing a mass axis type"
     The axis type determines how bin widths scale with m/z:

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -190,10 +190,20 @@ print(f"Non-zero: {X.nnz:,} ({X.nnz / (X.shape[0] * X.shape[1]) * 100:.2f}%)")
     write time.
 
     The stored matrix is canonical: within every column the row indices are in
-    ascending order, whatever order the source delivered its pixels in (a
-    multi-area Bruker acquisition comes back area by area, for instance). A
-    consumer can binary-search a column's indices directly, and scipy reports
-    `has_sorted_indices` as true without a `sort_indices()` pass.
+    ascending order and each appears once, whatever order the source delivered
+    its pixels in (a multi-area Bruker acquisition comes back area by area,
+    for instance). A consumer can binary-search a column's indices directly,
+    and scipy reports `has_sorted_indices` as true without a `sort_indices()`
+    pass.
+
+    One pixel is one row. A source that measures the same coordinate twice --
+    a processed imzML with a repeated coordinate -- has both spectra **summed**
+    into that row, which is what the pixel's TIC image and its
+    `non_empty_pixels` count then describe as well. The conversion says so in
+    the log, naming how many positions it applied to. Reading the store is not
+    how you would find out otherwise: scipy and dask both merge repeated
+    entries as they read, so `read_zarr` would show the sum whether or not the
+    stored arrays held one entry or two.
 
 !!! note "Every stored intensity is a real, non-negative number"
     Non-finite and negative intensities are dropped from a spectrum before it

--- a/tests/unit/converters/test_axis_memory_guard.py
+++ b/tests/unit/converters/test_axis_memory_guard.py
@@ -1,0 +1,199 @@
+"""A mass axis is refused for what it really costs, before it is built.
+
+The only guard was the count array's 1 GiB ceiling, which sizes 4 bytes
+per bin. Everything else the conversion builds per bin -- the axis, the
+``var`` frame with its string index, ``total_intensity``, ``avg_spectrum``,
+the column pointers, anndata's copies during the write -- comes to about
+200 bytes, measured. So the ceiling let through axes that could not
+possibly fit: 200M bins on a six-pixel dataset needed only 800 MB of count
+array, passed, and took 217 s and 67.5 GB. 300M bins were refused, but the
+process had reached 7.44 GB building the axis before anything looked at it
+(issue #251).
+
+The guard now reads the bin count the resampling plan resolved, before the
+axis is materialised, and compares the projection with the machine's free
+memory the way the mobility grid's own guard does.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from thyra.converters.spatialdata import base_spatialdata_converter as base_converter
+from thyra.converters.spatialdata import csc_assembly
+from thyra.converters.spatialdata.base_spatialdata_converter import _bin_width_range
+from thyra.converters.spatialdata.csc_assembly import (
+    AXIS_BYTES_PER_BIN,
+    AXIS_REFUSE_FRACTION,
+    AXIS_WARN_FRACTION,
+    mass_axis_refusal,
+    projected_axis_gb,
+)
+from thyra.converters.spatialdata.streaming_converter import (
+    StreamingSpatialDataConverter,
+)
+from thyra.errors import ConversionRefused
+
+
+class _Meta:
+    def __init__(self):
+        self.dimensions = (2, 3, 1)
+        self.mass_range = (100.0, 1000.0)
+        self.n_spectra = 6
+        self.pixel_size = (20.0, 20.0)
+        self.estimated_memory_gb = 1.0
+        self.coordinate_bounds = (0, 2, 0, 3)
+        self.is_3d = False
+        self.has_mass_axis = True
+        self.source_path = "mock"
+        self.total_peaks = 60
+        self.coordinate_offsets = (0, 0, 0)
+        self.spectrum_type = "centroid spectrum"
+        self.peak_counts_per_pixel = None
+        self.z_spacing_um = None
+
+
+class _Reader:
+    """Just enough reader to reach ``_setup_mass_axis``."""
+
+    def __init__(self):
+        self._meta = _Meta()
+        self.axis_built = False
+
+    def get_essential_metadata(self):
+        return self._meta
+
+    def get_common_mass_axis(self):
+        self.axis_built = True
+        return np.linspace(100.0, 1000.0, 1000)
+
+    @property
+    def has_shared_mass_axis(self):
+        return True
+
+    def close(self):
+        pass
+
+
+class TestTheProjection:
+    def test_it_is_the_measured_cost_per_bin(self):
+        assert projected_axis_gb(1_000_000) == pytest.approx(
+            1_000_000 * AXIS_BYTES_PER_BIN / 1024**3
+        )
+
+    def test_the_count_array_alone_would_have_let_it_through(self):
+        """The number the old ceiling saw, against the number it costs."""
+        n_bins = 200_000_000
+        assert csc_assembly.count_refusal(n_bins) is None
+        assert projected_axis_gb(n_bins) > 30.0
+
+    def test_an_axis_that_fits_is_not_refused(self):
+        assert mass_axis_refusal(1_000_000, available_gb=32.0) is None
+
+    def test_an_axis_that_does_not_fit_names_the_levers(self):
+        refusal = mass_axis_refusal(200_000_000, available_gb=32.0)
+
+        assert refusal is not None
+        assert "200,000,000 bins" in refusal
+        assert "--resample-bins" in refusal
+        assert f"{AXIS_BYTES_PER_BIN} bytes per bin" in refusal
+
+    def test_the_boundary_is_the_refuse_fraction(self):
+        free = 8.0
+        bins = int(free * AXIS_REFUSE_FRACTION * 1024**3 / AXIS_BYTES_PER_BIN)
+        assert mass_axis_refusal(bins, available_gb=free) is None
+        assert mass_axis_refusal(bins + 1, available_gb=free) is not None
+
+    def test_the_band_below_it_warns(self, thyra_logs):
+        """``thyra_logs`` rather than ``caplog``: see ``tests/conftest.py``."""
+        free = 8.0
+        bins = int(free * AXIS_WARN_FRACTION * 1024**3 / AXIS_BYTES_PER_BIN) + 1
+
+        with thyra_logs("thyra.converters.spatialdata.csc_assembly") as records:
+            assert mass_axis_refusal(bins, available_gb=free) is None
+
+        assert any("projected to need" in r.getMessage() for r in records)
+
+
+class TestTheConverterRefusesBeforeBuilding:
+    def _converter(self, reader, **kwargs):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            return StreamingSpatialDataConverter(
+                reader=reader,
+                output_path=Path(tmpdir) / "out.zarr",
+                dataset_id="m",
+                pixel_size_um=10.0,
+                **kwargs,
+            )
+
+    def test_a_resampled_axis_is_refused_unbuilt(self, monkeypatch):
+        """The point of the guard: nothing wide is allocated first."""
+        monkeypatch.setattr(csc_assembly, "available_memory_gb", lambda: 1.0)
+        reader = _Reader()
+        converter = self._converter(
+            reader,
+            resampling_config={
+                "method": "nearest_neighbor",
+                "target_bins": 200_000_000,
+            },
+        )
+
+        with pytest.raises(ConversionRefused, match=r"200,000,000 bins"):
+            converter._setup_mass_axis()
+
+        assert converter._common_mass_axis is None
+
+    def test_a_raw_axis_is_refused_too(self, monkeypatch):
+        """It is already built, but every per-bin structure is still ahead."""
+        monkeypatch.setattr(csc_assembly, "available_memory_gb", lambda: 1e-6)
+        reader = _Reader()
+        converter = self._converter(reader)
+
+        with pytest.raises(ConversionRefused, match=r"1,000 bins"):
+            converter._setup_mass_axis()
+
+        assert reader.axis_built
+
+    def test_an_axis_that_fits_is_built(self, monkeypatch):
+        monkeypatch.setattr(csc_assembly, "available_memory_gb", lambda: 32.0)
+        converter = self._converter(_Reader())
+
+        converter._setup_mass_axis()
+
+        assert converter._common_mass_axis is not None
+        assert len(converter._common_mass_axis) == 1000
+
+
+class TestBinWidthsAreNotMaterialised:
+    """``np.diff`` over the whole axis is 1.6 GB on a 200M-bin one, for a log line."""
+
+    @pytest.mark.parametrize("n", [2, 3, 1000, 100_000])
+    def test_it_is_the_min_and_max_of_the_diff(self, n):
+        rng = np.random.default_rng(4)
+        axis = np.sort(rng.random(n) * 900.0 + 100.0)
+        widths = np.diff(axis)
+
+        low, high = _bin_width_range(axis)
+
+        assert low == pytest.approx(float(widths.min()))
+        assert high == pytest.approx(float(widths.max()))
+
+    @pytest.mark.parametrize("gap_at", [1, 99, 100, 101, 199, 998])
+    def test_a_gap_at_a_chunk_edge_is_still_seen(self, monkeypatch, gap_at):
+        """Chunks overlap by one entry; a gap between two must not be lost."""
+        monkeypatch.setattr(base_converter, "BIN_WIDTH_CHUNK", 100)
+        axis = np.arange(1000, dtype=np.float64)
+        axis[gap_at:] += 5.0  # one wide gap, placed on and around an edge
+
+        low, high = _bin_width_range(axis)
+
+        assert low == pytest.approx(1.0)
+        assert high == pytest.approx(6.0)
+
+    def test_a_degenerate_axis_is_zero(self):
+        assert _bin_width_range(np.array([500.0])) == (0.0, 0.0)
+        assert _bin_width_range(np.array([])) == (0.0, 0.0)

--- a/tests/unit/converters/test_csc_assembly.py
+++ b/tests/unit/converters/test_csc_assembly.py
@@ -25,6 +25,7 @@ from thyra.converters.spatialdata.mobility_table import (
     disambiguate_labels,
     int_strings,
 )
+from thyra.errors import ConversionRefused
 
 SPAN = 1000
 
@@ -50,8 +51,9 @@ def _reference(rows, n_rows, keep_empty):
     return sparse.coo_matrix((d, (r, columns)), shape=(n_rows, occupied.size)).tocsc()
 
 
-def _build(rows, n_rows, scratch, keep_empty=False, order=None):
+def _build(rows, n_rows, scratch, keep_empty=False, order=None, merge=False):
     assembly = CscAssembly(SPAN, n_rows, keep_empty_columns=keep_empty)
+    assembly.merge_duplicates = merge
     sequence = rows if order is None else [rows[i] for i in order]
     for row, keys, _values in sequence:
         assembly.count(row, keys)
@@ -134,6 +136,117 @@ class TestAgainstScipy:
         assembly.release()
 
 
+class TestDuplicateEntries:
+    """Two spectra at one pixel are one row holding their sum.
+
+    ``coo_matrix(...).tocsc()`` -- the conversion this engine replaced --
+    summed duplicate triples. Scattering keeps both, which leaves the
+    stored matrix non-canonical: scipy and dask merge duplicates when they
+    read it, so ``read_zarr`` users cannot tell, while a consumer that
+    binary-searches ``X/indices`` sees one of the two values (issue #241).
+    The reference is the same one the rest of this file uses, because the
+    behaviour being restored is the one it describes.
+    """
+
+    def test_a_repeated_row_and_key_is_summed(self, tmp_path):
+        rows = [
+            (0, np.array([3, 20]), np.array([200.0, 1000.0])),
+            (1, np.array([3]), np.array([5.0])),
+            (0, np.array([3, 20]), np.array([1.0, 2.0])),
+        ]
+        assembly = _build(rows, 2, tmp_path / "s", merge=True)
+        matrix = assembly.matrix()
+
+        _assert_same(matrix, _reference(rows, 2, False))
+        assert matrix.nnz == 3
+        np.testing.assert_array_equal(matrix.toarray(), [[201.0, 1002.0], [5.0, 0.0]])
+        assembly.release()
+
+    def test_repeats_that_did_not_arrive_together_are_still_summed(self, tmp_path):
+        """A coordinate can recur anywhere in the file, not just next door."""
+        rows = [
+            (0, np.array([4]), np.array([1.0])),
+            (1, np.array([4]), np.array([2.0])),
+            (2, np.array([4]), np.array([3.0])),
+            (0, np.array([4]), np.array([10.0])),
+        ]
+        assembly = _build(rows, 3, tmp_path / "s", merge=True)
+        matrix = assembly.matrix()
+
+        _assert_same(matrix, _reference(rows, 3, False))
+        np.testing.assert_array_equal(matrix.toarray(), [[11.0], [2.0], [3.0]])
+        assembly.release()
+
+    @pytest.mark.parametrize("keep_empty", [False, True], ids=["occupied", "all"])
+    def test_a_duplicated_source_is_the_coo_to_csc_matrix(self, tmp_path, keep_empty):
+        """The whole matrix, against scipy, with repeats scattered through it."""
+        rng = np.random.default_rng(11)
+        rows = _rows(rng, 40)
+        repeats = [
+            (row, keys, rng.random(keys.size) + 0.5)
+            for row, keys, _v in (rows[i] for i in rng.choice(40, 12, replace=False))
+        ]
+        both = rows + repeats
+        rng.shuffle(both)
+
+        assembly = _build(both, 40, tmp_path / "s", keep_empty, merge=True)
+        _assert_same(assembly.matrix(), _reference(both, 40, keep_empty))
+        assembly.release()
+
+    def test_the_merge_survives_a_chunk_boundary(self, tmp_path):
+        """Columns are merged a bounded slice at a time, like the sort."""
+        from thyra.converters.spatialdata import csc_assembly
+
+        rng = np.random.default_rng(12)
+        rows = _rows(rng, 30)
+        both = rows + [(row, keys, values * 2) for row, keys, values in rows[:8]]
+        rng.shuffle(both)
+
+        assembly = _build(both, 30, tmp_path / "s", merge=True)
+        csc_assembly.SORT_CHUNK_ENTRIES, kept = 53, csc_assembly.SORT_CHUNK_ENTRIES
+        try:
+            matrix = assembly.matrix()
+        finally:
+            csc_assembly.SORT_CHUNK_ENTRIES = kept
+        _assert_same(matrix, _reference(both, 30, False))
+        assembly.release()
+
+    def test_nothing_repeated_leaves_the_matrix_alone(self, tmp_path):
+        """The flag is set from occupancy, which can be pessimistic per table."""
+        rows = _rows(np.random.default_rng(13), 20)
+        merged = _build(rows, 20, tmp_path / "m", merge=True).matrix()
+        plain = _build(rows, 20, tmp_path / "p").matrix()
+
+        _assert_same(merged, _reference(rows, 20, False))
+        np.testing.assert_array_equal(merged.data, plain.data)
+
+    def test_the_matrix_still_does_not_copy_the_memmaps(self, tmp_path):
+        rows = [
+            (0, np.array([2]), np.array([1.0])),
+            (0, np.array([2]), np.array([4.0])),
+            (1, np.array([2]), np.array([9.0])),
+        ]
+        assembly = _build(rows, 2, tmp_path / "s", merge=True)
+        matrix = assembly.matrix()
+        assert np.shares_memory(matrix.data, assembly._data)
+        assert np.shares_memory(matrix.indices, assembly._indices)
+        assembly.release()
+
+    def test_merging_twice_is_merging_once(self, tmp_path):
+        """``matrix()`` is not documented as single-shot; a second merge would
+        halve nothing but would rewrite the arrays from the wrong offsets."""
+        rows = [
+            (0, np.array([1]), np.array([1.0])),
+            (0, np.array([1]), np.array([2.0])),
+        ]
+        assembly = _build(rows, 1, tmp_path / "s", merge=True)
+        first = assembly.matrix().toarray()
+        second = assembly.matrix().toarray()
+        np.testing.assert_array_equal(first, [[3.0]])
+        np.testing.assert_array_equal(second, first)
+        assembly.release()
+
+
 class TestTheGuards:
     def test_the_count_array_has_a_budget_naming_the_lever(self):
         assert count_refusal(MAX_COUNT_BYTES // 4) is None
@@ -155,8 +268,11 @@ class TestTheGuards:
         assembly.allocate(tmp_path / "s")
         assembly.scatter(0, np.array([1, 2]), np.array([1.0, 1.0]))
         # Row 1 was counted and never scattered: a reserved slot nothing
-        # wrote, which must not become a silent zero at row 0.
-        with pytest.raises(RuntimeError, match="disagree"):
+        # wrote, which must not become a silent zero at row 0. A property
+        # of the source and its reader, so it is spelled as a refusal --
+        # the message is the whole explanation, and a traceback in front
+        # of it reads like a crash (issue #234's convention).
+        with pytest.raises(ConversionRefused, match="disagree"):
             assembly.matrix()
         assembly.release()
 

--- a/tests/unit/converters/test_routing_estimate.py
+++ b/tests/unit/converters/test_routing_estimate.py
@@ -1,32 +1,29 @@
 # tests/unit/converters/test_routing_estimate.py
-"""The size estimate must be honest, and routing must not depend on it.
+"""The size the log reports must be the size that gets written.
 
-``_estimate_output_size_gb`` scores a dataset as
-``n_pixels * n_mz_bins * 4``. The resampling branch already resolved the
-real bin count (issue #87), but the raw-axis branch still guessed it from
-``(max_mass - min_mass) / 0.01`` -- a 10 mDa spacing the data need not have.
+**What used to be here.** ``_estimate_output_size_gb`` scored a dataset as
+``n_pixels * n_mz_bins * 4`` -- the *bounding box* by the bin count, as
+though the matrix were dense. The bin count itself had been fixed once
+already (issue #87): the raw-axis branch guessed it from ``(max_mass -
+min_mass) / 0.01``, a 10 mDa spacing the data need not have, which scored
+a continuous file carrying 4,000 points over 250-1200 m/z as though it had
+95,000. While that number drove the routing it mis-sent the largest
+datasets to the method that held the most in memory.
 
-That guess is wrong in both directions. A continuous file carrying 4,000
-points over 250-1200 m/z was scored as though it had 95,000, inflating it
-24x; a processed file whose spectra share no m/z values was scored far too
-low, which routed the very largest datasets to the method that holds the
-most in memory.
+**Why it is gone.** Fixing the bin count never fixed the *dense*. On
+``TIMS-test-data/02_tiny_longramp_1465px`` the line read
+``Estimated output size: 40.3 GB (513,339 pixels x 21,072 m/z bins)`` for
+a store of 106 MB; 2.5 GB for a 7.6 MB store, 240.7 GB for a 329 MB one
+(issue #254). Since the route stopped being chosen by size (design
+decision D11) the number selected nothing, so all it could still do was
+talk somebody out of a conversion they had room for.
 
-**The routing half of that is now history.** PCS was faster and lighter at
-every size measured, so ``"auto"`` first picked it unconditionally and
-``PCS_SIZE_THRESHOLD_GB`` went; then the COO route itself went, and with it
-the predicate. The estimate survives as a log line, and these tests survive
-with it -- an inaccurate number in a support log is a smaller problem than
-an inaccurate route, but it is still a problem, and the 24x inflation is
-the kind of thing that gets re-derived if nobody wrote down that the
-fallback is unreliable.
-
-``convert()`` runs ``_initialize_conversion()`` before reaching the
-estimate, so the axis is already built and there is nothing to guess. These
-tests pin that the built axis is preferred, that the old heuristics still
-apply when it is not available -- which is the case when the estimator is
-called directly, as the older tests in ``test_streaming_converter.py`` do --
-and that ``use_csc`` survives only as a compatibility keyword.
+Nothing has to be estimated. The pre-scan counts every entry before the
+scatter, and ``_matrix_size_gb`` reports those: eight bytes of value plus
+four or eight of row index each, which is an upper bound on what lands on
+disk because zarr compresses it. These tests pin that arithmetic, that it
+is reported per table rather than per grid position, and that neither the
+dense estimate nor the routing machinery came back.
 """
 
 from __future__ import annotations
@@ -40,6 +37,7 @@ import pytest
 
 from thyra.converters.spatialdata.streaming_converter import (
     StreamingSpatialDataConverter,
+    _TableUnit,
 )
 
 
@@ -83,58 +81,60 @@ def _converter(
     return conv
 
 
-class TestPrefersTheBuiltAxis:
-    """When the axis exists, its length is what counts."""
-
-    def test_uses_real_axis_length(self):
-        n_pixels = 10_000
-        axis = np.linspace(250.0, 1200.0, 4_000)
-        conv = _converter((100, 100, 1), axis=axis)
-
-        expected = n_pixels * 4_000 * 4 / (1024**3)
-        assert conv._estimate_output_size_gb() == pytest.approx(expected, rel=1e-9)
-
-    def test_real_axis_beats_the_raw_heuristic(self):
-        """The heuristic would say 95,000 bins; the axis says 4,000."""
-        axis = np.linspace(250.0, 1200.0, 4_000)
-        conv = _converter((100, 100, 1), axis=axis)
-        with_axis = conv._estimate_output_size_gb()
-
-        conv._common_mass_axis = None
-        without_axis = conv._estimate_output_size_gb()
-
-        # (1200 - 250) / 0.01 = 95,000, i.e. 23.75x the real count.
-        assert without_axis == pytest.approx(with_axis * 95_000 / 4_000, rel=1e-6)
-
-    def test_real_axis_beats_the_resampling_plan_too(self):
-        """A built axis is authoritative even when resampling is configured."""
-        axis = np.linspace(250.0, 1200.0, 1_000)
-        conv = _converter(
-            (100, 100, 1),
-            axis=axis,
-            resampling_config={"method": "nearest_neighbor", "target_bins": 500_000},
-        )
-        expected = 10_000 * 1_000 * 4 / (1024**3)
-        assert conv._estimate_output_size_gb() == pytest.approx(expected, rel=1e-9)
+def _unit(n_grid: int, n_cols: int, rows: dict[int, int]) -> _TableUnit:
+    """A table whose pre-scan found ``rows[grid]`` entries at each position."""
+    unit = _TableUnit("t", "t_pixels", 0, n_grid, n_cols, (1, n_grid))
+    for grid, n_entries in rows.items():
+        keys = np.arange(n_entries, dtype=np.int64)
+        unit.count(grid, keys, np.ones(n_entries))
+    unit.finish_counting()
+    return unit
 
 
-class TestFallbacksStillApply:
-    """Without a built axis, the previous behaviour is unchanged."""
+class TestTheReportedSize:
+    """It is the counted entries, not the bounding box."""
 
-    def test_raw_heuristic_when_no_axis_and_no_resampling(self):
-        conv = _converter((100, 100, 1), mass_range=(250.0, 1200.0), axis=None)
-        expected = 10_000 * 95_000 * 4 / (1024**3)
-        assert conv._estimate_output_size_gb() == pytest.approx(expected, rel=1e-9)
+    def test_entries_times_twelve_bytes(self):
+        conv = _converter((4, 1, 1), axis=np.linspace(250.0, 1200.0, 50))
+        unit = _unit(4, 50, {0: 10, 1: 7, 3: 3})
 
-    def test_resampling_plan_when_no_axis(self):
-        conv = _converter(
-            (50, 50, 1),
-            mass_range=(100.0, 1000.0),
-            axis=None,
-            resampling_config={"method": "nearest_neighbor", "target_bins": 5_000},
-        )
-        expected = 2_500 * 5_000 * 4 / (1024**3)
-        assert conv._estimate_output_size_gb() == pytest.approx(expected, rel=1e-9)
+        assert unit.assembly.n_nonzeros == 20
+        expected = 20 * (8 + 4) / 1024**3
+        assert conv._matrix_size_gb([unit]) == pytest.approx(expected, rel=1e-12)
+
+    def test_empty_positions_cost_nothing(self):
+        """The bounding box is mostly empty on a polygon-shaped acquisition."""
+        conv = _converter((1000, 1000, 1), axis=np.linspace(250.0, 1200.0, 21_072))
+        unit = _unit(1_000_000, 21_072, {5: 4})
+
+        # Dense arithmetic would have said 1e6 x 21072 x 4 = 78 GB.
+        assert conv._matrix_size_gb([unit]) < 1e-6
+
+    def test_several_tables_are_added_up(self):
+        conv = _converter((4, 1, 2), axis=np.linspace(250.0, 1200.0, 50))
+        units = [_unit(4, 50, {0: 6}), _unit(4, 50, {1: 9})]
+
+        expected = (6 + 9) * (8 + 4) / 1024**3
+        assert conv._matrix_size_gb(units) == pytest.approx(expected, rel=1e-12)
+
+    def test_nothing_counted_is_zero(self):
+        conv = _converter((4, 1, 1), axis=np.linspace(250.0, 1200.0, 50))
+        assert conv._matrix_size_gb([_unit(4, 50, {})]) == 0.0
+
+
+class TestTheDenseEstimateIsGone:
+    """Left behind, somebody would fix its bin count again instead of it."""
+
+    def test_the_estimator_is_gone(self):
+        assert not hasattr(StreamingSpatialDataConverter, "_estimate_output_size_gb")
+
+    def test_the_route_machinery_is_gone(self):
+        """A leftover predicate or constant would read as a live gate.
+
+        Left behind, the next person tunes it and nothing happens.
+        """
+        for name in ("PCS_SIZE_THRESHOLD_GB", "_should_use_pcs", "_stream_build_coo"):
+            assert not hasattr(StreamingSpatialDataConverter, name), name
 
 
 class TestUseCscIsCompatibilityOnly:
@@ -149,7 +149,7 @@ class TestUseCscIsCompatibilityOnly:
     @pytest.mark.parametrize("value", ["auto", True])
     def test_auto_and_true_are_accepted(self, value):
         conv = _converter((10, 10, 1), use_csc=value)
-        assert conv._estimate_output_size_gb() >= 0.0
+        assert conv._matrix_size_gb([]) == 0.0
 
     def test_false_names_the_removed_route(self):
         with pytest.raises(ValueError, match=r"COO route, which has been removed"):
@@ -165,24 +165,3 @@ class TestUseCscIsCompatibilityOnly:
         """
         with pytest.raises(ValueError, match=r"sparse_format was removed"):
             _converter((10, 10, 1), sparse_format="csr")
-
-    def test_the_route_machinery_is_gone(self):
-        """A leftover predicate or constant would read as a live gate.
-
-        Left behind, the next person tunes it and nothing happens.
-        """
-        for name in ("PCS_SIZE_THRESHOLD_GB", "_should_use_pcs", "_stream_build_coo"):
-            assert not hasattr(StreamingSpatialDataConverter, name), name
-
-
-class TestDegenerate:
-    """Empty and tiny axes must not raise."""
-
-    def test_empty_axis_is_zero_sized(self):
-        conv = _converter((10, 10, 1), axis=np.array([]))
-        assert conv._estimate_output_size_gb() == 0.0
-
-    def test_single_bin_axis(self):
-        conv = _converter((10, 10, 1), axis=np.array([500.0]))
-        expected = 100 * 1 * 4 / (1024**3)
-        assert conv._estimate_output_size_gb() == pytest.approx(expected, rel=1e-9)

--- a/tests/unit/converters/test_scratch_release.py
+++ b/tests/unit/converters/test_scratch_release.py
@@ -1,0 +1,235 @@
+"""The CSC scratch directories go, on every way out of a conversion.
+
+Each table is an AnnData built over memmapped CSC arrays in a
+``.thyra_*`` directory next to the output. Windows will not delete a
+mapped file, so the directory survives for exactly as long as something
+still references the table -- and two things kept one alive:
+
+**A log handler that retains records** (issue #249). The finalize path
+passed exception *objects* as logger arguments at 19 sites. A retained
+record holds the exception, the exception holds its traceback, the
+traceback's frames reach the AnnData, and the scratch cannot be removed.
+pytest's ``caplog`` retains records; so does Ousia's per-session log
+capture, which is the consumer that met it. A plain ``StreamHandler``
+never showed it.
+
+**An interrupt** (issue #245). ``KeyboardInterrupt`` propagated past
+``except Exception``, so nothing released the tables and nothing ran the
+CLI's quarantine step: a whole-slide mobility grid left 18 GB of scratch
+and an unopenable store blocking the retry. Measured on
+``TIMS-test-data/02_tiny_longramp_1465px`` with ``--mobility-grid``:
+330 MB of scratch left behind, exit status 0xC000013A.
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+from pathlib import Path
+
+import pytest
+
+from tests.fixtures.mock_msi_generator import MockMSIConfig, MockMSIReader
+from thyra.converters.spatialdata.streaming_converter import (
+    SPATIALDATA_AVAILABLE,
+    StreamingSpatialDataConverter,
+)
+
+pytestmark = pytest.mark.skipif(
+    not SPATIALDATA_AVAILABLE,
+    reason="SpatialData dependencies not available",
+)
+
+
+class _Retaining(logging.Handler):
+    """What pytest's caplog and a GUI's session log both do."""
+
+    def __init__(self):
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
+def _config() -> MockMSIConfig:
+    return MockMSIConfig(
+        n_x=3, n_y=2, n_z=1, n_mz_bins=200, peaks_per_spectrum=(5, 9), seed=3
+    )
+
+
+def _converter(reader, output: Path) -> StreamingSpatialDataConverter:
+    return StreamingSpatialDataConverter(
+        reader=reader,
+        output_path=output,
+        dataset_id="m",
+        pixel_size_um=10.0,
+        include_optical=False,
+    )
+
+
+def _scratch(parent: Path) -> list[str]:
+    return sorted(p.name for p in parent.iterdir() if p.name.startswith(".thyra_"))
+
+
+@pytest.fixture
+def retaining_handler():
+    """A record-retaining handler on the ``thyra`` logger, not on the root.
+
+    ``setup_logging`` sets ``propagate = False`` on that logger and it is
+    process-global, so a handler on the root sees Thyra records only until
+    some other test has invoked the CLI -- which passes alone and fails in
+    the full suite. Same reason ``tests/conftest.py`` has ``thyra_logs``.
+    """
+    handler = _Retaining()
+    logger = logging.getLogger("thyra")
+    previous = logger.level
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+    try:
+        yield handler
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(previous)
+
+
+def _reader_that_loses_its_metadata():
+    """A reader that makes one finalize-path warning fire.
+
+    ``build_uns_metadata`` catches this and logs it while the table's
+    AnnData is a live local, which is the frame a retained exception
+    reaches through ``tb_frame.f_back``.
+    """
+    reader = MockMSIReader(_config())
+
+    def raising(*_args, **_kwargs):
+        raise RuntimeError("simulated metadata failure")
+
+    reader.get_comprehensive_metadata = raising
+    return reader
+
+
+class TestAFailedSave:
+    def test_the_scratch_goes_even_with_a_retaining_handler(
+        self, tmp_path, monkeypatch, retaining_handler
+    ):
+        import spatialdata
+
+        def boom(self, *_args, **_kwargs):
+            raise OSError("simulated write failure")
+
+        monkeypatch.setattr(spatialdata.SpatialData, "write", boom)
+
+        converter = _converter(_reader_that_loses_its_metadata(), tmp_path / "s.zarr")
+        assert converter.convert() is False
+
+        del converter
+        gc.collect()
+        assert _scratch(tmp_path) == []
+
+    def test_the_warning_that_used_to_pin_it_still_reaches_the_log(
+        self, tmp_path, monkeypatch, retaining_handler
+    ):
+        """Logging ``str(e)`` must not have silenced the message itself."""
+        import spatialdata
+
+        def boom(self, *_args, **_kwargs):
+            raise OSError("simulated write failure")
+
+        monkeypatch.setattr(spatialdata.SpatialData, "write", boom)
+
+        _converter(_reader_that_loses_its_metadata(), tmp_path / "s.zarr").convert()
+
+        assert any(
+            "simulated metadata failure" in record.getMessage()
+            for record in retaining_handler.records
+        )
+
+    def test_no_record_holds_an_exception_object(
+        self, tmp_path, monkeypatch, retaining_handler
+    ):
+        """The rule, not just its effect: an object in ``args`` is the defect."""
+        import spatialdata
+
+        def boom(self, *_args, **_kwargs):
+            raise OSError("simulated write failure")
+
+        monkeypatch.setattr(spatialdata.SpatialData, "write", boom)
+
+        _converter(_reader_that_loses_its_metadata(), tmp_path / "s.zarr").convert()
+
+        offenders = [
+            record.name
+            for record in retaining_handler.records
+            if record.name.startswith("thyra")
+            and any(isinstance(arg, BaseException) for arg in (record.args or ()))
+        ]
+        assert offenders == []
+
+
+class TestAnInterrupt:
+    def test_it_is_reported_as_a_failed_conversion(self, tmp_path, monkeypatch):
+        import spatialdata
+
+        def interrupt(self, *_args, **_kwargs):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(spatialdata.SpatialData, "write", interrupt)
+
+        assert _converter(MockMSIReader(_config()), tmp_path / "i.zarr").convert() is (
+            False
+        )
+
+    def test_the_scratch_goes(self, tmp_path, monkeypatch, retaining_handler):
+        import spatialdata
+
+        def interrupt(self, *_args, **_kwargs):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(spatialdata.SpatialData, "write", interrupt)
+
+        converter = _converter(MockMSIReader(_config()), tmp_path / "i.zarr")
+        assert converter.convert() is False
+
+        del converter
+        gc.collect()
+        assert _scratch(tmp_path) == []
+
+    def test_the_reader_is_closed(self, tmp_path, monkeypatch):
+        import spatialdata
+
+        def interrupt(self, *_args, **_kwargs):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(spatialdata.SpatialData, "write", interrupt)
+
+        reader = MockMSIReader(_config())
+        closed = []
+        reader.close = lambda: closed.append(True)
+
+        _converter(reader, tmp_path / "i.zarr").convert()
+
+        assert closed == [True]
+
+    def test_an_interrupt_during_the_passes_is_the_same(self, tmp_path):
+        """Not only the write: the scatter is where a long run spends its time."""
+
+        class _InterruptingReader(MockMSIReader):
+            def iter_spectra(self, batch_size=None):
+                for n, spectrum in enumerate(super().iter_spectra(batch_size)):
+                    if self._scattering and n == 2:
+                        raise KeyboardInterrupt
+                    yield spectrum
+
+            _scattering = False
+
+            def reset(self):
+                super().reset()
+                self._scattering = True
+
+        converter = _converter(_InterruptingReader(_config()), tmp_path / "p.zarr")
+        assert converter.convert() is False
+
+        del converter
+        gc.collect()
+        assert _scratch(tmp_path) == []

--- a/tests/unit/converters/test_streaming_converter.py
+++ b/tests/unit/converters/test_streaming_converter.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Generator, Optional, Tuple
 from unittest.mock import MagicMock
 
+import anndata
 import numpy as np
 import pytest
 
@@ -154,12 +155,15 @@ class MockMSIReader:
     not SPATIALDATA_AVAILABLE,
     reason="SpatialData dependencies not available",
 )
-def test_estimate_output_size_uses_real_bins_for_width_based_config():
-    """Regression for #87: when ``target_bins`` is None, the size estimator
-    must resolve the bin count via ``width_at_mz`` rather than fall back to a
-    hardcoded 10,000 placeholder. That fallback used to pick the wrong
-    streaming method as well; routing no longer depends on the estimate, so
-    what is left at stake is the number in the log.
+def test_resampling_plan_uses_real_bins_for_width_based_config():
+    """Regression for #87: when ``target_bins`` is None, the bin count must be
+    resolved from ``width_at_mz`` rather than a hardcoded 10,000 placeholder.
+
+    That fallback used to pick the wrong streaming method; there is one
+    route now, but the resolved count is what the memory guard reads
+    before the axis is built (issue #251), so an axis scored at 10,000
+    bins instead of 180,000 would be waved through by a guard sized for
+    the wrong number.
     """
     reader = MockMSIReader(
         dimensions=(50, 50, 1),
@@ -182,12 +186,10 @@ def test_estimate_output_size_uses_real_bins_for_width_based_config():
             use_csc="auto",
             resampling_config=config,
         )
-        size_gb = converter._estimate_output_size_gb()
+        _, _, _, target_bins = converter._resolve_resampling_plan()
 
-    # 2500 pixels x 180k bins x 4 bytes = ~1.68 GB. With the buggy 10k
-    # fallback it would have been ~0.09 GB.
-    assert size_gb > 1.0, (
-        f"Expected size estimate > 1 GB (resolved bins), got {size_gb:.3f} GB. "
+    assert target_bins == pytest.approx(180_000, rel=0.01), (
+        f"Expected ~180,000 bins from the 5 mDa width, got {target_bins:,}. "
         "Likely regression of #87 (10k hardcoded fallback)."
     )
 
@@ -554,7 +556,7 @@ def test_rectangular_grid():
     reason="SpatialData dependencies not available",
 )
 def test_auto_use_csc_mode_with_resampling():
-    """Test auto mode estimation with resampling config."""
+    """``use_csc="auto"`` converts, and the size it reports is the counted one."""
     reader = MockMSIReader(
         dimensions=(50, 50, 1),  # 2500 pixels
         peaks_per_spectrum=200,
@@ -576,10 +578,15 @@ def test_auto_use_csc_mode_with_resampling():
             resampling_config=resampling_config,
         )
 
-        # Estimate should use target_bins from resampling config
-        size_gb = converter._estimate_output_size_gb()
-        # 2500 * 5000 * 4 bytes = 50 MB = 0.047 GB
-        assert size_gb < 1.0, "Should be less than 1 GB"
+        assert converter.convert() is True
+
+        # The route converts on the resolved axis. What the log reports
+        # about its size is the counted non-zeros rather than the dense
+        # product of pixels and bins (issue #254, pinned in
+        # test_routing_estimate.py).
+        table = anndata.read_zarr(output_path / "tables" / "auto_resample_test_z0")
+        assert table.shape == (2500, 5000)
+        assert int(table.X.nnz) > 0
 
 
 class MockMSIReaderWithOptical(MockMSIReader):

--- a/tests/unit/converters/test_two_pass_agreement.py
+++ b/tests/unit/converters/test_two_pass_agreement.py
@@ -1,0 +1,243 @@
+"""What the second pass is allowed to hand the assembly.
+
+Every conversion reads the source twice: pass 1 counts the entries each
+m/z column will hold and records each position's TIC, pass 2 scatters the
+values. Two things were taken on trust.
+
+**A position handed in twice** (issue #241). Two spectra at one pixel were
+written as two ``(row, col)`` entries rather than one holding their sum,
+which is what ``coo_matrix(...).tocsc()`` -- the conversion the streaming
+engine replaced -- produced. The stored matrix is then non-canonical, and
+invisibly so: scipy and dask both merge duplicates as they read, so
+``read_zarr`` shows the sum while a consumer that binary-searches
+``X/indices`` directly sees one of the two values. The TIC image held the
+last spectrum's total against a row holding the sum, and
+``non_empty_pixels`` counted spectra rather than rows. So these tests read
+the zarr arrays themselves.
+
+**A pass that returns different values** (issue #247). The only agreement
+check was per-column entry counts, so a reader whose second iteration
+returned the same counts with different values wrote a store whose ``X``
+came from pass 2 while its TIC image and ``average_spectrum`` came from
+pass 1 -- measured at ``TIC sum=147066`` against ``X.sum=294132``, with
+nothing said. Pass 2 now compares each position's total with the one pass
+1 recorded.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import anndata
+import numpy as np
+import pytest
+import spatialdata
+import zarr
+
+from tests.fixtures.mock_msi_generator import MockMSIConfig, MockMSIReader
+from thyra.converters.spatialdata.streaming_converter import (
+    SPATIALDATA_AVAILABLE,
+    StreamingSpatialDataConverter,
+)
+from thyra.errors import ConversionRefused
+
+pytestmark = pytest.mark.skipif(
+    not SPATIALDATA_AVAILABLE,
+    reason="SpatialData dependencies not available",
+)
+
+N_X, N_Y = 3, 2
+KEY = "m_z0"
+
+
+def _config() -> MockMSIConfig:
+    return MockMSIConfig(
+        n_x=N_X, n_y=N_Y, n_z=1, n_mz_bins=64, peaks_per_spectrum=(3, 5), seed=11
+    )
+
+
+def _converter(reader, output: Path) -> StreamingSpatialDataConverter:
+    return StreamingSpatialDataConverter(
+        reader=reader,
+        output_path=output,
+        dataset_id="m",
+        pixel_size_um=10.0,
+        include_optical=False,
+    )
+
+
+class _RepeatedCoordinate(MockMSIReader):
+    """The raster, then one more spectrum at the pixel (1, 0) already has.
+
+    It carries m/z values that pixel already carries, so the extra entries
+    land in columns it already occupies -- which is the case the stored
+    arrays cannot represent twice.
+    """
+
+    def iter_spectra(self, batch_size=None):
+        extra = None
+        for coords, mzs, intensities in super().iter_spectra(batch_size):
+            if coords == (1, 0, 0):
+                extra = mzs[:2]
+            yield coords, mzs, intensities
+        assert extra is not None
+        yield (1, 0, 0), extra, np.array([1.0, 2.0])
+
+
+class _ScaledSecondPass(MockMSIReader):
+    """Same entry counts on the second pass, every value doubled."""
+
+    def __init__(self, config):
+        super().__init__(config)
+        self._pass = 0
+
+    def reset(self):
+        super().reset()
+        self._pass += 1
+
+    def iter_spectra(self, batch_size=None):
+        scale = 2.0 if self._pass else 1.0
+        for coords, mzs, intensities in super().iter_spectra(batch_size):
+            yield coords, mzs, intensities * scale
+
+
+class _SwappedPixels(MockMSIReader):
+    """The second pass exchanges two pixels' spectra: counts unchanged."""
+
+    def __init__(self, config):
+        super().__init__(config)
+        self._pass = 0
+
+    def reset(self):
+        super().reset()
+        self._pass += 1
+
+    def iter_spectra(self, batch_size=None):
+        spectra = list(super().iter_spectra(batch_size))
+        if self._pass:
+            first, second = spectra[0], spectra[1]
+            spectra[0] = (first[0], second[1], second[2])
+            spectra[1] = (second[0], first[1], first[2])
+        yield from spectra
+
+
+def _stored_arrays(store: Path, key: str = KEY):
+    """``X`` exactly as written -- not what scipy or dask hand back."""
+    group = zarr.open_group(str(store / "tables" / key / "X"), mode="r")
+    return (
+        np.asarray(group["indices"][:]),
+        np.asarray(group["data"][:]),
+        np.asarray(group["indptr"][:]),
+    )
+
+
+def _first_non_canonical_column(indices, indptr) -> Optional[int]:
+    for column, (lo, hi) in enumerate(zip(indptr[:-1], indptr[1:])):
+        rows = indices[lo:hi]
+        if rows.size > 1 and not np.all(np.diff(rows) > 0):
+            return column
+    return None
+
+
+class TestRepeatedCoordinates:
+    def test_the_store_holds_one_entry_per_pixel_and_bin(self, tmp_path):
+        store = tmp_path / "dup.zarr"
+        assert _converter(_RepeatedCoordinate(_config()), store).convert() is True
+
+        indices, _data, indptr = _stored_arrays(store)
+        assert _first_non_canonical_column(indices, indptr) is None
+
+    def test_the_repeated_pixel_holds_the_sum(self, tmp_path):
+        store = tmp_path / "sum.zarr"
+        plain = tmp_path / "plain.zarr"
+        assert _converter(_RepeatedCoordinate(_config()), store).convert() is True
+        assert _converter(MockMSIReader(_config()), plain).convert() is True
+
+        with_repeat = anndata.read_zarr(store / "tables" / KEY)
+        without = anndata.read_zarr(plain / "tables" / KEY)
+        row = int(np.flatnonzero(with_repeat.obs.index.astype(int) == 1)[0])
+
+        # The extra spectrum carried 1.0 and 2.0 into columns the pixel had.
+        assert with_repeat.n_obs == without.n_obs
+        assert float(with_repeat.X[row].sum()) == pytest.approx(
+            float(without.X[row].sum()) + 3.0
+        )
+
+    def test_the_tic_image_agrees_with_the_row(self, tmp_path):
+        store = tmp_path / "tic.zarr"
+        assert _converter(_RepeatedCoordinate(_config()), store).convert() is True
+
+        table = anndata.read_zarr(store / "tables" / KEY)
+        sdata = spatialdata.read_zarr(store)
+        tic = np.asarray(sdata.images[f"{KEY}_tic"].data).reshape(N_Y, N_X)
+        row = int(np.flatnonzero(table.obs.index.astype(int) == 1)[0])
+
+        assert float(tic[0, 1]) == pytest.approx(float(table.X[row].sum()))
+
+    def test_non_empty_pixels_counts_rows_not_spectra(self, tmp_path):
+        store = tmp_path / "count.zarr"
+        assert _converter(_RepeatedCoordinate(_config()), store).convert() is True
+
+        sdata = spatialdata.read_zarr(store)
+        table = anndata.read_zarr(store / "tables" / KEY)
+        reported = sdata.attrs["msi_dataset_info"]["non_empty_pixels"]
+
+        assert reported == table.n_obs == N_X * N_Y
+
+    def test_the_repeat_is_reported(self, tmp_path, thyra_logs):
+        """``thyra_logs`` rather than ``caplog``: see ``tests/conftest.py``."""
+        store = tmp_path / "logged.zarr"
+        with thyra_logs("thyra.converters.spatialdata.streaming_converter") as records:
+            assert _converter(_RepeatedCoordinate(_config()), store).convert() is True
+
+        assert any(
+            "carry more than one spectrum" in record.getMessage() for record in records
+        )
+
+
+class TestTheSecondPassMustRepeatTheFirst:
+    def test_a_scaled_second_pass_is_refused(self, tmp_path):
+        store = tmp_path / "scaled.zarr"
+        converter = _converter(_ScaledSecondPass(_config()), store)
+        converter._initialize_conversion()
+
+        with pytest.raises(ConversionRefused, match=r"disagree at pixel"):
+            converter._process_spectra(converter._create_data_structures())
+
+    def test_the_cli_reports_it_as_a_failure(self, tmp_path):
+        """Through ``convert()``, which turns a refusal into ``False``."""
+        store = tmp_path / "failed.zarr"
+        assert _converter(_ScaledSecondPass(_config()), store).convert() is False
+        assert not store.exists()
+
+    def test_exchanged_pixels_are_refused(self, tmp_path):
+        """No count can see this: the entries are all still there."""
+        store = tmp_path / "swapped.zarr"
+        assert _converter(_SwappedPixels(_config()), store).convert() is False
+
+    def test_a_repeatable_reader_is_not_refused(self, tmp_path):
+        store = tmp_path / "fine.zarr"
+        assert _converter(MockMSIReader(_config()), store).convert() is True
+        assert anndata.read_zarr(store / "tables" / KEY).n_obs == N_X * N_Y
+
+    def test_a_repeated_position_is_checked_on_its_total(self, tmp_path):
+        """The summed positions are compared once the pass is over."""
+
+        class _RepeatAndDiverge(_RepeatedCoordinate):
+            def __init__(self, config):
+                super().__init__(config)
+                self._pass = 0
+
+            def reset(self):
+                super().reset()
+                self._pass += 1
+
+            def iter_spectra(self, batch_size=None):
+                for coords, mzs, intensities in super().iter_spectra(batch_size):
+                    if self._pass and coords == (1, 0, 0):
+                        intensities = intensities * 3.0
+                    yield coords, mzs, intensities
+
+        store = tmp_path / "repeat_diverge.zarr"
+        assert _converter(_RepeatAndDiverge(_config()), store).convert() is False

--- a/tests/unit/readers/test_bruker_calibration.py
+++ b/tests/unit/readers/test_bruker_calibration.py
@@ -63,14 +63,13 @@ class TestCalibrationMetadataReading:
             conn.close()
 
             # Create a mock BrukerReader with minimal setup
-            with patch.object(BrukerReader, "_validate_data_path"), patch.object(
-                BrukerReader, "_detect_file_type"
-            ), patch.object(BrukerReader, "_setup_components"), patch.object(
-                BrukerReader, "_initialize_sdk"
-            ), patch.object(
-                BrukerReader, "_initialize_database"
-            ), patch.object(
-                BrukerReader, "_preload_frame_num_peaks"
+            with (
+                patch.object(BrukerReader, "_validate_data_path"),
+                patch.object(BrukerReader, "_detect_file_type"),
+                patch.object(BrukerReader, "_setup_components"),
+                patch.object(BrukerReader, "_initialize_sdk"),
+                patch.object(BrukerReader, "_initialize_database"),
+                patch.object(BrukerReader, "_preload_frame_num_peaks"),
             ):
 
                 reader = BrukerReader.__new__(BrukerReader)
@@ -153,14 +152,13 @@ class TestCalibrationMetadataReading:
             conn.commit()
             conn.close()
 
-            with patch.object(BrukerReader, "_validate_data_path"), patch.object(
-                BrukerReader, "_detect_file_type"
-            ), patch.object(BrukerReader, "_setup_components"), patch.object(
-                BrukerReader, "_initialize_sdk"
-            ), patch.object(
-                BrukerReader, "_initialize_database"
-            ), patch.object(
-                BrukerReader, "_preload_frame_num_peaks"
+            with (
+                patch.object(BrukerReader, "_validate_data_path"),
+                patch.object(BrukerReader, "_detect_file_type"),
+                patch.object(BrukerReader, "_setup_components"),
+                patch.object(BrukerReader, "_initialize_sdk"),
+                patch.object(BrukerReader, "_initialize_database"),
+                patch.object(BrukerReader, "_preload_frame_num_peaks"),
             ):
 
                 reader = BrukerReader.__new__(BrukerReader)
@@ -190,14 +188,13 @@ class TestCalibrationMetadataReading:
             data_path.mkdir()
             # Don't create calibration.sqlite
 
-            with patch.object(BrukerReader, "_validate_data_path"), patch.object(
-                BrukerReader, "_detect_file_type"
-            ), patch.object(BrukerReader, "_setup_components"), patch.object(
-                BrukerReader, "_initialize_sdk"
-            ), patch.object(
-                BrukerReader, "_initialize_database"
-            ), patch.object(
-                BrukerReader, "_preload_frame_num_peaks"
+            with (
+                patch.object(BrukerReader, "_validate_data_path"),
+                patch.object(BrukerReader, "_detect_file_type"),
+                patch.object(BrukerReader, "_setup_components"),
+                patch.object(BrukerReader, "_initialize_sdk"),
+                patch.object(BrukerReader, "_initialize_database"),
+                patch.object(BrukerReader, "_preload_frame_num_peaks"),
             ):
 
                 reader = BrukerReader.__new__(BrukerReader)
@@ -223,14 +220,13 @@ class TestCalibrationMetadataReading:
             conn.close()
 
             try:
-                with patch.object(BrukerReader, "_validate_data_path"), patch.object(
-                    BrukerReader, "_detect_file_type"
-                ), patch.object(BrukerReader, "_setup_components"), patch.object(
-                    BrukerReader, "_initialize_sdk"
-                ), patch.object(
-                    BrukerReader, "_initialize_database"
-                ), patch.object(
-                    BrukerReader, "_preload_frame_num_peaks"
+                with (
+                    patch.object(BrukerReader, "_validate_data_path"),
+                    patch.object(BrukerReader, "_detect_file_type"),
+                    patch.object(BrukerReader, "_setup_components"),
+                    patch.object(BrukerReader, "_initialize_sdk"),
+                    patch.object(BrukerReader, "_initialize_database"),
+                    patch.object(BrukerReader, "_preload_frame_num_peaks"),
                 ):
 
                     reader = BrukerReader.__new__(BrukerReader)
@@ -338,28 +334,19 @@ class TestDefaultCalibrationBehavior:
         def mock_detect(self):
             self.file_type = "tsf"
 
-        with patch.object(BrukerReader, "_validate_data_path"), patch.object(
-            BrukerReader, "_detect_file_type", mock_detect
-        ), patch.object(
-            BrukerReader, "_read_calibration_metadata", return_value=None
-        ), patch.object(
-            BrukerReader, "_setup_components"
-        ), patch.object(
-            BrukerReader, "_initialize_sdk"
-        ), patch.object(
-            BrukerReader, "_initialize_database"
-        ), patch.object(
-            BrukerReader, "_detect_regions", return_value=[]
-        ), patch.object(
-            BrukerReader, "_select_region", return_value=(None, None)
-        ), patch.object(
-            BrukerReader, "_parse_mis_alignment", return_value={}
-        ), patch.object(
-            BrukerReader, "_build_positions_from_db", return_value=[]
-        ), patch.object(
-            BrukerReader, "_build_header_alignment", return_value={}
-        ), patch.object(
-            BrukerReader, "_preload_frame_num_peaks", return_value={}
+        with (
+            patch.object(BrukerReader, "_validate_data_path"),
+            patch.object(BrukerReader, "_detect_file_type", mock_detect),
+            patch.object(BrukerReader, "_read_calibration_metadata", return_value=None),
+            patch.object(BrukerReader, "_setup_components"),
+            patch.object(BrukerReader, "_initialize_sdk"),
+            patch.object(BrukerReader, "_initialize_database"),
+            patch.object(BrukerReader, "_detect_regions", return_value=[]),
+            patch.object(BrukerReader, "_select_region", return_value=(None, None)),
+            patch.object(BrukerReader, "_parse_mis_alignment", return_value={}),
+            patch.object(BrukerReader, "_build_positions_from_db", return_value=[]),
+            patch.object(BrukerReader, "_build_header_alignment", return_value={}),
+            patch.object(BrukerReader, "_preload_frame_num_peaks", return_value={}),
         ):
 
             reader = BrukerReader(Path("/fake/path.d"), use_recalibrated_state=False)
@@ -378,14 +365,13 @@ class TestRealCalibrationData:
         data_path = Path("test_data/260225_SN_L10.d")
 
         # Just test the metadata reading function directly
-        with patch.object(BrukerReader, "_validate_data_path"), patch.object(
-            BrukerReader, "_detect_file_type"
-        ), patch.object(BrukerReader, "_setup_components"), patch.object(
-            BrukerReader, "_initialize_sdk"
-        ), patch.object(
-            BrukerReader, "_initialize_database"
-        ), patch.object(
-            BrukerReader, "_preload_frame_num_peaks"
+        with (
+            patch.object(BrukerReader, "_validate_data_path"),
+            patch.object(BrukerReader, "_detect_file_type"),
+            patch.object(BrukerReader, "_setup_components"),
+            patch.object(BrukerReader, "_initialize_sdk"),
+            patch.object(BrukerReader, "_initialize_database"),
+            patch.object(BrukerReader, "_preload_frame_num_peaks"),
         ):
 
             reader = BrukerReader.__new__(BrukerReader)

--- a/tests/unit/readers/test_bruker_reader_phase1.py
+++ b/tests/unit/readers/test_bruker_reader_phase1.py
@@ -32,9 +32,11 @@ class TestBrukerReader:
         mock_sdk_functions.return_value = mock_sdk
         mock_sdk.open_file.return_value = MagicMock()
 
-        with patch.object(Path, "exists", return_value=True), patch.object(
-            Path, "is_dir", return_value=True
-        ), patch("sqlite3.connect") as mock_connect:
+        with (
+            patch.object(Path, "exists", return_value=True),
+            patch.object(Path, "is_dir", return_value=True),
+            patch("sqlite3.connect") as mock_connect,
+        ):
 
             # Mock database connection
             mock_conn = MagicMock()
@@ -78,9 +80,11 @@ class TestBrukerReader:
         mock_sdk.open_file.return_value = MagicMock()
 
         # Mock database connection
-        with patch("sqlite3.connect") as mock_connect, patch.object(
-            Path, "exists", return_value=True
-        ), patch.object(Path, "is_dir", return_value=True):
+        with (
+            patch("sqlite3.connect") as mock_connect,
+            patch.object(Path, "exists", return_value=True),
+            patch.object(Path, "is_dir", return_value=True),
+        ):
 
             mock_conn = MagicMock()
             mock_connect.return_value = mock_conn
@@ -285,9 +289,11 @@ class TestReaderInterface:
         mock_sdk_functions.return_value = mock_sdk
         mock_sdk.open_file.return_value = MagicMock()
 
-        with patch("sqlite3.connect") as mock_connect, patch.object(
-            Path, "exists", return_value=True
-        ), patch.object(Path, "is_dir", return_value=True):
+        with (
+            patch("sqlite3.connect") as mock_connect,
+            patch.object(Path, "exists", return_value=True),
+            patch.object(Path, "is_dir", return_value=True),
+        ):
 
             mock_conn = MagicMock()
             mock_connect.return_value = mock_conn
@@ -323,9 +329,11 @@ class TestIntensityThresholdFiltering:
         mock_sdk_functions.return_value = mock_sdk
         mock_sdk.open_file.return_value = MagicMock()
 
-        with patch("sqlite3.connect") as mock_connect, patch.object(
-            Path, "exists", return_value=True
-        ), patch.object(Path, "is_dir", return_value=True):
+        with (
+            patch("sqlite3.connect") as mock_connect,
+            patch.object(Path, "exists", return_value=True),
+            patch.object(Path, "is_dir", return_value=True),
+        ):
 
             mock_conn = MagicMock()
             mock_connect.return_value = mock_conn
@@ -366,9 +374,11 @@ class TestIntensityThresholdFiltering:
         mock_sdk_functions.return_value = mock_sdk
         mock_sdk.open_file.return_value = MagicMock()
 
-        with patch("sqlite3.connect") as mock_connect, patch.object(
-            Path, "exists", return_value=True
-        ), patch.object(Path, "is_dir", return_value=True):
+        with (
+            patch("sqlite3.connect") as mock_connect,
+            patch.object(Path, "exists", return_value=True),
+            patch.object(Path, "is_dir", return_value=True),
+        ):
 
             mock_conn = MagicMock()
             mock_connect.return_value = mock_conn

--- a/tests/unit/readers/test_mzpeak_reader.py
+++ b/tests/unit/readers/test_mzpeak_reader.py
@@ -189,6 +189,30 @@ class TestNullPairPadding:
             assert not np.isnan(mzs).any()
             assert not np.isnan(intensities).any()
 
+    def test_the_dropped_count_is_per_iteration(self, tmp_path):
+        """Every conversion iterates twice, and the count must not accumulate.
+
+        ``_dropped_points`` was set once in ``__init__`` and only ever
+        incremented, so the second pass logged the sum of both passes --
+        12 dropped points, then 24, then 36 on a third iteration of the
+        same file (issue #238). Cleared as ``iter_spectra`` starts, which
+        also covers a caller that iterates again without ``reset()``.
+        """
+        spectra = grid_spectra(3, 2, n_points=6)
+        archive = build_mzpeak(tmp_path / "counted.mzpeak", spectra, null_pair_after=3)
+
+        counts = []
+        with MzPeakReader(archive) as reader:
+            for _ in range(3):
+                reader.reset()
+                list(reader.iter_spectra())
+                counts.append(reader._dropped_points)
+            list(reader.iter_spectra())  # no reset() at all
+            counts.append(reader._dropped_points)
+
+        assert counts[0] > 0
+        assert counts == [counts[0]] * 4
+
     def test_padding_is_excluded_from_the_mass_axis(self, tmp_path):
         """The axis holds only channels that can take a value."""
         spectra = grid_spectra(2, 1, n_points=6)

--- a/tests/unit/readers/test_progress_bars_quiet.py
+++ b/tests/unit/readers/test_progress_bars_quiet.py
@@ -1,0 +1,74 @@
+"""A reader's own progress bar must be silenceable by the converter.
+
+Every conversion reads the source twice (issue #226), and the converter
+sets ``reader._quiet_mode`` for both passes because it draws its own
+Pre-scan and Scatter bars. A reader whose bar ignores that flag prints it
+twice per conversion, interleaved with the converter's bars and their
+cursor-control codes:
+
+    grep -c "Reading Rapiflex spectra: 100%" rapi_default.log  ->  2
+
+imzML and timsTOF honoured it; solariX, Rapiflex and Waters did not
+(issue #238). Rather than pin those three call sites, this states the
+rule for any reader added later: a progress bar drawn inside a reader's
+own iteration is a bar the converter can turn off.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Iterator, Tuple
+
+import pytest
+
+READERS = Path(__file__).resolve().parents[3] / "thyra" / "readers"
+
+#: Functions whose bars are drawn once per pass over the source.
+ITERATORS = ("iter_spectra", "iter_frame_scans")
+
+
+def _bars() -> Iterator[Tuple[str, str, ast.Call]]:
+    """Every ``tqdm(...)`` a reader draws from one of its iteration methods."""
+    for path in sorted(READERS.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for function in ast.walk(tree):
+            if not isinstance(function, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not any(name in function.name for name in ITERATORS):
+                continue
+            for node in ast.walk(function):
+                if isinstance(node, ast.Call) and (
+                    getattr(node.func, "id", None) == "tqdm"
+                ):
+                    module = path.relative_to(READERS.parent.parent).as_posix()
+                    yield module, function.name, node
+
+
+CASES = list(_bars())
+
+
+def test_the_readers_that_draw_bars_are_the_ones_expected():
+    """A reader dropping its bar entirely would make the rule below vacuous."""
+    modules = {module for module, _fn, _call in CASES}
+    assert modules >= {
+        "thyra/readers/bruker/rapiflex/rapiflex_reader.py",
+        "thyra/readers/bruker/solarix/solarix_reader.py",
+        "thyra/readers/imzml/imzml_reader.py",
+        "thyra/readers/waters/waters_reader.py",
+    }
+
+
+@pytest.mark.parametrize(
+    "module,function,call",
+    CASES,
+    ids=[f"{module.split('/')[-1]}::{fn}" for module, fn, _call in CASES],
+)
+def test_iteration_bars_can_be_disabled(module, function, call):
+    """``disable=`` is what lets ``_quiet_mode`` reach the bar."""
+    keywords = {keyword.arg for keyword in call.keywords}
+    assert "disable" in keywords, (
+        f"{module}:{call.lineno} draws a progress bar in {function}() without "
+        "disable=; the converter's _quiet_mode cannot silence it, so it "
+        "prints once per pass."
+    )

--- a/tests/unit/test_cli_exit_status.py
+++ b/tests/unit/test_cli_exit_status.py
@@ -102,6 +102,35 @@ class TestPartialOutputQuarantine:
         )
         assert (temp_dir / "out.zarr.failed").is_dir()
 
+    def test_an_interrupt_is_quarantined_like_any_other_failure(
+        self, create_minimal_imzml, temp_dir, monkeypatch, runner
+    ):
+        """Ctrl-C is a failed conversion, not a separate kind of exit.
+
+        ``KeyboardInterrupt`` used to propagate past every handler: click
+        printed ``Aborted!``, the partial store stayed where a finished one
+        belongs, the retry was refused with "Output path already exists",
+        and the CSC scratch memmaps -- 330 MB on a small TIMS set with
+        ``--mobility-grid``, 18 GB on a whole slide -- were left behind
+        (issue #245). Verified with a real CTRL_BREAK as well; this pins
+        the exit path it has to reach.
+        """
+        imzml_path, _, _, _ = create_minimal_imzml
+        output_path = temp_dir / "out.zarr"
+
+        def interrupted(*_args, **_kwargs):
+            output_path.mkdir(parents=True)
+            (output_path / "zarr.json").write_text("{}")
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr("thyra.__main__.convert_msi", interrupted)
+
+        result = _invoke(runner, imzml_path, output_path)
+
+        assert result.exit_code == 1, result.output
+        assert not output_path.exists()
+        assert (temp_dir / "out.zarr.failed").is_dir()
+
     def test_quarantine_does_not_overwrite_an_earlier_failure(
         self, create_minimal_imzml, temp_dir, monkeypatch, runner
     ):

--- a/thyra/__main__.py
+++ b/thyra/__main__.py
@@ -1116,31 +1116,39 @@ def main(
         waters_spectrum,
     )
 
-    # Perform conversion
-    success = convert_msi(
-        str(input),
-        str(output),
-        format_type=format,
-        dataset_id=dataset_id,
-        pixel_size_um=pixel_size,
-        handle_3d=handle_3d,
-        z_spacing_um=z_spacing,
-        resampling_config=resampling_config,
-        reader_options=reader_options,
-        include_optical=include_optical,
-        streaming=_parse_streaming_option(streaming),
-        region=region,
-        write_mobility_table=mobility_table,
-        mobility_heatmap=mobility_heatmap,
-        mobility_grid=mobility_grid,
-        mobility_bins=mobility_bins,
-        mobility_min=mobility_min,
-        mobility_max=mobility_max,
-        # Passed only when given: the converter's own default applies
-        # otherwise, and an explicit request is what the lossless-spectrum
-        # check in convert.py reacts to.
-        **({} if msms_table is None else {"msms_table": msms_table}),
-    )
+    # Perform conversion. ``convert_msi`` catches its own interrupt, but
+    # this catches one that lands anywhere else between here and the
+    # quarantine below -- so however the run is stopped, the exit status
+    # and the partial store are the ones the "Exit status" section of
+    # docs/cli.md describes (issue #245).
+    try:
+        success = convert_msi(
+            str(input),
+            str(output),
+            format_type=format,
+            dataset_id=dataset_id,
+            pixel_size_um=pixel_size,
+            handle_3d=handle_3d,
+            z_spacing_um=z_spacing,
+            resampling_config=resampling_config,
+            reader_options=reader_options,
+            include_optical=include_optical,
+            streaming=_parse_streaming_option(streaming),
+            region=region,
+            write_mobility_table=mobility_table,
+            mobility_heatmap=mobility_heatmap,
+            mobility_grid=mobility_grid,
+            mobility_bins=mobility_bins,
+            mobility_min=mobility_min,
+            mobility_max=mobility_max,
+            # Passed only when given: the converter's own default applies
+            # otherwise, and an explicit request is what the lossless-spectrum
+            # check in convert.py reacts to.
+            **({} if msms_table is None else {"msms_table": msms_table}),
+        )
+    except KeyboardInterrupt:
+        logger.error("Interrupted.")
+        success = False
 
     ok = _handle_post_conversion(success, output)
 

--- a/thyra/convert.py
+++ b/thyra/convert.py
@@ -571,6 +571,15 @@ def convert_msi(
         logger.debug("Refusal raised at:\n%s", traceback.format_exc())
         return False
 
+    except KeyboardInterrupt:
+        # The converter catches its own interrupt (BaseMSIConverter.convert);
+        # this covers the steps before it -- opening the reader, detecting
+        # the pixel size -- so wherever Ctrl-C lands the caller gets False
+        # and the CLI's post-conversion step runs. Without it click printed
+        # ``Aborted!`` and no partial store was ever moved aside (#245).
+        logger.error("Conversion interrupted before it started reading.")
+        return False
+
     except Exception as e:
         logger.error(f"Error during conversion: {e}")
         logger.error(f"Detailed traceback:\n{traceback.format_exc()}")

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -1,5 +1,20 @@
 # thyra/converters/spatialdata/base_spatialdata_converter.py
 
+"""The SpatialData write path every converter shares.
+
+**Exceptions are logged as text here, never as objects.** Every
+``logger.warning("...: %s", str(e))`` in this file could read ``e`` and
+render the same line -- but a log record keeps its arguments, a handler
+that keeps records keeps the record, and an exception object drags along
+its traceback, the frames reachable through ``tb_frame.f_back`` and every
+memmap those frames hold. The finalize path builds each table's AnnData
+over the CSC scratch memmaps, so one retained record is enough to keep the
+scratch directory mapped, and Windows will not delete a mapped file: the
+directory survives the conversion and the user is told to remove it by
+hand. pytest's ``caplog`` retains records, and so does Ousia's per-session
+log capture, which is the consumer that met it (issue #249).
+"""
+
 import json
 import logging
 import warnings
@@ -35,6 +50,32 @@ from ...utils.zarr_atomic_write import install_windows_atomic_write_retry
 from ._chunking import image_chunks, table_write_config
 
 logger = logging.getLogger(__name__)
+
+
+#: Axis entries differenced at once by :func:`_bin_width_range`. 32 MB of
+#: float64 at a time; read at call time so a test can shrink it.
+BIN_WIDTH_CHUNK = 1 << 22
+
+
+def _bin_width_range(axis: NDArray[np.float64]) -> Tuple[float, float]:
+    """The narrowest and widest gap between consecutive axis entries.
+
+    Chunked, because the obvious ``np.diff(axis)`` allocates a second
+    array the length of the axis to produce two numbers for a log line --
+    1.6 GB of it on the 200M-bin axis issue #251 measures. Chunks overlap
+    by one entry so no gap falls between two of them.
+    """
+    axis = np.asarray(axis, dtype=np.float64)
+    if axis.size < 2:
+        return 0.0, 0.0
+    low = np.inf
+    high = -np.inf
+    for start in range(0, axis.size - 1, BIN_WIDTH_CHUNK):
+        stop = min(start + BIN_WIDTH_CHUNK + 1, axis.size)
+        widths = np.diff(axis[start:stop])
+        low = min(low, float(widths.min()))
+        high = max(high, float(widths.max()))
+    return low, high
 
 
 @contextmanager
@@ -1172,7 +1213,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             # spectra. But it is not a debug-level event -- the whole
             # point of the block is that a consumer can say where the
             # data came from, so losing it has to be visible in the log.
-            logger.warning("Could not read metadata for uns provenance: %s", e)
+            logger.warning("Could not read metadata for uns provenance: %s", str(e))
             return {}
 
         uns: Dict[str, Any] = {}
@@ -1181,7 +1222,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             self._collect_optional_sections(uns, comp_meta)
             self._collect_region_info(uns)
         except Exception as e:
-            logger.warning("Could not build the full uns provenance block: %s", e)
+            logger.warning("Could not build the full uns provenance block: %s", str(e))
 
         self._collect_msi_metadata_block(uns, comp_meta)
         self._collect_mobility_axis(uns)
@@ -1207,7 +1248,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 try:
                     self._fragmentation_schedule = describe()
                 except Exception as e:  # pragma: no cover - reader-defined
-                    logger.warning("Could not describe the fragmentation: %s", e)
+                    logger.warning("Could not describe the fragmentation: %s", str(e))
                     self._fragmentation_schedule = None
             self._warn_if_precursors_merge()
         return self._fragmentation_schedule
@@ -1273,7 +1314,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 return
             axis = self.reader.get_mobility_axis()
         except Exception as e:  # pragma: no cover - reader-defined
-            logger.warning("Could not describe the mobility axis: %s", e)
+            logger.warning("Could not describe the mobility axis: %s", str(e))
             return
         if axis is None:
             return
@@ -1311,7 +1352,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             if not getattr(self.reader, "has_ion_mobility", False):
                 return None
         except Exception as e:  # pragma: no cover - reader-defined
-            logger.warning("Could not inspect the mobility axis: %s", e)
+            logger.warning("Could not inspect the mobility axis: %s", str(e))
             return None
         if self._common_mass_axis is None:
             logger.warning(
@@ -1327,7 +1368,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 n_spectra=self._get_total_spectra_count(),
             )
         except Exception as e:
-            logger.error("Could not build the mass-mobility heatmap: %s", e)
+            logger.error("Could not build the mass-mobility heatmap: %s", str(e))
             self._mobility_heatmap_block = None
         return self._mobility_heatmap_block
 
@@ -1350,7 +1391,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 return None
             shared = bool(self.reader.has_shared_mobility_axis)
         except Exception as e:  # pragma: no cover - reader-defined
-            logger.warning("Could not inspect the mobility axis: %s", e)
+            logger.warning("Could not inspect the mobility axis: %s", str(e))
             return None
         from .mobility_table import mobility_table_key
 
@@ -1396,7 +1437,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         try:
             measured = mobility_grid_range(self.reader)
         except Exception as e:  # pragma: no cover - reader-defined
-            logger.warning("Could not read the mobility axis values: %s", e)
+            logger.warning("Could not read the mobility axis values: %s", str(e))
             return None
         lower, upper = self._mobility_bounds
         if measured is None and (lower is None or upper is None):
@@ -1415,7 +1456,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 self._mobility_bins,
             )
         except ValueError as e:
-            logger.warning("No mobility-resolved table: %s", e)
+            logger.warning("No mobility-resolved table: %s", str(e))
             return None
         refusal = grid_refusal(self.reader, self._common_mass_axis, grid)
         if refusal is not None:
@@ -1476,7 +1517,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             if not getattr(self.reader, "has_ion_mobility", False):
                 return
         except Exception as e:  # pragma: no cover - reader-defined
-            logger.warning("Could not inspect the mobility axis: %s", e)
+            logger.warning("Could not inspect the mobility axis: %s", str(e))
             return
         if self._common_mass_axis is None:
             return
@@ -1500,7 +1541,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 ),
             )
         except Exception as e:
-            logger.error("Could not scan the mobility spectra: %s", e)
+            logger.error("Could not scan the mobility spectra: %s", str(e))
             if heatmap is not None:
                 self._mobility_heatmap_built = True
                 self._mobility_heatmap_block = None
@@ -1534,7 +1575,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 int(len(obs)),
             )
         except MemoryError as e:
-            logger.warning("No mobility-resolved table: %s", e)
+            logger.warning("No mobility-resolved table: %s", str(e))
             return None
 
     def _new_sibling_scratch(self, prefix: str) -> Path:
@@ -1585,7 +1626,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                     n_grid,
                 )
             except MemoryError as e:
-                logger.warning("No mobility-resolved table: %s", e)
+                logger.warning("No mobility-resolved table: %s", str(e))
         msms = None
         if self._msms_table_key is not None:
             msms = new_msms_accumulator(self.reader, self._common_mass_axis, n_grid)
@@ -1701,7 +1742,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 scratch=scratch,
             )
         except Exception as e:
-            logger.error("Could not build the mobility-resolved table: %s", e)
+            logger.error("Could not build the mobility-resolved table: %s", str(e))
             return None
 
     def _build_msms_sibling(
@@ -1733,7 +1774,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 accumulator=accumulator,
             )
         except Exception as e:
-            logger.error("Could not build the demultiplexed MS/MS table: %s", e)
+            logger.error("Could not build the demultiplexed MS/MS table: %s", str(e))
             return None
 
     @staticmethod
@@ -1762,7 +1803,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         try:
             block = _current_ratio_block(table, summed_key, summed)
         except Exception as e:  # pragma: no cover - defensive
-            logger.debug("Could not compare the mobility marginal: %s", e)
+            logger.debug("Could not compare the mobility marginal: %s", str(e))
             return
         if block is None:
             return
@@ -1825,7 +1866,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         try:
             block = _current_ratio_block(table, summed_key, summed)
         except Exception as e:  # pragma: no cover - defensive
-            logger.debug("Could not compare the demultiplexed current: %s", e)
+            logger.debug("Could not compare the demultiplexed current: %s", str(e))
             return
         if block is None:
             return
@@ -1889,7 +1930,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             )
             uns[MSI_METADATA_UNS_KEY] = meta.to_uns_dict()
         except Exception as e:
-            logger.warning("Could not build the msi_metadata block: %s", e)
+            logger.warning("Could not build the msi_metadata block: %s", str(e))
 
     def _processing_provenance(self) -> List[Any]:
         """The processing steps this conversion performed, oldest first.
@@ -2321,10 +2362,12 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         if self._common_mass_axis is None:
             raise RuntimeError("Common mass axis is None after assignment")
 
-        # Calculate bin sizes for informative logging
-        bin_widths = np.diff(self._common_mass_axis)
-        min_bin_size = np.min(bin_widths) * 1000  # Convert to mDa
-        max_bin_size = np.max(bin_widths) * 1000  # Convert to mDa
+        # Bin sizes for the log line, in chunks. ``np.diff`` over the whole
+        # axis is another float64 array of its length -- 1.6 GB on a 200M
+        # bin axis, allocated for two numbers in one INFO line (#251).
+        min_bin_size, max_bin_size = _bin_width_range(self._common_mass_axis)
+        min_bin_size *= 1000  # Convert to mDa
+        max_bin_size *= 1000
 
         logger.info(
             f"Resampled mass axis created: {len(self._common_mass_axis)} bins, "
@@ -2427,7 +2470,18 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             raise
 
     def _setup_mass_axis(self) -> None:
-        """Set up the common mass axis (resampled or raw)."""
+        """Set up the common mass axis (resampled or raw), and refuse one too wide.
+
+        The width is checked *before* the resampled axis is built, from
+        the bin count the plan resolved. Everything the conversion holds
+        per bin -- the axis, ``total_intensity``, ``avg_spectrum``, the
+        ``var`` frame, the count array, the column pointers -- comes to
+        about 200 bytes, so a wide axis is expensive long before the count
+        array's own 1 GiB ceiling notices: 200M bins on a six-pixel
+        dataset passed that ceiling and took 67.5 GB (issue #251). A raw
+        axis is checked too, after the reader hands it over, since the
+        per-bin structures are still ahead of it.
+        """
         config_status = "SET" if self._resampling_config else "NOT SET"
         logger.info(f"Mass axis mode: resampling_config={config_status}")
         if self._resampling_config:
@@ -2436,6 +2490,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 "Building RESAMPLED mass axis (resampling enabled) - "
                 "will NOT iterate through all spectra"
             )
+            self._refuse_wide_mass_axis(self._resolve_resampling_plan()[3])
             self._build_resampled_mass_axis()
             if self._common_mass_axis is None:
                 raise RuntimeError(
@@ -2462,12 +2517,26 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 raise ConversionRefused(
                     "Common mass axis is empty. Cannot proceed with conversion."
                 )
+            self._refuse_wide_mass_axis(len(self._common_mass_axis))
             logger.info(
                 f"Using raw mass axis with "
                 f"{len(self._common_mass_axis)} unique m/z values"
             )
 
         self._refuse_non_finite_axis()
+
+    def _refuse_wide_mass_axis(self, n_bins: int) -> None:
+        """Refuse a mass axis whose per-bin cost will not fit in memory.
+
+        Raises:
+            ConversionRefused: When the projection exceeds the fraction of
+                free memory a conversion may take.
+        """
+        from .csc_assembly import mass_axis_refusal
+
+        refusal = mass_axis_refusal(int(n_bins))
+        if refusal is not None:
+            raise ConversionRefused(refusal)
 
     def _refuse_non_finite_axis(self) -> None:
         """Refuse a mass axis carrying NaN or infinity.
@@ -3849,7 +3918,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         try:
             essential = self.reader.get_essential_metadata()
         except Exception as e:
-            logger.debug("Could not read coordinate offsets: %s", e)
+            logger.debug("Could not read coordinate offsets: %s", str(e))
             return None
         offsets = getattr(essential, "coordinate_offsets", None)
         if offsets is None:

--- a/thyra/converters/spatialdata/csc_assembly.py
+++ b/thyra/converters/spatialdata/csc_assembly.py
@@ -34,6 +34,14 @@ some other order gets its columns sorted afterwards, a bounded chunk of
 columns at a time (:func:`sort_csc_columns`, which the summed table
 shares), so the stored matrix is canonical either way.
 
+Canonical also means one entry per ``(row, column)``. A caller whose rows
+can repeat a key -- the summed table, whose row is a grid position and
+whose source may hold two spectra for one pixel -- sets
+:attr:`CscAssembly.merge_duplicates`, and :func:`merge_duplicate_entries`
+sums the repeats into one entry the same chunked way. That is what
+``coo_matrix(...).tocsc()`` did for the route this replaced, and it is
+what the tests in ``test_csc_assembly.py`` pin the whole engine against.
+
 :meth:`matrix` wraps the memmaps as a :class:`scipy.sparse.csc_matrix`
 without copying them (index dtypes are chosen up front by scipy's own
 rule so its constructor takes the arrays as they are), and the AnnData
@@ -49,11 +57,13 @@ import shutil
 import tempfile
 import weakref
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, Tuple
 
 import numpy as np
 from numpy.typing import NDArray
 from scipy import sparse
+
+from ...errors import ConversionRefused
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +80,108 @@ MAX_COUNT_BYTES = 1 << 30
 #: hundred megabytes whatever the matrix size.
 SORT_CHUNK_ENTRIES = 16_000_000
 
+#: Process memory one m/z bin of the summed table costs, everything the
+#: conversion builds per bin included. :data:`MAX_COUNT_BYTES` sizes the
+#: 4 B/bin count array alone, and that is 2 percent of the real figure:
+#: around it sit the axis itself and ``total_intensity`` and
+#: ``avg_spectrum`` (8 B/bin each), the ``var`` frame with its index, the
+#: ``indptr`` and the write cursor, and anndata's own copies during the
+#: write. Measured 2026-09-09 with a six-pixel conversion at a forced bin
+#: count, peak working set above the pre-conversion baseline:
+#:
+#: =============  ==================  ==========
+#: bins           peak above baseline bytes/bin
+#: =============  ==================  ==========
+#: 200,000        56 MB               292
+#: 1,000,000      231 MB              243
+#: 2,000,000      429 MB              225
+#: 5,000,000      966 MB              203
+#: 10,000,000     1,802 MB            189
+#: =============  ==================  ==========
+#:
+#: Issue #251 measured 208 B/bin at 20M bins and 337 B/bin at 200M, where
+#: a 6-pixel dataset peaked at 67.5 GB. 200 is the figure those agree on.
+#:
+#: The ``var`` index is over half of it -- 117 B/bin peak at 20M bins --
+#: and that is not something a cheaper construction fixes. Building the
+#: labels as a numpy ``StringDType`` array rather than a Python list was
+#: measured at both 5M and 20M bins: 583 MB against 584 MB, and 2,328 MB
+#: against 2,329 MB. On pandas 3 the index becomes an Arrow-backed ``str``
+#: either way and the peak is the conversion, not the labels. So the cost
+#: is real, it is inherent to a string ``var`` index, and the answer is to
+#: refuse an axis that cannot afford it rather than to shave the index.
+AXIS_BYTES_PER_BIN = 200
+
+#: Fractions of the machine's free memory the projected mass axis may
+#: take before the conversion warns, and before it refuses. Fractions
+#: rather than sizes, for the reason the grid's own guard gives: an axis
+#: that is routine on a workstation is fatal on a laptop.
+AXIS_WARN_FRACTION = 0.25
+AXIS_REFUSE_FRACTION = 0.5
+
+#: What to assume is free when the machine will not say. Generous on
+#: purpose: a guess must never be the thing that refuses a conversion
+#: that would have fitted.
+ASSUMED_FREE_GB = 8.0
+
 _COUNT_DTYPE = np.uint32
+
+
+def available_memory_gb() -> float:
+    """The machine's free memory in GB, or :data:`ASSUMED_FREE_GB`."""
+    try:
+        import psutil
+
+        return float(psutil.virtual_memory().available) / 1024**3
+    except Exception as e:  # pragma: no cover - platform-dependent
+        logger.debug("Could not read available memory: %s", str(e))
+        return ASSUMED_FREE_GB
+
+
+def projected_axis_gb(n_bins: int) -> float:
+    """What a mass axis of this many bins is expected to cost in memory."""
+    return float(n_bins) * AXIS_BYTES_PER_BIN / 1024**3
+
+
+def mass_axis_refusal(
+    n_bins: int, available_gb: Optional[float] = None
+) -> Optional[str]:
+    """Why a mass axis this wide cannot be converted here, or ``None``.
+
+    Asked *before* the axis is materialised, from the bin count the
+    resampling plan resolved, because building it is already expensive:
+    300M bins on a six-pixel dataset were refused in 2.3 s by the count
+    array's own ceiling, but the process had reached 7.44 GB getting
+    there. 200M bins passed that ceiling entirely -- ``span * 4`` is
+    800 MB, under the 1 GiB it allows -- and took 217 s and 67.5 GB
+    (issue #251).
+
+    ``available_gb`` overrides the machine's own answer, for tests.
+    """
+    gb = projected_axis_gb(n_bins)
+    free = available_memory_gb() if available_gb is None else float(available_gb)
+    levers = (
+        "resample to fewer mass bins (--resample-bins) or ask for a wider "
+        "bin (--resample-width-at-mz)"
+    )
+    if gb > free * AXIS_REFUSE_FRACTION:
+        return (
+            f"the mass axis would have {int(n_bins):,} bins, and the "
+            f"structures built per bin are projected to need {gb:.1f} GB "
+            f"({AXIS_BYTES_PER_BIN} bytes per bin, measured) against "
+            f"{free:.1f} GB free, more than the {AXIS_REFUSE_FRACTION:.0%} of "
+            f"free memory a conversion may take; {levers}"
+        )
+    if gb > free * AXIS_WARN_FRACTION:
+        logger.warning(
+            "The mass axis has %s bins, projected to need %.1f GB of the "
+            "%.1f GB free. It will be attempted; %s to make it smaller.",
+            f"{int(n_bins):,}",
+            gb,
+            free,
+            levers,
+        )
+    return None
 
 
 def sort_csc_columns(
@@ -135,6 +246,81 @@ def sort_csc_columns(
         start_col = end_col
 
 
+def merge_duplicate_entries(
+    indices: Any,
+    data: Any,
+    indptr: NDArray[Any],
+    chunk_entries: int = SORT_CHUNK_ENTRIES,
+) -> Tuple[NDArray[np.int64], int]:
+    """Sum entries that repeat a ``(column, row)`` and compact them away.
+
+    ``coo_matrix(...).tocsc()`` -- the conversion this engine replaced --
+    summed duplicate triples, so a pixel measured twice ended up as one
+    row entry holding the sum. Scattering straight into the CSC arrays
+    keeps both, which leaves the stored matrix non-canonical: scipy and
+    dask quietly merge duplicates when they read it, but a consumer that
+    binary-searches ``X/indices`` directly -- an ion-image column reader
+    -- finds one of the two values and no way to know the other exists
+    (issue #241). This restores the summation out of core.
+
+    Each column's rows must already be ascending, which is what
+    :func:`sort_csc_columns` guarantees; equal rows are then adjacent and
+    a chunk's groups are one ``reduceat``. The compaction only ever moves
+    entries left, so it is written into the same arrays in one forward
+    pass, a bounded slice at a time.
+
+    Args:
+        indices: CSC row indices, sorted within each column, modified in
+            place.
+        data: CSC values aligned with ``indices``, modified in place.
+        indptr: Column pointers of the matrix as scattered.
+        chunk_entries: Entries a chunk may hold; column boundaries are
+            never split, so a column larger than this is done on its own.
+
+    Returns:
+        The new column pointers and the surviving non-zero count. The
+        first ``nnz`` entries of ``indices`` and ``data`` are the matrix;
+        what follows them is stale.
+    """
+    indptr = np.asarray(indptr, dtype=np.int64)
+    n_cols = int(indptr.size - 1)
+    counts = np.zeros(n_cols, dtype=np.int64)
+    out = 0
+    start_col = 0
+    while start_col < n_cols:
+        end_col = int(
+            np.searchsorted(indptr, indptr[start_col] + chunk_entries, side="right")
+        )
+        end_col = max(min(end_col - 1, n_cols), start_col + 1)
+        lo, hi = int(indptr[start_col]), int(indptr[end_col])
+        if hi > lo:
+            # Copies, not memmap views: the compaction writes back over
+            # this same range while these are still being read from.
+            rows = np.array(indices[lo:hi], dtype=np.int64)
+            values = np.array(data[lo:hi], dtype=np.float64)
+            column = np.repeat(
+                np.arange(start_col, end_col, dtype=np.int64),
+                np.diff(indptr[start_col : end_col + 1]),
+            )
+            starts = np.empty(hi - lo, dtype=bool)
+            starts[0] = True
+            starts[1:] = (rows[1:] != rows[:-1]) | (column[1:] != column[:-1])
+            group = np.flatnonzero(starts)
+            merged_rows = rows[group]
+            merged_values = np.add.reduceat(values, group)
+            counts[start_col:end_col] = np.bincount(
+                column[group] - start_col, minlength=end_col - start_col
+            )
+            n_new = int(group.size)
+            indices[out : out + n_new] = merged_rows
+            data[out : out + n_new] = merged_values
+            out += n_new
+        start_col = end_col
+    merged_indptr = np.zeros(n_cols + 1, dtype=np.int64)
+    np.cumsum(counts, out=merged_indptr[1:])
+    return merged_indptr, out
+
+
 def index_dtype(n_nonzeros: int, n_rows: int) -> Any:
     """The index dtype scipy would give a CSC matrix of this size.
 
@@ -185,6 +371,13 @@ class CscAssembly:
     :meth:`scatter` must be called for exactly the rows :meth:`count` was,
     in the same order; a row may be handed in more than once when its
     entries come in several disjoint groups (one per precursor, say).
+
+    Those groups being disjoint is the caller's guarantee, not something
+    checked here. A caller that *cannot* give it -- the summed table,
+    whose row is a grid position and whose source may hold two spectra
+    for one pixel -- sets :attr:`merge_duplicates`, and the repeated
+    entries are summed into one when the matrix is handed out, which is
+    what ``coo_matrix(...).tocsc()`` did for the route this replaced.
     """
 
     def __init__(
@@ -204,6 +397,10 @@ class CscAssembly:
         #: Whether every row so far arrived at or after the previous one.
         #: Ascending rows make the scattered columns canonical for free.
         self.rows_in_order = True
+        #: Set by a caller that may hand the same ``(row, key)`` in twice --
+        #: two spectra at one pixel. :meth:`matrix` then sums the repeats
+        #: into one entry instead of storing both.
+        self.merge_duplicates = False
         self._last_row = -1
         self.unique_keys: Optional[NDArray[np.int64]] = None
         self.indptr: Optional[NDArray[Any]] = None
@@ -315,6 +512,13 @@ class CscAssembly:
         count would carry zero-filled entries at row 0, out of order, which
         scipy reports as a non-canonical matrix. The callers guarantee it
         by scattering exactly the rows they counted; this checks.
+
+        Raises:
+            ConversionRefused: When pass 2 scattered fewer entries than
+                pass 1 counted. That is a property of the source and its
+                reader, not of this code, so it is spelled as a refusal
+                like the per-row disagreement the converter checks for
+                (issue #247) rather than as a traceback.
         """
         if self.indptr is None or self._write_pos is None:
             raise RuntimeError("matrix() needs allocate() first")
@@ -322,23 +526,63 @@ class CscAssembly:
             raise RuntimeError("matrix() after release()")
         if not np.array_equal(self._write_pos, self.indptr[1:]):
             short = int(np.count_nonzero(self._write_pos != self.indptr[1:]))
-            raise RuntimeError(
+            raise ConversionRefused(
                 f"{short} columns were counted for more entries than were "
                 "scattered; the two passes disagree on which rows exist"
             )
-        if not self.rows_in_order:
+        if self.merge_duplicates:
+            # The repeats need not have arrived next to each other -- a
+            # coordinate can recur anywhere in the file -- so the columns
+            # are sorted whatever order the rows came in, which is what
+            # puts equal rows side by side for the merge.
+            self._sort_columns()
+            self._merge_duplicates()
+        elif not self.rows_in_order:
             self._sort_columns()
         self._indices.flush()
         self._data.flush()
         n_cols = int(self.indptr.size - 1)
+        nnz = self.n_nonzeros
         return sparse.csc_matrix(
-            (self._data, self._indices, self.indptr), shape=(self.n_rows, n_cols)
+            (self._data[:nnz], self._indices[:nnz], self.indptr),
+            shape=(self.n_rows, n_cols),
         )
+
+    def _merge_duplicates(self) -> None:
+        """Sum the repeated ``(row, key)`` entries into one; see #241.
+
+        Runs after the sort, and leaves the assembly describing the
+        merged matrix: ``indptr`` and ``n_nonzeros`` shrink, the write
+        cursor follows them so the slot check above still holds, and the
+        flag is cleared so a second :meth:`matrix` call is a no-op rather
+        than a second merge.
+        """
+        assert self.indptr is not None and self._indices is not None
+        assert self._data is not None
+        before = self.n_nonzeros
+        merged, nnz = merge_duplicate_entries(
+            self._indices,
+            self._data,
+            self.indptr,
+            chunk_entries=SORT_CHUNK_ENTRIES,
+        )
+        self.indptr = merged.astype(self._index_dtype, copy=False)
+        self._write_pos = merged[1:].copy()
+        self.n_nonzeros = int(nnz)
+        self.merge_duplicates = False
+        if before != nnz:
+            logger.info(
+                "Summed %s entries that repeated a (row, column): %s "
+                "non-zeros remain",
+                f"{before - nnz:,}",
+                f"{nnz:,}",
+            )
 
     def _sort_columns(self) -> None:
         """Put each column's entries in ascending row order, chunk by chunk.
 
-        Only needed when the source handed its rows out of order; see
+        Only needed when the source handed its rows out of order, or when
+        a merge is coming and needs equal rows adjacent; see
         :func:`sort_csc_columns`. The chunk budget is read at call time
         so a test can shrink it through the module constant.
         """

--- a/thyra/converters/spatialdata/fused_passes.py
+++ b/thyra/converters/spatialdata/fused_passes.py
@@ -176,6 +176,18 @@ class SiblingPasses:
                 self.msms.scratch = self.msms_scratch
                 self.msms.allocate(self.msms_scratch)
 
+    def merge_duplicate_rows(self) -> None:
+        """Tell every sink a row may be scattered into more than once.
+
+        The summed table's converter knows which grid positions the
+        source gave two spectra for; those frames reach these sinks
+        twice under the same row as well, so their matrices need the
+        same summation the summed table's does (issue #241).
+        """
+        for sink in (self.discovery, self.msms):
+            if sink is not None:
+                sink.assembly.merge_duplicates = True
+
     # -- pass 2 ----------------------------------------------------------
 
     def scatter(self, frame: FrameScans, row: Optional[int]) -> None:

--- a/thyra/converters/spatialdata/mobility_table.py
+++ b/thyra/converters/spatialdata/mobility_table.py
@@ -56,6 +56,7 @@ from ...errors import ConversionRefused
 from ...resampling.mobility_grid import MobilityGrid
 from .csc_assembly import (
     CscAssembly,
+    available_memory_gb,
     count_refusal,
     release_when_collected,
     remove_scratch,
@@ -428,25 +429,10 @@ VAR_BYTES_PER_FEATURE = 330
 #: Fractions of the machine's free memory the projected ``var`` frame may
 #: take before the conversion warns, and before it refuses. Fractions and
 #: not sizes: a table that is routine on a workstation is fatal on a
-#: laptop, and the same number cannot be right for both.
+#: laptop, and the same number cannot be right for both. The mass axis's
+#: own guard (``csc_assembly.mass_axis_refusal``) uses the same pair.
 GRID_VAR_WARN_FRACTION = 0.25
 GRID_VAR_REFUSE_FRACTION = 0.5
-
-#: What to assume is free when the machine will not say. Generous on
-#: purpose: a guess must never be the thing that refuses a conversion
-#: that would have fitted.
-ASSUMED_FREE_GB = 8.0
-
-
-def available_memory_gb() -> float:
-    """The machine's free memory in GB, or :data:`ASSUMED_FREE_GB`."""
-    try:
-        import psutil
-
-        return float(psutil.virtual_memory().available) / 1024**3
-    except Exception as e:  # pragma: no cover - platform-dependent
-        logger.debug("Could not read available memory: %s", e)
-        return ASSUMED_FREE_GB
 
 
 def projected_var_gb(n_features: int) -> float:

--- a/thyra/converters/spatialdata/msms_table.py
+++ b/thyra/converters/spatialdata/msms_table.py
@@ -149,7 +149,7 @@ def _window_mobility(reader: BaseMSIReader) -> Callable[[Any], float]:
         if axis is not None:
             values = axis.values
     except Exception as e:  # pragma: no cover - reader-defined
-        logger.debug("No mobility axis for the precursor axis: %s", e)
+        logger.debug("No mobility axis for the precursor axis: %s", str(e))
 
     def mobility_of(window: Any) -> float:
         if values is None or not window.is_mobility_resolved:

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -14,6 +14,7 @@
 """
 
 import logging
+import math
 from typing import Any, Dict, Generator, List, Literal, Optional, Tuple, Union
 
 import numpy as np
@@ -24,7 +25,7 @@ from tqdm import tqdm
 from ...errors import ConversionRefused
 from ...resampling import ResamplingMethod
 from .base_spatialdata_converter import SPATIALDATA_AVAILABLE, BaseSpatialDataConverter
-from .csc_assembly import CscAssembly
+from .csc_assembly import CscAssembly, index_dtype
 
 if SPATIALDATA_AVAILABLE:
     import xarray as xr
@@ -73,6 +74,14 @@ class _TableUnit:
         # var is the mass axis, and an empty column is still a bin.
         self.assembly = CscAssembly(n_cols, n_rows=0, keep_empty_columns=True)
         self.occupancy = np.zeros(self.n_grid, dtype=bool)
+        #: Positions the source gave more than one spectrum for. Their
+        #: entries are summed into the one row the position gets, so both
+        #: the row's TIC and pass 2's per-row check have to accumulate
+        #: rather than compare a single spectrum (#241, #247).
+        self.repeats = np.zeros(self.n_grid, dtype=bool)
+        #: Pass 2's running total per repeated position, with the
+        #: coordinate to name if it does not come out as pass 1's.
+        self.observed: Dict[int, Tuple[float, Tuple[int, int, int]]] = {}
         self.tic = np.zeros(tic_shape, dtype=np.float64)
         self.kept_grid: Optional[NDArray[np.int64]] = None
         self.row_of_grid: Optional[NDArray[np.int64]] = None
@@ -83,8 +92,15 @@ class _TableUnit:
     ) -> None:
         """Pass 1: one spectrum at grid position ``grid``."""
         self.assembly.count(grid, mz_indices)
+        if self.occupancy[grid]:
+            # A pixel the source measured twice. One position is one row,
+            # so the two spectra are summed into it -- what the COO route
+            # got from ``coo.tocsc()`` before this engine replaced it --
+            # and the assembly is told the repeats are coming.
+            self.repeats[grid] = True
+            self.assembly.merge_duplicates = True
         self.occupancy[grid] = True
-        self.tic.reshape(-1)[grid] = values.sum()
+        self.tic.reshape(-1)[grid] += values.sum()
 
     def finish_counting(self) -> None:
         """Decide which grid positions become rows, and in what order.
@@ -115,6 +131,87 @@ class _TableUnit:
                 n_dropped,
                 self.n_rows,
             )
+        self.observed = {}
+        n_repeats = int(np.count_nonzero(self.repeats))
+        if n_repeats:
+            logger.warning(
+                "%s: %d pixel position(s) carry more than one spectrum. Their "
+                "spectra are summed into the one row the position has, which "
+                "is what the COO route stored before this one replaced it; "
+                "the TIC image and the row agree on the sum.",
+                self.key,
+                n_repeats,
+            )
+
+    def check_against_pass_one(
+        self,
+        grid: int,
+        coords: Tuple[int, int, int],
+        values: NDArray[np.float64],
+    ) -> None:
+        """Pass 2: refuse unless this position's total is the one pass 1 saw.
+
+        A position the source gives one spectrum for is settled here. One
+        it gives several for cannot be: pass 1 recorded the sum, so the
+        running total is accumulated and
+        :meth:`check_repeated_positions` compares it once the pass is
+        over.
+
+        Raises:
+            ConversionRefused: When the two passes disagree.
+        """
+        total = float(np.sum(values))
+        expected = float(self.tic.reshape(-1)[grid])
+        if self.repeats[grid]:
+            running = self.observed.get(grid, (0.0, coords))[0] + total
+            self.observed[grid] = (running, coords)
+            return
+        if not _passes_agree(total, expected):
+            raise ConversionRefused(_disagreement(self.key, coords, expected, total))
+
+    def check_repeated_positions(self) -> None:
+        """The same check for the positions whose spectra had to be summed.
+
+        Raises:
+            ConversionRefused: When the two passes disagree.
+        """
+        flat = self.tic.reshape(-1)
+        for grid, (total, coords) in self.observed.items():
+            expected = float(flat[grid])
+            if not _passes_agree(total, expected):
+                raise ConversionRefused(
+                    _disagreement(self.key, coords, expected, total)
+                )
+
+
+#: How far pass 2's total for a pixel may sit from pass 1's before the
+#: conversion is refused. The two passes run the same deterministic code
+#: over the same spectrum, so the difference is normally exactly zero;
+#: the tolerance is only there so a reader whose arithmetic is merely
+#: re-associated between iterations is not refused for it. The divergence
+#: this exists to catch was a factor of two.
+PASS_AGREEMENT_RTOL = 1e-9
+
+
+def _passes_agree(observed: float, expected: float) -> bool:
+    """Whether pass 2's total for a pixel is pass 1's."""
+    return math.isclose(observed, expected, rel_tol=PASS_AGREEMENT_RTOL, abs_tol=0.0)
+
+
+def _disagreement(
+    key: str, coords: Tuple[int, int, int], expected: float, observed: float
+) -> str:
+    """What to tell someone whose reader did not repeat itself."""
+    x, y, z = coords
+    return (
+        f"{key}: the two passes over the source disagree at pixel "
+        f"(x={x}, y={y}, z={z}). The pre-scan totalled {expected:.6g} for it "
+        f"and the second pass totalled {observed:.6g}. Every conversion reads "
+        "the source twice and the second read has to reproduce the first "
+        "exactly; a reader whose iteration is not repeatable would otherwise "
+        "write a store whose TIC image and average spectrum describe "
+        "different data from its matrix."
+    )
 
 
 class StreamingSpatialDataConverter(BaseSpatialDataConverter):
@@ -214,59 +311,47 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         """Suppress progress output from reader during the passes."""
         setattr(self.reader, "_quiet_mode", True)
 
-    def _estimate_output_size_gb(self) -> float:
-        """Estimate the output dataset size in GB, for the log line.
+    def _matrix_size_gb(self, units: List[_TableUnit]) -> float:
+        """What the counted matrices come to, uncompressed, in GB.
 
-        Dense size, ``n_pixels * n_mz_bins * 4`` bytes (float32).
+        Not an estimate: the pre-scan has counted every entry by the time
+        this is called, and the matrix is those entries -- eight bytes of
+        value and four or eight of row index each. The store itself is
+        smaller, because zarr compresses it, and a source with repeated
+        coordinates ends with fewer entries than were counted because
+        those are summed into one. Measured on
+        ``TIMS-test-data/02_tiny_longramp_1465px``, converted with the
+        defaults: 9,149,840 non-zeros, 0.10 GB here, 27 MB on disk. So
+        the number is an upper bound, and it is on the right side to be
+        one.
 
-        **Diagnostic only.** Nothing routes on this: there is one route. It
-        is kept because the number is genuinely useful in a support log and
-        because getting it right was not free: the fallback below is wrong
-        in both directions (see the comment in the body), and deleting the
-        function would delete that finding along with the tests that pin
-        it.
+        It replaces an "Estimated output size" line that multiplied the
+        *bounding box* by the bin count as though the matrix were dense
+        and logged 40.3 GB for that dataset -- 2.5 GB for a 7.6 MB store,
+        240.7 GB for a 329 MB one (issue #254). Since the route stopped
+        being chosen by size (design decision D11) that number selected
+        nothing, so the only thing left for it to do was talk somebody out
+        of a conversion they had room for.
+
+        Args:
+            units: The tables, after their pre-scan.
 
         Returns:
-            Estimated size in gigabytes
+            Size in gigabytes.
         """
-        metadata = self.reader.get_essential_metadata()
-
-        # Get dimensions
-        n_x, n_y, n_z = metadata.dimensions
-        n_pixels = n_x * n_y * n_z
-
-        # Prefer the axis that was actually built. ``convert()`` runs
-        # ``_initialize_conversion()`` -- and so ``_setup_mass_axis()`` --
-        # before this is reached, so the real bin count is known and there
-        # is nothing to estimate. That matters most on the raw-axis path,
-        # where the fallback below assumes a 10 mDa spacing that the data
-        # need not have: a continuous file carrying 4,000 points over
-        # 250-1200 m/z was scored as though it had 95,000, and a processed
-        # file whose spectra share no m/z values was scored far too low.
-        # While this drove the routing (issue #87) that mis-sent the
-        # largest datasets to the method that holds the most in memory; it
-        # now only makes the logged number honest.
-        if self._common_mass_axis is not None:
-            n_mz_bins = len(self._common_mass_axis)
-        elif self._resampling_config:
-            # Same resolution path the axis builder will use, so the
-            # reported bin count is the real one.
-            _, _, _, n_mz_bins = self._resolve_resampling_plan()
-        else:
-            min_mass, max_mass = metadata.mass_range
-            n_mz_bins = int((max_mass - min_mass) / 0.01)
-
-        # Dense matrix size in bytes (float32 = 4 bytes)
-        dense_bytes = n_pixels * n_mz_bins * 4
-
-        # Convert to GB
-        size_gb = dense_bytes / (1024**3)
-
+        entry_bytes = 0
+        n_entries = 0
+        for unit in units:
+            nnz = int(unit.assembly.n_nonzeros)
+            n_entries += nnz
+            entry_bytes += nnz * (8 + np.dtype(index_dtype(nnz, unit.n_rows)).itemsize)
+        size_gb = entry_bytes / (1024**3)
         logger.info(
-            f"Estimated output size: {size_gb:.1f} GB "
-            f"({n_pixels:,} pixels x {n_mz_bins:,} m/z bins)"
+            "Matrix: %s non-zero entries over %s rows, %.2f GB uncompressed",
+            f"{n_entries:,}",
+            f"{sum(unit.n_rows for unit in units):,}",
+            size_gb,
         )
-
         return size_gb
 
     # ------------------------------------------------------------------
@@ -373,10 +458,6 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         if self._common_mass_axis is None:
             raise ValueError("Common mass axis is not initialized")
 
-        # Diagnostic only -- nothing below depends on it. After
-        # _initialize_conversion() so it reports the built axis.
-        self._estimate_output_size_gb()
-
         units = self._plan_tables()
         n_cols = len(self._common_mass_axis)
         logger.info(
@@ -482,8 +563,22 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
             unit.assembly.allocate(
                 self._register_table_scratch("summed", unit.assembly)
             )
+
+        self._matrix_size_gb(units)
+
+        # The rows that are written, not the spectra that were read: a
+        # position measured twice is one row, and an empty or out-of-grid
+        # spectrum is none. The root attrs report this as
+        # ``non_empty_pixels``, where it used to be the reader's spectrum
+        # count and so disagreed with the table it described (#241).
+        self._non_empty_pixel_count = sum(unit.n_rows for unit in units)
+
         if passes is not None:
             passes.finish_counting(units[0].n_rows, self._register_table_scratch)
+            if units[0].repeats.any():
+                # A position measured twice is scattered twice into every
+                # table fed from these passes, not just the summed one.
+                passes.merge_duplicate_rows()
 
         logger.info("Step 3/3: Processing spectra and scattering to CSC...")
         self._scatter_pass(data_structures)
@@ -579,9 +674,11 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                 n_z,
             )
 
-        # The other write paths used to set this in their finalize step;
-        # the root attrs builder reads it for msi_dataset_info.
-        self._non_empty_pixel_count = pixel_count
+        # ``pixel_count`` is every spectrum the reader yielded, which is what
+        # the average is over. It is not the table's row count -- an empty
+        # spectrum gets no row, an out-of-grid one gets no row, and a
+        # position measured twice gets one -- so ``non_empty_pixels`` is
+        # set from the rows in _process_spectra rather than from here (#241).
         data_structures["pixel_count"] = pixel_count
         data_structures["avg_spectrum"] = total_intensity / max(pixel_count, 1)
         if region_total is not None:
@@ -598,6 +695,17 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         checks that agreement before it hands the matrix out. With
         ``passes`` it also scatters the sibling tables from the same
         frame read.
+
+        The assembly's check is on *counts*, and counts are not enough. A
+        reader whose second iteration hands back the same number of
+        entries with different values wrote a store in which ``X`` came
+        from pass 2 while the TIC image and ``average_spectrum`` came from
+        pass 1 -- measured, on a probe reader that scaled its values:
+        ``TIC sum=147066`` against ``X.sum=294132``, and nothing said so
+        (issue #247). Pass 1 already recorded each position's total in
+        ``unit.tic``, so pass 2 compares the row it is about to scatter
+        with it and refuses on the first disagreement. That also catches
+        two pixels exchanging spectra, which no count can.
         """
         units: List[_TableUnit] = data_structures["units"]
         passes = data_structures["passes"]
@@ -629,6 +737,7 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                 # the grid, both skipped there) comes back as -1.
                 row = -1
                 if mz_indices.size > 0 and unit is not None:
+                    unit.check_against_pass_one(grid, coords, values)
                     row = int(unit.row_of_grid[grid])
 
                 if frame is not None:
@@ -637,6 +746,9 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                     unit.assembly.scatter(row, mz_indices, values)
 
                 pbar.update(1)
+
+        for unit in units:
+            unit.check_repeated_positions()
 
         logger.info("  Scatter complete")
 

--- a/thyra/core/base_converter.py
+++ b/thyra/core/base_converter.py
@@ -132,6 +132,17 @@ class BaseMSIConverter(ABC):
     def convert(self) -> bool:
         """Template method defining the conversion workflow.
 
+        An interrupt is a failed conversion, not a separate kind of exit.
+        ``KeyboardInterrupt`` is caught here so the caller gets ``False``
+        and the CLI's ``_handle_post_conversion`` runs, renaming the
+        partial store to ``.failed`` and leaving the output path free for
+        a retry -- which is what ``docs/cli.md`` promises of *any* failed
+        conversion. Before this it propagated past ``except Exception``,
+        click printed ``Aborted!``, and an interrupted run left an
+        unopenable store where a finished one belongs, a blocked retry,
+        and (on a whole-slide mobility grid) 18 GB of scratch memmaps
+        nothing came back to remove (issue #245).
+
         Returns:
         --------
         bool: True if conversion was successful, False otherwise.
@@ -158,6 +169,18 @@ class BaseMSIConverter(ABC):
 
             logger.error("%s", str(e))
             logger.debug("Refusal raised at:\n%s", traceback.format_exc())
+            return False
+        except KeyboardInterrupt:
+            # No ``as e``: the exception is cleared when this block ends,
+            # and with it the traceback whose frames still hold the tables
+            # built over the CSC scratch memmaps. Windows will not delete a
+            # mapped file, so letting those frames go here is what lets the
+            # scratch directories go in the converter's own cleanup.
+            logger.error(
+                "Conversion interrupted. Nothing usable was written: any "
+                "partial store is moved aside and the scratch directories "
+                "are removed."
+            )
             return False
         except Exception as e:
             logger.error(f"Error during conversion: {e}")

--- a/thyra/readers/bruker/rapiflex/rapiflex_reader.py
+++ b/thyra/readers/bruker/rapiflex/rapiflex_reader.py
@@ -673,6 +673,7 @@ class RapiflexReader(BrukerBaseMSIReader):
             desc="Reading Rapiflex spectra",
             unit=" spectra",
             dynamic_ncols=True,
+            disable=getattr(self, "_quiet_mode", False),
         )
 
         try:

--- a/thyra/readers/bruker/solarix/solarix_reader.py
+++ b/thyra/readers/bruker/solarix/solarix_reader.py
@@ -549,6 +549,7 @@ class SolarixReader(BrukerBaseMSIReader):
             unit=" spectra",
             total=self._summary["n_spectra"],
             dynamic_ncols=True,
+            disable=getattr(self, "_quiet_mode", False),
         )
         try:
             for spectrum_id, x, y, num_peaks, mz_blob, intensity_blob in pbar:

--- a/thyra/readers/mzpeak/mzpeak_reader.py
+++ b/thyra/readers/mzpeak/mzpeak_reader.py
@@ -586,6 +586,8 @@ class MzPeakReader(BaseMSIReader):
         self._offsets: Optional[Tuple[int, int]] = None
         self._common_axis: Optional[NDArray[np.float64]] = None
         self._announced = False
+        #: Null-pair padding points dropped by the iteration in
+        #: progress; ``iter_spectra`` clears it as it starts.
         self._dropped_points = 0
 
     # ------------------------------------------------------------------
@@ -735,6 +737,14 @@ class MzPeakReader(BaseMSIReader):
                 "mzPeak reads are row-group sized; ignoring batch_size=%s",
                 batch_size,
             )
+
+        # Per iteration, not per reader. Every conversion reads the source
+        # twice (issue #226), and a counter carried across the passes made
+        # the second pass report the sum of both -- 12 dropped points, then
+        # 24, then 36 on a third iteration of the same file. Resetting here
+        # rather than in ``reset()`` also covers a caller that iterates
+        # again without one.
+        self._dropped_points = 0
 
         data = self.archive.parquet("spectrum", "data_arrays")
         positioned = {

--- a/thyra/readers/waters/waters_reader.py
+++ b/thyra/readers/waters/waters_reader.py
@@ -758,7 +758,12 @@ class WatersReader(BaseMSIReader):
 
         total = sum(ml.get_number_of_scans_in_function(handle, f) for f in ms_functions)
 
-        with tqdm(total=total, desc="Reading spectra", unit="spectrum") as pbar:
+        with tqdm(
+            total=total,
+            desc="Reading spectra",
+            unit="spectrum",
+            disable=getattr(self, "_quiet_mode", False),
+        ) as pbar:
             for func in ms_functions:
                 n_scans = ml.get_number_of_scans_in_function(handle, func)
                 for scan in range(n_scans):


### PR DESCRIPTION
Batch 3 of the 2026-09-08 robustness sweep, closing the whole milestone:
what the second pass may hand the assembly, what cleanup owes on the way
out, and two numbers that were wrong by orders of magnitude.

Merging this releases nothing (see `docs/contributing.md`, "Releases are
batched, not per-merge").

## A. What pass 2 is allowed to hand the assembly

### #241 duplicate coordinates -- **decided: sum, do not refuse**

The brief left this open. `tests/unit/converters/test_csc_assembly.py`
already states the engine's contract as "whatever it writes through its
two passes must be the matrix `coo_matrix(...).tocsc()` would have built
from the same triples", and `tocsc()` sums duplicate triples. So the two
`(row, col)` entries are a regression against the module's own stated
contract rather than a policy question, and summing keeps converting the
processed imzML files that have converted for the project's whole history.

`merge_duplicate_entries()` does it out of core -- sort the columns, sum
equal `(col, row)` with one `reduceat` per chunk, compact left, rebuild
`indptr` -- and runs only when the converter saw a position twice. It is
pinned against `coo.tocsc()` on random matrices with repeats scattered
through them, at chunk sizes down to one column at a time. The TIC image
now accumulates, and `non_empty_pixels` is the row count rather than the
reader's spectrum count, so both agree with `X`.

Measured on the synthetic raster from the issue (3x2 plus one extra
spectrum at the pixel (1,0), on m/z values that pixel already carries):

| | before | after |
|---|---|---|
| stored nnz | 22 | 20 |
| canonical | `False` | `True` |
| columns with a repeated row | `[14, 30]` | `[]` |
| TIC(1,0) vs X row sum | 3.0 vs 8493.3 | 8493.3 vs 8493.3 |
| `non_empty_pixels` (6 pixels) | 7 | 6 |

### #247 a value-divergent second pass

Pass 1 records each position's total, so pass 2 compares the row it is
about to scatter and refuses on the first disagreement, naming the pixel.
The probe reader that scaled its values wrote a store with `TIC
sum=53364.9` against `X.sum=106729.7`; it is now refused with

> `m_z0: the two passes over the source disagree at pixel (x=0, y=0, z=0).
> The pre-scan totalled 1614.82 for it and the second pass totalled
> 3229.65. ...`

Two pixels exchanging spectra is caught too, which no count can. Pass 1
already summed each spectrum for the TIC, so pass 2 doing the same costs
nothing measurable: best of three on `TIMS-test-data/02_tiny_longramp_1465px`,
**23.05 s with the check against 23.28 s with it stubbed out**.

## B. Cleanup on the way out

### #245 Ctrl-C

`KeyboardInterrupt` now takes the same exit path as any failure.
**Verified with a real interrupt**, not a unit test on the handler --
`SIGBREAK` with `default_int_handler` installed, which is what Ctrl-C
does (plain `CTRL_BREAK` terminates the process instead, and one such run
deadlocked in process teardown; that is not what a user's Ctrl-C sends).
On `02_tiny_longramp_1465px --mobility-grid`:

| interrupt at | before | after |
|---|---|---|
| the table build | exit `0xC000013A`, 330 MB of scratch left | exit 1, output parent empty |
| inside `sdata.write` | process hung, killed after 300 s | exit 1, store moved to `.failed`, no scratch |

A retry on the same path then succeeds, which is what `docs/cli.md`
promises and did not deliver.

### #249 the retained-record leak

19 sites logged exception *objects*; the record holds the exception, the
exception its traceback, the traceback the frames that reach the AnnData
over the memmaps, and Windows will not delete a mapped file. Reproduced
and fixed:

```
StreamHandler (control)           leaked=[]
record-retaining handler          leaked=['.thyra_summed_my7e7l5x']   <- before
record-retaining handler          leaked=[]                           <- after
```

All 21 sites in the package log `str(e)`, the rule is in the module
docstring, and a test asserts no `thyra` record carries a `BaseException`
in its args.

## C. Numbers that were wrong by orders of magnitude

### #251 the memory guard

The old ceiling sized the 4 B/bin count array, which is 2 percent of the
real cost. Measured here with a six-pixel conversion at a forced bin
count, peak working set above baseline:

| bins | peak | bytes/bin |
|---|---|---|
| 200,000 | 56 MB | 292 |
| 1,000,000 | 231 MB | 243 |
| 2,000,000 | 429 MB | 225 |
| 5,000,000 | 966 MB | 203 |
| 10,000,000 | 1,802 MB | 189 |

The issue measured 208 B/bin at 20M and 337 B/bin at 200M. The guard uses
200 B/bin against the machine's free memory -- refuse past half, warn past
a quarter -- the same shape as the mobility grid's own guard, and it runs
*before* the axis is materialised.

**The issue's other suggestion does not hold up.** Building the `var`
index as a numpy `StringDType` array rather than a Python list was
measured at 5M and 20M bins: 583 MB against 584 MB, and 2,328 MB against
2,329 MB. On pandas 3 the index becomes an Arrow-backed `str` either way
and the peak is the conversion, not the labels. Recorded in the constant's
docstring so nobody re-derives it. The `np.diff()` over the whole axis
(1.6 GB at 200M bins, for two numbers in one log line) is gone.

### #254 the size estimate -- **decided: report the real number**

`total_peaks` would still be badly wrong for a TDF under `scan_sum` (raw
peaks against a scan-summed store), so rather than swap one wrong estimate
for another the dense line is dropped and the counted non-zeros are
reported once the pre-scan has them -- before the write, which is where
disk space matters.

```
before:  Estimated output size: 40.3 GB (513,339 pixels x 21,072 m/z bins)
after:   Matrix: 9,149,840 non-zero entries over 1,465 rows, 0.10 GB uncompressed
store on disk: 27 MB
```

## D. Two-pass leftovers (#238)

`MzPeakReader`'s null-pair counter is per iteration rather than per
reader. The solariX, Rapiflex **and Waters** spectrum bars take `disable=`
like imzML and timsTOF -- Waters had the same defect and is not in the
issue. A structural test states the rule for any reader added later
instead of pinning the three call sites.

## Also

The count-based half of the pass disagreement raised `RuntimeError`, so it
reached the user as a traceback; it is a `ConversionRefused` now, like
every refusal batch 2 established the convention for.

## Verification

- `pytest` **2454 passed, 13 skipped, 0 failed** (2283 on `main` before
  this branch, so 171 new tests and no pre-existing failures in this
  environment).
- `pytest -m integration` **54 passed, 11 skipped, 0 failed**, same as
  `main`.
- `pre-commit run --all-files` clean, except `test_bruker_calibration.py`
  and `test_bruker_reader_phase1.py`, which black wants to reformat and no
  batch has touched.
- #241 and #247 inspected through the stored `X/indices`, `X/data` and
  `X/indptr`, not through `read_zarr` -- scipy and dask merge duplicates on
  read, which is why the defect was invisible.

Closes #238
Closes #241
Closes #245
Closes #247
Closes #249
Closes #251
Closes #254
