### PR TITLE
fix(convert): per-table average, refuse an empty store, per-axis pitch

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -28,10 +28,20 @@ thyra [OPTIONS] INPUT OUTPUT
 | `2` | Invalid command-line arguments (click usage error) |
 
 A refusal Thyra planned for -- a `.d` directory with no analysis files, a
-Waters raster whose stage never moved, a mass range with no extent -- prints
-its message once at `ERROR` and nothing else. The traceback behind it is kept
-for `-v DEBUG`, and a traceback at `ERROR` now means an exception nobody
-planned for, which is worth reporting as a bug.
+Waters raster whose stage never moved, a mass range with no extent, a source
+in which no pixel carries a spectrum -- prints its message once at `ERROR` and
+nothing else. The traceback behind it is kept for `-v DEBUG`, and a traceback
+at `ERROR` now means an exception nobody planned for, which is worth reporting
+as a bug.
+
+A conversion that would store **nothing** is one of those failures. If no
+position carries a spectrum -- an all-zero source, every spectrum empty,
+every peak outside a narrowed `--resample-min-mz`/`--resample-max-mz` range,
+every coordinate off the declared grid -- the conversion exits `1` and
+leaves no store, rather than exiting `0` with a zarr holding no table. The
+message names which of those happened. A multi-slice source with *some*
+empty planes is not affected: those planes are dropped with a warning and
+the rest of the store is written.
 
 A failed conversion renames any partially written store to
 `<output>.zarr.failed`, so the output path stays free for a retry and an
@@ -53,7 +63,7 @@ thyra input.imzML output.zarr && python analyse.py output.zarr
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--format [spatialdata]` | `spatialdata` | Output format |
-| `--pixel-size FLOAT` | auto-detect | Pixel size in micrometers |
+| `--pixel-size FLOAT` | auto-detect | Pixel size in micrometers, applied to **both** axes. Auto-detection keeps the source's own x and y pitch separately, so an anisotropic raster stays anisotropic; passing this declares it square |
 | `--region TEXT` | all | Convert one region, by `.mis` Area Name or by DB RegionNumber. Checked against the dataset's own region list whether it has one region or several; a value that matches no Area Name is read as a RegionNumber, and says so |
 | `--resample / --no-resample` | enabled | Mass axis resampling |
 | `--include-optical / --no-optical` | enabled | Include optical images in output |
@@ -474,7 +484,7 @@ thyra synapt_run.raw output.zarr --waters-spectrum profile
 |--------|---------|-------------|
 | `--dataset-id TEXT` | `msi_dataset` | Dataset identifier used in element keys. Letters, digits, underscores, dots and hyphens only, and not `.`, `..` or a leading `__`: it names every element in the store, so SpatialData's naming rule applies to it. Checked before any pass over the source |
 | `--handle-3d` | off | Process as 3D volume instead of 2D slices |
-| `--z-spacing FLOAT` | in-plane pixel size | Distance between consecutive slices, in um. Only used with `--handle-3d` |
+| `--z-spacing FLOAT` | in-plane pixel size (x) | Distance between consecutive slices, in um. Only used with `--handle-3d` |
 
 ### Examples
 
@@ -497,10 +507,11 @@ apart consecutive slices are: that distance is set by the microtome that cut the
 sections, not by the stage that rastered them, and the two match only by
 coincidence.
 
-With no `--z-spacing`, Thyra reuses the in-plane pitch, warns, and records
-`z_spacing_source: "assumed_isotropic"` in the store so the guess stays
-distinguishable from a measurement. The volume's voxel values are unaffected
-either way — what is wrong is its depth, so a viewer reading it in micrometres
+With no `--z-spacing`, Thyra reuses the in-plane pitch (the x one, when the
+raster is anisotropic and there is no single in-plane pitch to reuse), warns,
+and records `z_spacing_source: "assumed_isotropic"` in the store so the guess
+stays distinguishable from a measurement. The volume's voxel values are
+unaffected either way — what is wrong is its depth, so a viewer reading it in micrometres
 renders the stack squashed or stretched along z.
 
 There is no way to detect this from the data. imzML has no term for slice

--- a/docs/coordinate-systems.md
+++ b/docs/coordinate-systems.md
@@ -119,14 +119,19 @@ When there is no optical photo to align against, the only naturally
 meaningful frame is **physical micrometers of the imaged tissue**.
 
 - TIC / ion images: stored intrinsically in raster pixel indices,
-  with a transform ``Scale([pixel_size_um, pixel_size_um])`` to
+  with a transform ``Scale([pixel_size_x_um, pixel_size_y_um])`` to
   ``"global"``.
 - Pixel-polygon shapes: stored intrinsically in micrometers
-  (``spatial_x = x * pixel_size_um``), with ``Identity`` to
-  ``"global"``.
+  (``spatial_x = x * pixel_size_x_um``, ``spatial_y = y *
+  pixel_size_y_um``), with ``Identity`` to ``"global"``.
 - ``zarr.attrs["coordinate_systems"]["global"]`` declares
   ``unit="micrometer"`` and fills ``pixel_size_um_x/y`` with the
   MSI grid pixel size.
+
+The two pitches are equal on a square raster and are *not* assumed to be:
+an anisotropic acquisition (a DESI method with ``DesiXStep !=
+DesiYStep``) scales each axis by its own, here and in every other block
+of the store that states a pitch.
 
 Both elements resolve to the same micrometer extent at ``"global"``.
 
@@ -140,7 +145,7 @@ So a volume's elements agree like this:
 
 | Element | x, y at ``"global"`` | z at ``"global"`` |
 |---------|---------------------|-------------------|
-| TIC volume | ``Scale([pixel_size_um, pixel_size_um])`` | ``Scale([z_spacing_um])`` |
+| TIC volume | ``Scale([pixel_size_x_um, pixel_size_y_um])`` | ``Scale([z_spacing_um])`` |
 | Table | ``spatial_x``, ``spatial_y`` | ``spatial_z`` |
 | Pixel shapes | micrometres, ``Identity`` | **absent** — join via ``spatial_z`` |
 

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1061,3 +1061,73 @@ moot twice over: the only writer of CSR was in-memory.
 string index it carries is built by pandas at about 125 bytes per bin: a
 raw, unresampled axis of millions of bins is the one thing that still
 scales with the source, and it is the case to resample.
+
+---
+
+## D12. An anisotropic raster is carried, not refused
+
+**Status:** Implemented (2026-09-09), issue #228.
+
+**Decision.** When a source declares a different pitch on each axis, the
+store carries both — root attrs, `coordinate_systems.global` and its
+`raster_to_global_affine`, the image and shapes transforms, the pixel
+footprints, `obs["spatial_x"]`/`["spatial_y"]` and the `msi_metadata`
+block. Thyra does not refuse the acquisition, and `--pixel-size` keeps its
+meaning of one number applied to both axes.
+
+**The defect this replaces.** The converter carried a single float. Pixel
+size detection kept the source's x pitch (`# Use X size`), the root attrs
+wrote that same value as `pixel_size_y_um`, and it went on into the affine
+and the footprints; only `msi_metadata.ms_analysis.pixel_size_um` read the
+true pair back out of the detection info. A raster acquired at 30 x 50 um
+was stored as 30 x 30 in one block and (30, 50) in another. So the store
+contradicted itself and rendered squashed by y/x.
+
+**Why not refuse.** Refusing was the alternative the issue named, and it
+loses on both counts that decide it:
+
+- *The format is already per-axis.* `pixel_size_um` is `{x, y}` and
+  **required** by the metadata schema, mapped to `IMS:1000046` and
+  `IMS:1000047`. Nothing needed adding and no schema version moves; the
+  converter was the only thing carrying one number where the format
+  carries two. Refusing would have been declining to write a store the
+  format already describes.
+- *The only escape would be a false statement.* `--pixel-size` overrides
+  detection with one number on both axes, so the way out of a refusal
+  would be to declare a 30 x 50 um raster square. That is a worse store
+  than the one the refusal was protecting against, because nothing in it
+  records that a number was invented.
+
+**What it cost.** `self.pixel_size_um` had 31 call sites across
+`base_spatialdata_converter.py`, `streaming_converter.py` and
+`core/base_converter.py`, and each had to be read to decide which axis it
+meant. Most are x, or a single number that is written twice. Eleven meant
+y and now take `pixel_size_y_um`: the root attrs, `pixel_size_um_y` and
+the `raster_to_global_affine`, `stage_offset_um`, the optical-to-micrometre
+scale matrix, the half-pixel footprint, `obs["spatial_y"]` on all three obs
+builders, and the TIC image's `Scale` on the plane and volume paths. Two
+provenance echoes gained a `pixel_size_y_um` key beside the x one. Two were
+judgement calls:
+
+- *`_resolve_z_spacing`'s fallback* ("nobody said, so reuse the in-plane
+  pitch") takes x. There is no single in-plane pitch on an anisotropic
+  raster and the choice is arbitrary — which is the point, since nothing
+  about the raster predicts the section thickness either way, and
+  `z_spacing_source` already marks the number as assumed rather than
+  measured.
+- *`stage_offset_um`* multiplies the source's raw acquisition-index
+  offsets by the pitch, so each offset takes its own axis.
+
+**The tolerance.** The anisotropy is reported in the log only when the two
+pitches differ by more than float noise (`rel_tol=1e-9`). Nothing is
+refused, so the tolerance decides a log line rather than whether a file
+converts. It is deliberately tight: a real anisotropy is a percent or
+more, and the near-misses a detector used to produce were not noise but a
+bug — until issue #217 the Waters extractor returned 29.66 x 28.93 for
+every square raster, which this code would have carried faithfully into
+the affine. That is fixed at the extractor, which is where it belonged.
+
+**Known limit.** No dataset in the registry is anisotropic, so this is
+tested synthetically: a reader is asked for a 30 x 50 um pitch and the
+written store is read back. A DESI method with `DesiXStep != DesiYStep`
+would be the first real case, and nothing here has been run against one.

--- a/docs/metadata-schema.md
+++ b/docs/metadata-schema.md
@@ -78,7 +78,11 @@ is readable without resolving anything.
 
 `pixel_size_um` is the one acquisition field that is required: conversion
 refuses to run without a pixel size, so a document without it describes no
-store Thyra ever wrote.
+store Thyra ever wrote. It is a pair because a raster need not be square, and
+the same pair now reaches the rest of the store -- the root attrs, the
+coordinate system and its affine, the element transforms and
+`obs["spatial_x"]`/`["spatial_y"]`. This block used to be the only place the y
+pitch survived.
 
 !!! note "Unknown fields are rejected"
     Validation refuses keys the schema does not define, so a typo fails

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -144,10 +144,28 @@ plt.title("Average Mass Spectrum")
 plt.show()
 ```
 
-It is the **mean over the acquired spectra** -- the intensity summed down the
-m/z axis and divided by the number of pixels that carry a spectrum, not by the
-number of grid positions. Every write path stores it on that scale, including
-the 3D volume path, which previously stored the undivided sum here.
+It is **that table's own `X.mean(axis=0)`** -- the intensity summed down the
+m/z axis and divided by the rows the table holds, not by the grid positions it
+covers and not by the spectra the reader handed in. Read it off the matrix and
+you get the same numbers back:
+
+```python
+import numpy as np
+
+X = msi_table.X.toarray() if hasattr(msi_table.X, "toarray") else msi_table.X
+np.allclose(msi_table.uns["average_spectrum"], X.mean(axis=0))   # True
+```
+
+Two consequences of "rows, not spectra". A grid position the acquisition never
+reached has no row and so is in neither the sum nor the count. A position the
+source measured **twice** has one row holding the sum of both spectra, so it
+contributes two spectra of ion current over one row -- which is what that row
+really holds.
+
+On a multi-slice source converted as 2D each plane's table carries **its own**
+mean. They used to all carry one dataset-wide vector, so a plane brighter or
+dimmer than the average was described by a spectrum that was not its own; the
+3D volume path had the same key fixed a release earlier.
 
 ### Per-Region Average Spectrum
 
@@ -167,9 +185,20 @@ if "average_spectrum_per_region" in msi_table.uns:
     plt.show()
 ```
 
+Each region's vector is the mean of the rows in that region, on the same
+"rows, not spectra" rule as `average_spectrum`.
+
 !!! note
     This key is only present when the dataset contains multiple acquisition
     regions. Single-region datasets only have the global `average_spectrum`.
+
+!!! note "Regions span the slices"
+    A region is an in-plane footprint: `get_region_map()` is keyed on `(x, y)`
+    and has no z component, so on a multi-slice store one region covers the
+    same area on every plane. `average_spectrum_per_region` is therefore
+    **dataset-wide** and identical in every plane's table, while
+    `average_spectrum` beside it is that plane's alone. On the single-table
+    stores that regions actually occur on, the two are over the same rows.
 
 ### Intensity Matrix
 
@@ -915,7 +944,10 @@ Stored in `sdata.attrs`:
 
 ```python
 if "pixel_size_x_um" in sdata.attrs:
-    print(f"Pixel size: {sdata.attrs['pixel_size_x_um']} um")
+    print(
+        f"Pixel size: {sdata.attrs['pixel_size_x_um']} x "
+        f"{sdata.attrs['pixel_size_y_um']} um"
+    )
 
 if "msi_dataset_info" in sdata.attrs:
     info = sdata.attrs["msi_dataset_info"]
@@ -1078,5 +1110,20 @@ print(f"  m/z bins: {msi_table.n_vars:,}")
 print(f"  m/z range: {mz_values.min():.2f} -- {mz_values.max():.2f}")
 print(f"  Sparsity: {(1 - X.nnz / (X.shape[0] * X.shape[1])) * 100:.1f}%")
 if "pixel_size_x_um" in sdata.attrs:
-    print(f"  Pixel size: {sdata.attrs['pixel_size_x_um']} um")
+    print(
+        f"  Pixel size: {sdata.attrs['pixel_size_x_um']} x "
+        f"{sdata.attrs['pixel_size_y_um']} um"
+    )
 ```
+
+!!! note "Read both axes"
+    `pixel_size_x_um` and `pixel_size_y_um` are equal on a square raster,
+    which is nearly every acquisition -- but a DESI method with
+    `DesiXStep != DesiYStep` is not square, and the store carries the real
+    pitch on each axis in every block that states one: these attrs,
+    `coordinate_systems.global` and its `raster_to_global_affine`, the image
+    and shapes transforms, `obs["spatial_x"]`/`["spatial_y"]`, the pixel
+    footprints and `msi_metadata.ms_analysis.pixel_size_um`. Reading only
+    `pixel_size_x_um` as *the* pixel size renders such a raster squashed by
+    y/x. Pass `--pixel-size` to declare the raster square instead, which
+    applies one number to both axes.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -131,14 +131,19 @@ settable with `--dataset-id`, and `_z0` marking the first z-slice):
 Confirm the pixel size survived the round trip:
 
 ```python
-print(sdata.attrs["pixel_size_x_um"], sdata.attrs["pixel_size_units"])
+print(sdata.attrs["pixel_size_x_um"], sdata.attrs["pixel_size_y_um"])
+print(sdata.attrs["pixel_size_units"])
 print(sdata.attrs["pixel_size_detection_info"]["method"])
 ```
 
 ```
-25.0 micrometers
+25.0 25.0
+micrometers
 automatic
 ```
+
+The two are equal here because this raster is square. They are stored
+separately because not every raster is.
 
 ### Step 4: The intensity matrix
 

--- a/tests/unit/converters/test_anisotropic_pixel_size.py
+++ b/tests/unit/converters/test_anisotropic_pixel_size.py
@@ -1,0 +1,278 @@
+# tests/unit/converters/test_anisotropic_pixel_size.py
+"""One pitch per axis, in every block of the store that states one.
+
+An anisotropic raster -- a DESI method with ``DesiXStep != DesiYStep`` --
+used to be written down twice with two different answers. ``convert.py``
+kept only the detected x pitch (``# Use X size``), the root attrs wrote
+that same value as ``pixel_size_y_um``, and the single float went into
+``coordinate_systems.global``, the image and shapes transforms and
+``obs["spatial_x"]``/``["spatial_y"]``; only
+``msi_metadata.ms_analysis.pixel_size_um`` carried the true ``(x, y)``.
+With a detected 30 x 50 um the store said 30 x 30 in one place and
+(30, 50) in another, and the raster rendered squashed by y/x (issue #228).
+
+The schema was already per-axis -- ``pixel_size_um`` is ``{x, y}`` and
+required, mapped to IMS:1000046 and IMS:1000047 -- so the fix is the
+converter reading both halves back, not a format change. These assertions
+are on the *stored artefacts* rather than on a helper's return value,
+because the defect was that those artefacts disagreed with each other.
+
+No registry dataset is anisotropic, so the pitch here is synthetic: the
+reader is asked for one, exactly as ``convert.py`` asks a real Waters or
+DESI extractor.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import spatialdata
+from spatialdata.transformations import get_transformation
+
+from tests.fixtures.mock_msi_generator import MockMSIConfig, MockMSIReader
+from thyra.converters.spatialdata.streaming_converter import (
+    SPATIALDATA_AVAILABLE,
+    StreamingSpatialDataConverter,
+)
+from thyra.core.base_converter import PixelSizeSource
+from thyra.metadata.schema import MSI_METADATA_UNS_KEY
+
+pytestmark = pytest.mark.skipif(
+    not SPATIALDATA_AVAILABLE,
+    reason="SpatialData dependencies not available",
+)
+
+N_X, N_Y = 3, 2
+PITCH_X, PITCH_Y = 30.0, 50.0
+KEY = "m_z0"
+
+
+def _config() -> MockMSIConfig:
+    return MockMSIConfig(
+        n_x=N_X,
+        n_y=N_Y,
+        n_z=1,
+        n_mz_bins=64,
+        peaks_per_spectrum=(3, 5),
+        seed=3,
+    )
+
+
+class _AnisotropicReader(MockMSIReader):
+    """A source whose essential metadata declares 30 x 50 um."""
+
+    def get_essential_metadata(self):
+        essential = super().get_essential_metadata()
+        object.__setattr__(essential, "pixel_size", (PITCH_X, PITCH_Y))
+        return essential
+
+
+def _detection_info() -> dict:
+    """What ``convert.py`` builds when auto-detection succeeds."""
+    return {
+        "method": "automatic",
+        "detected_x_um": PITCH_X,
+        "detected_y_um": PITCH_Y,
+        "source_format": "mock",
+        "detection_successful": True,
+    }
+
+
+def _convert(output: Path, **kwargs) -> Path:
+    """The CLI's own construction: the x pitch plus the detected pair."""
+    converter = StreamingSpatialDataConverter(
+        reader=MockMSIReader(_config()),
+        output_path=output,
+        dataset_id="m",
+        pixel_size_um=PITCH_X,
+        pixel_size_source=PixelSizeSource.AUTO_DETECTED,
+        pixel_size_detection_info=_detection_info(),
+        include_optical=False,
+        **kwargs,
+    )
+    assert converter.convert() is True
+    return output
+
+
+def _root_attrs(store: Path) -> dict:
+    doc = json.loads((store / "zarr.json").read_text())
+    return doc.get("attributes", {}) or {}
+
+
+@pytest.fixture(scope="module")
+def store(tmp_path_factory) -> Path:
+    return _convert(tmp_path_factory.mktemp("aniso") / "out.zarr")
+
+
+class TestTheStoredArtefactsAgree:
+    """Every block that states a pitch states the same pair."""
+
+    def test_root_attrs_carry_both_pitches(self, store):
+        attrs = _root_attrs(store)
+        assert attrs["pixel_size_x_um"] == PITCH_X
+        assert attrs["pixel_size_y_um"] == PITCH_Y
+
+    def test_the_coordinate_system_carries_both_pitches(self, store):
+        cs = _root_attrs(store)["coordinate_systems"]["global"]
+        assert cs["unit"] == "micrometer"
+        assert cs["pixel_size_um_x"] == PITCH_X
+        assert cs["pixel_size_um_y"] == PITCH_Y
+
+    def test_the_raster_affine_is_not_square(self, store):
+        affine = _root_attrs(store)["coordinate_systems"]["global"][
+            "raster_to_global_affine"
+        ]
+        np.testing.assert_allclose(
+            affine,
+            [[PITCH_X, 0.0, 0.0], [0.0, PITCH_Y, 0.0], [0.0, 0.0, 1.0]],
+        )
+
+    def test_the_image_transform_scales_each_axis_by_its_own_pitch(self, store):
+        sdata = spatialdata.SpatialData.read(str(store))
+        image = sdata.images[f"{KEY}_tic"]
+        matrix = get_transformation(
+            image, to_coordinate_system="global"
+        ).to_affine_matrix(input_axes=("x", "y"), output_axes=("x", "y"))
+        assert matrix[0, 0] == PITCH_X
+        assert matrix[1, 1] == PITCH_Y
+
+    def test_obs_positions_use_each_axis_pitch(self, store):
+        table = spatialdata.SpatialData.read(str(store)).tables[KEY]
+        np.testing.assert_allclose(
+            table.obs["spatial_x"].values, table.obs["x"].values * PITCH_X
+        )
+        np.testing.assert_allclose(
+            table.obs["spatial_y"].values, table.obs["y"].values * PITCH_Y
+        )
+
+    def test_the_pixel_footprints_are_not_square(self, store):
+        shapes = spatialdata.SpatialData.read(str(store)).shapes[f"{KEY}_pixels"]
+        xmin, ymin, xmax, ymax = shapes.geometry.iloc[0].bounds
+        assert xmax - xmin == pytest.approx(PITCH_X)
+        assert ymax - ymin == pytest.approx(PITCH_Y)
+
+    def test_the_metadata_block_still_carries_the_pair(self, store):
+        """The one block that was right before, and must stay right."""
+        table = spatialdata.SpatialData.read(str(store)).tables[KEY]
+        block = table.uns[MSI_METADATA_UNS_KEY]
+        assert block["ms_analysis"]["pixel_size_um"] == {"x": PITCH_X, "y": PITCH_Y}
+
+    def test_the_shapes_span_the_image_extent(self, store):
+        """The contract the issue's "squashed by y/x" broke.
+
+        The footprints are in micrometres and the image is scaled into
+        them, so the two describe the same rectangle to within the half
+        pixel the boxes add on each side.
+        """
+        sdata = spatialdata.SpatialData.read(str(store))
+        shapes = sdata.shapes[f"{KEY}_pixels"]
+        xmin, ymin, xmax, ymax = shapes.total_bounds
+        assert xmax - xmin == pytest.approx((N_X - 1) * PITCH_X + PITCH_X)
+        assert ymax - ymin == pytest.approx((N_Y - 1) * PITCH_Y + PITCH_Y)
+
+
+class TestWhereTheYPitchComesFrom:
+    """Both detection routes, and the declaration that overrides them."""
+
+    def test_a_reader_detected_pair_is_taken_whole(self, tmp_path):
+        """The API-direct route: no detection info, the reader is asked.
+
+        ``essential.pixel_size`` is a pair on every reader and taking only
+        ``[0]`` of it is the same defect one layer down.
+        """
+        converter = StreamingSpatialDataConverter(
+            reader=_AnisotropicReader(_config()),
+            output_path=tmp_path / "reader.zarr",
+            dataset_id="m",
+            include_optical=False,
+        )
+        assert converter.convert() is True
+
+        assert converter.pixel_size_um == PITCH_X
+        assert converter.pixel_size_y_um == PITCH_Y
+        attrs = _root_attrs(tmp_path / "reader.zarr")
+        assert attrs["pixel_size_x_um"] == PITCH_X
+        assert attrs["pixel_size_y_um"] == PITCH_Y
+
+    def test_a_stated_pitch_makes_the_raster_square(self, tmp_path):
+        """``--pixel-size`` is a declaration and applies to both axes.
+
+        Someone who knows the file's y step is wrong -- or who simply
+        wants square pixels -- says so with one number, and the store then
+        says that number twice rather than mixing it with a detected one.
+        """
+        converter = StreamingSpatialDataConverter(
+            reader=_AnisotropicReader(_config()),
+            output_path=tmp_path / "stated.zarr",
+            dataset_id="m",
+            pixel_size_um=17.0,
+            pixel_size_source=PixelSizeSource.USER_PROVIDED,
+            pixel_size_detection_info=_detection_info(),
+            include_optical=False,
+        )
+        assert converter.convert() is True
+
+        assert converter.pixel_size_um == 17.0
+        assert converter.pixel_size_y_um == 17.0
+        attrs = _root_attrs(tmp_path / "stated.zarr")
+        assert attrs["pixel_size_x_um"] == 17.0
+        assert attrs["pixel_size_y_um"] == 17.0
+        table = spatialdata.SpatialData.read(str(tmp_path / "stated.zarr")).tables[KEY]
+        assert table.uns[MSI_METADATA_UNS_KEY]["ms_analysis"]["pixel_size_um"] == {
+            "x": 17.0,
+            "y": 17.0,
+        }
+
+    def test_a_square_raster_is_unchanged(self, tmp_path):
+        """The ordinary case: one number, everywhere, as before."""
+        converter = StreamingSpatialDataConverter(
+            reader=MockMSIReader(_config()),
+            output_path=tmp_path / "square.zarr",
+            dataset_id="m",
+            pixel_size_um=10.0,
+            include_optical=False,
+        )
+        assert converter.convert() is True
+
+        attrs = _root_attrs(tmp_path / "square.zarr")
+        assert attrs["pixel_size_x_um"] == attrs["pixel_size_y_um"] == 10.0
+
+    def test_it_says_so_when_the_raster_is_anisotropic(self, tmp_path, thyra_logs):
+        with thyra_logs("thyra.core.base_converter") as records:
+            StreamingSpatialDataConverter(
+                reader=MockMSIReader(_config()),
+                output_path=tmp_path / "logged.zarr",
+                dataset_id="m",
+                pixel_size_um=PITCH_X,
+                pixel_size_source=PixelSizeSource.AUTO_DETECTED,
+                pixel_size_detection_info=_detection_info(),
+                include_optical=False,
+            )
+        assert any("Anisotropic raster" in r.getMessage() for r in records), [
+            r.getMessage() for r in records
+        ]
+
+    def test_float_noise_is_not_an_anisotropic_raster(self, tmp_path, thyra_logs):
+        """A detector dividing an extent by a count can land a few ULP apart.
+
+        Until #217 the Waters extractor returned 29.66 x 28.93 for every
+        square raster; that is 2.5 percent and genuinely anisotropic, and
+        it was fixed there. What must not be reported is the last bit of a
+        float.
+        """
+        info = _detection_info()
+        info["detected_y_um"] = np.nextafter(PITCH_X, PITCH_X + 1)
+        with thyra_logs("thyra.core.base_converter") as records:
+            StreamingSpatialDataConverter(
+                reader=MockMSIReader(_config()),
+                output_path=tmp_path / "noise.zarr",
+                dataset_id="m",
+                pixel_size_um=PITCH_X,
+                pixel_size_source=PixelSizeSource.AUTO_DETECTED,
+                pixel_size_detection_info=info,
+                include_optical=False,
+            )
+        assert not any("Anisotropic raster" in r.getMessage() for r in records)

--- a/tests/unit/converters/test_empty_conversion_refused.py
+++ b/tests/unit/converters/test_empty_conversion_refused.py
@@ -1,0 +1,151 @@
+# tests/unit/converters/test_empty_conversion_refused.py
+"""A conversion that would store no spectrum is refused, and which one is not.
+
+``convert_msi`` used to return ``True`` for a source in which no position
+carries a spectrum: exit 0, and a store at the output path with no table,
+no image and no shapes -- while the log said both "No non-zero entries
+found!" and, per plane, "no position carries a spectrum" (issue #242).
+The exit status and what is left at the path are checked through the CLI
+in ``tests/unit/test_cli_exit_status.py``; what is checked here is where
+the refusal fires and, more importantly, where it must not.
+
+The line it must not cross is #88: an acquisition is polygon-shaped and
+the grid is its bounding box, so empty positions -- and, on a multi-slice
+source, whole empty planes -- are ordinary. A plane with no row is dropped
+with a warning and the rest of the store is written. Only a conversion
+with no row *anywhere* has nothing to write.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import spatialdata
+
+from tests.fixtures.mock_msi_generator import MockMSIConfig, MockMSIReader
+from thyra.converters.spatialdata.streaming_converter import (
+    SPATIALDATA_AVAILABLE,
+    StreamingSpatialDataConverter,
+)
+from thyra.errors import ConversionRefused
+
+pytestmark = pytest.mark.skipif(
+    not SPATIALDATA_AVAILABLE,
+    reason="SpatialData dependencies not available",
+)
+
+N_X, N_Y = 3, 2
+
+
+def _config(n_z: int = 1) -> MockMSIConfig:
+    return MockMSIConfig(
+        n_x=N_X,
+        n_y=N_Y,
+        n_z=n_z,
+        n_mz_bins=64,
+        peaks_per_spectrum=(3, 5),
+        seed=5,
+    )
+
+
+def _converter(reader, output: Path) -> StreamingSpatialDataConverter:
+    return StreamingSpatialDataConverter(
+        reader=reader,
+        output_path=output,
+        dataset_id="m",
+        pixel_size_um=10.0,
+        include_optical=False,
+    )
+
+
+class _NoSpectraAtAll(MockMSIReader):
+    def iter_spectra(self, batch_size=None):
+        return iter(())
+
+
+class _EverySpectrumEmpty(MockMSIReader):
+    def iter_spectra(self, batch_size=None):
+        for coords, _mzs, _intensities in super().iter_spectra(batch_size):
+            yield coords, np.array([]), np.array([])
+
+
+class _EveryCoordinateOffTheGrid(MockMSIReader):
+    def iter_spectra(self, batch_size=None):
+        for _coords, mzs, intensities in super().iter_spectra(batch_size):
+            yield (N_X + 3, N_Y + 3, 0), mzs, intensities
+
+
+class _OnlyThePlaneInTheMiddle(MockMSIReader):
+    """Planes 0 and 2 carry nothing; plane 1 is a full raster."""
+
+    def iter_spectra(self, batch_size=None):
+        for coords, mzs, intensities in super().iter_spectra(batch_size):
+            if coords[2] != 1:
+                continue
+            yield coords, mzs, intensities
+
+
+class TestNothingToWriteIsRefused:
+    """Every route into the empty store, and the sentence each gets."""
+
+    def test_no_spectra_at_all(self, tmp_path):
+        converter = _converter(_NoSpectraAtAll(_config()), tmp_path / "a.zarr")
+        with pytest.raises(ConversionRefused, match="no spectra at all"):
+            converter._initialize_conversion()
+            converter._process_spectra(converter._create_data_structures())
+
+    def test_every_spectrum_empty(self, tmp_path):
+        converter = _converter(_EverySpectrumEmpty(_config()), tmp_path / "b.zarr")
+        with pytest.raises(ConversionRefused, match="every spectrum.*was empty"):
+            converter._initialize_conversion()
+            converter._process_spectra(converter._create_data_structures())
+
+    def test_every_coordinate_off_the_grid(self, tmp_path):
+        converter = _converter(
+            _EveryCoordinateOffTheGrid(_config()), tmp_path / "c.zarr"
+        )
+        with pytest.raises(ConversionRefused, match="outside the declared 3x2x1 grid"):
+            converter._initialize_conversion()
+            converter._process_spectra(converter._create_data_structures())
+
+    def test_the_refusal_reaches_the_caller_as_a_failure(self, tmp_path):
+        """``convert`` catches it, so the caller sees False, not a traceback."""
+        output = tmp_path / "d.zarr"
+        assert _converter(_EverySpectrumEmpty(_config()), output).convert() is False
+        assert not output.exists()
+
+    def test_it_refuses_before_the_second_pass(self, tmp_path):
+        """The source is read once, not twice, before being turned away.
+
+        Refusing here rather than on the empty ``tables`` mapping at write
+        time is what saves a full second read of a source that has already
+        shown it has nothing to give.
+        """
+        reader = _EverySpectrumEmpty(_config())
+        passes = []
+        original = reader.iter_spectra
+
+        def counted(batch_size=None):
+            passes.append(1)
+            return original(batch_size)
+
+        reader.iter_spectra = counted  # type: ignore[method-assign]
+        assert _converter(reader, tmp_path / "e.zarr").convert() is False
+        assert sum(passes) == 1, f"the source was read {sum(passes)} times"
+
+
+class TestSomeEmptyPlanesAreNotRefused:
+    """#88: an empty plane is dropped, an empty conversion is refused."""
+
+    def test_a_source_with_one_live_plane_converts(self, tmp_path):
+        output = tmp_path / "planes.zarr"
+        assert (
+            _converter(_OnlyThePlaneInTheMiddle(_config(n_z=3)), output).convert()
+            is True
+        )
+
+        sdata = spatialdata.SpatialData.read(str(output))
+        assert set(sdata.tables) == {"m_z1"}
+        assert sdata.tables["m_z1"].n_obs == N_X * N_Y

--- a/tests/unit/converters/test_per_table_average_spectrum.py
+++ b/tests/unit/converters/test_per_table_average_spectrum.py
@@ -1,0 +1,256 @@
+# tests/unit/converters/test_per_table_average_spectrum.py
+"""What ``uns["average_spectrum"]`` is the mean of.
+
+``docs/output-format.md`` promises each table "the mean over the acquired
+spectra" of that table, and Ousia reads it as that table's own mean. A
+multi-slice source converted as 2D -- the default, one table per plane --
+stored one dataset-wide vector in every plane's table instead. Measured on
+a 3-plane source with intensities scaled by z, the ratio of the stored
+vector to ``X.mean(axis=0)`` was 1.96 / 0.996 / 0.67 across the planes,
+with the same vector in all three (issue #243). ``#199`` had already fixed
+this key for the 3D volume path.
+
+Two things the denominator has to get right, both checked here against
+``X.mean(axis=0)`` rather than a hand-computed expectation, because that
+is the number the docs promise:
+
+* a **dropped** row -- an all-zero spectrum gets no row, so it belongs in
+  neither the sum nor the count. Counting the spectra fed in made a plane
+  with one of four rows dropped come out at 0.75 of its mean.
+* a **repeated** position -- since #241 the source measuring one pixel
+  twice gives one row holding the sum of both spectra, so its contribution
+  is two spectra of current over one row. That is the row's real ion
+  current, and counting the position twice would be the error.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import spatialdata
+
+from tests.fixtures.mock_msi_generator import MockMSIConfig, MockMSIReader
+from thyra.converters.spatialdata.streaming_converter import (
+    SPATIALDATA_AVAILABLE,
+    StreamingSpatialDataConverter,
+)
+
+pytestmark = pytest.mark.skipif(
+    not SPATIALDATA_AVAILABLE,
+    reason="SpatialData dependencies not available",
+)
+
+N_X, N_Y = 3, 2
+
+
+def _config(n_z: int = 3) -> MockMSIConfig:
+    return MockMSIConfig(
+        n_x=N_X,
+        n_y=N_Y,
+        n_z=n_z,
+        n_mz_bins=64,
+        peaks_per_spectrum=(3, 5),
+        seed=11,
+    )
+
+
+def _convert(reader, output: Path, **kwargs) -> Path:
+    converter = StreamingSpatialDataConverter(
+        reader=reader,
+        output_path=output,
+        dataset_id="m",
+        pixel_size_um=10.0,
+        include_optical=False,
+        **kwargs,
+    )
+    assert converter.convert() is True
+    return output
+
+
+class _ScaledByPlane(MockMSIReader):
+    """Every plane is plane 0's raster, scaled by ``z + 1``.
+
+    The same spectra rather than merely the same intensity scale, so the
+    planes' mean spectra stand in an exactly known ratio and a shared
+    vector cannot pass for any of them.
+    """
+
+    def iter_spectra(self, batch_size=None):
+        plane_zero: dict = {}
+        for coords, mzs, intensities in super().iter_spectra(batch_size):
+            x, y, z = coords
+            if z == 0:
+                plane_zero[(x, y)] = (mzs, intensities)
+            mzs, intensities = plane_zero[(x, y)]
+            yield coords, mzs, intensities * (z + 1)
+
+
+class _DroppedRowAndRepeat(MockMSIReader):
+    """Plane 0 loses a row to an all-zero spectrum, plane 1 repeats a pixel."""
+
+    def iter_spectra(self, batch_size=None):
+        extra = None
+        for coords, mzs, intensities in super().iter_spectra(batch_size):
+            if coords == (0, 0, 0):
+                yield coords, mzs, np.zeros_like(intensities)
+                continue
+            if coords == (1, 0, 1):
+                extra = mzs[:2]
+            yield coords, mzs, intensities
+        assert extra is not None
+        yield (1, 0, 1), extra, np.array([3.0, 5.0])
+
+
+class _TwoRegions(MockMSIReader):
+    """The left column is region 1, the rest region 2."""
+
+    def get_region_map(self):
+        return {
+            (x, y): (1 if x == 0 else 2)
+            for y in range(self.config.n_y)
+            for x in range(self.config.n_x)
+        }
+
+
+def _tables(store: Path):
+    return spatialdata.SpatialData.read(str(store)).tables
+
+
+def _dense(table) -> np.ndarray:
+    X = table.X
+    return X.toarray() if hasattr(X, "toarray") else np.asarray(X)
+
+
+class TestEachTableStoresItsOwnMean:
+    """The promise in docs/output-format.md, per table."""
+
+    def test_every_plane_matches_its_own_matrix(self, tmp_path):
+        store = _convert(_ScaledByPlane(_config()), tmp_path / "scaled.zarr")
+
+        tables = _tables(store)
+        assert set(tables) == {"m_z0", "m_z1", "m_z2"}
+        for key, table in tables.items():
+            stored = np.asarray(table.uns["average_spectrum"])
+            np.testing.assert_allclose(
+                stored,
+                _dense(table).mean(axis=0),
+                err_msg=f"{key} does not store its own mean spectrum",
+            )
+
+    def test_the_planes_do_not_share_one_vector(self, tmp_path):
+        """The symptom the issue reported: the same vector in every table."""
+        tables = _tables(_convert(_ScaledByPlane(_config()), tmp_path / "s.zarr"))
+
+        z0 = np.asarray(tables["m_z0"].uns["average_spectrum"])
+        z1 = np.asarray(tables["m_z1"].uns["average_spectrum"])
+        z2 = np.asarray(tables["m_z2"].uns["average_spectrum"])
+
+        # The source scales plane z by (z + 1), so the planes' means are in
+        # the ratio 1 : 2 : 3 and cannot be one shared vector.
+        np.testing.assert_allclose(z1, 2.0 * z0)
+        np.testing.assert_allclose(z2, 3.0 * z0)
+
+    def test_a_dropped_row_and_a_repeat_both_land_on_the_matrix(self, tmp_path):
+        """The two denominators the sub-finding names, in one store."""
+        store = _convert(_DroppedRowAndRepeat(_config(n_z=2)), tmp_path / "mixed.zarr")
+        tables = _tables(store)
+
+        # The all-zero spectrum got no row; the repeat got one, not two.
+        assert tables["m_z0"].n_obs == N_X * N_Y - 1
+        assert tables["m_z1"].n_obs == N_X * N_Y
+
+        for key, table in tables.items():
+            np.testing.assert_allclose(
+                np.asarray(table.uns["average_spectrum"]),
+                _dense(table).mean(axis=0),
+                err_msg=f"{key} does not store its own mean spectrum",
+            )
+
+    def test_a_volume_stores_the_volume_mean(self, tmp_path):
+        """``handle_3d=True`` is one table, so its mean is the whole stack's."""
+        store = _convert(
+            _ScaledByPlane(_config()), tmp_path / "vol.zarr", handle_3d=True
+        )
+
+        tables = _tables(store)
+        assert set(tables) == {"m"}
+        table = tables["m"]
+        np.testing.assert_allclose(
+            np.asarray(table.uns["average_spectrum"]), _dense(table).mean(axis=0)
+        )
+
+
+class TestThePerRegionMeans:
+    """``average_spectrum_per_region`` is a mean too, over the same rows."""
+
+    def test_each_region_is_the_mean_of_its_rows(self, tmp_path):
+        store = _convert(_TwoRegions(_config(n_z=1)), tmp_path / "regions.zarr")
+
+        table = _tables(store)["m_z0"]
+        per_region = table.uns["average_spectrum_per_region"]
+        assert set(per_region) == {"1", "2"}
+
+        X = _dense(table)
+        for region in ("1", "2"):
+            rows = table.obs["region_number"].values == int(region)
+            np.testing.assert_allclose(
+                np.asarray(per_region[region]),
+                X[rows].mean(axis=0),
+                err_msg=f"region {region} is not the mean of its rows",
+            )
+
+    def test_a_repeated_position_does_not_dilute_its_region(self, tmp_path):
+        """The denominator is rows, so the summed row counts once."""
+
+        class _RegionsWithRepeat(_TwoRegions):
+            def iter_spectra(self, batch_size=None):
+                extra = None
+                for coords, mzs, intensities in super().iter_spectra(batch_size):
+                    if coords == (0, 0, 0):
+                        extra = mzs[:2]
+                    yield coords, mzs, intensities
+                assert extra is not None
+                yield (0, 0, 0), extra, np.array([7.0, 11.0])
+
+        store = _convert(_RegionsWithRepeat(_config(n_z=1)), tmp_path / "repeat.zarr")
+
+        table = _tables(store)["m_z0"]
+        X = _dense(table)
+        rows = table.obs["region_number"].values == 1
+        np.testing.assert_allclose(
+            np.asarray(table.uns["average_spectrum_per_region"]["1"]),
+            X[rows].mean(axis=0),
+        )
+
+    def test_the_regions_span_the_planes(self, tmp_path):
+        """A region has no z, so its mean is over every plane's rows.
+
+        ``get_region_map`` is keyed on ``(x, y)``, so one region is one
+        in-plane footprint sampled on every plane. The per-region key is
+        therefore dataset-wide while ``average_spectrum`` is per table --
+        which is the one place the two disagree, and it is deliberate.
+        """
+        store = _convert(_TwoRegions(_config(n_z=2)), tmp_path / "span.zarr")
+
+        tables = _tables(store)
+        stacked = np.vstack([_dense(tables[k]) for k in ("m_z0", "m_z1")])
+        regions = np.concatenate(
+            [tables[k].obs["region_number"].values for k in ("m_z0", "m_z1")]
+        )
+
+        per_region = tables["m_z0"].uns["average_spectrum_per_region"]
+        for region in ("1", "2"):
+            np.testing.assert_allclose(
+                np.asarray(per_region[region]),
+                stacked[regions == int(region)].mean(axis=0),
+                err_msg=f"region {region} is not the mean of its rows on every plane",
+            )
+
+        # Same dict on every plane's table, because it describes them all.
+        for region in ("1", "2"):
+            np.testing.assert_allclose(
+                np.asarray(per_region[region]),
+                np.asarray(tables["m_z1"].uns["average_spectrum_per_region"][region]),
+            )

--- a/tests/unit/test_cli_exit_status.py
+++ b/tests/unit/test_cli_exit_status.py
@@ -9,6 +9,7 @@ destination path where it can be mistaken for a finished conversion.
 from __future__ import annotations
 
 import importlib
+import logging
 
 import pytest
 from click.testing import CliRunner
@@ -73,6 +74,123 @@ class TestExitStatus:
         result = _invoke(runner, unknown_input, output_path)
 
         assert result.exit_code == 1, result.output
+
+
+#: The logger the base workflow reports a refusal on. Named rather than
+#: reached through ``thyra``, because ``setup_logging`` clears that
+#: logger's handlers and the CLI calls it on every invocation -- a
+#: collector attached to ``thyra`` before ``runner.invoke`` is gone by
+#: the time anything is logged.
+_REFUSAL_LOGGER = "thyra.core.base_converter"
+
+
+@pytest.fixture
+def all_zero_imzml(temp_dir):
+    """A 2x2 processed imzML whose every intensity is zero.
+
+    Every peak is dropped as a zero, so no position carries a spectrum
+    and there is no table to write -- the input the conversion used to
+    report success on (issue #242).
+    """
+    import numpy as np
+    from pyimzml.ImzMLWriter import ImzMLWriter
+
+    path = temp_dir / "all_zero.imzML"
+    mzs = np.linspace(100.0, 1000.0, 20)
+    with ImzMLWriter(str(path), mode="processed") as writer:
+        for x, y in ((1, 1), (1, 2), (2, 1), (2, 2)):
+            writer.addSpectrum(mzs, np.zeros_like(mzs), (x, y, 1))
+    return path
+
+
+class TestAConversionThatStoresNothing:
+    """An empty conversion is a failed one (issue #242).
+
+    It used to return ``True``, exit 0 and leave a store with no table,
+    no image and no shapes at the output path -- while logging both "No
+    non-zero entries found!" and, per plane, "no position carries a
+    spectrum". A calling script saw a finished conversion; opening the
+    store found nothing to read. These go through the CLI because the
+    exit status and what is left at the path are the observable part.
+    """
+
+    def test_an_all_zero_source_exits_one(self, all_zero_imzml, temp_dir, runner):
+        output_path = temp_dir / "out.zarr"
+
+        result = _invoke(runner, all_zero_imzml, output_path)
+
+        assert result.exit_code == 1, result.output
+        assert not output_path.exists(), (
+            "an empty conversion must not leave a store where a finished " "one belongs"
+        )
+        assert not (temp_dir / "out.zarr.failed").exists()
+
+    def test_the_refusal_names_the_cause(
+        self, all_zero_imzml, temp_dir, runner, thyra_logs
+    ):
+        """Not just "nothing was stored" -- which nothing, and why.
+
+        The source here has peaks at every position and every one of them
+        is zero. A resampled axis lands a few tenths of a mDa inside the
+        source's own range, so two of this source's twenty peaks fall off
+        its ends on every spectrum; the refusal must not read that as the
+        range being the problem.
+        """
+        output_path = temp_dir / "out.zarr"
+
+        with thyra_logs(_REFUSAL_LOGGER, logging.ERROR) as records:
+            _invoke(runner, all_zero_imzml, output_path)
+
+        messages = [r.getMessage() for r in records]
+        assert any(
+            "no pixel carries a spectrum" in m
+            and "every intensity in the source is zero" in m
+            for m in messages
+        ), messages
+
+    def test_a_range_that_excludes_every_peak_exits_one(
+        self, create_minimal_imzml, temp_dir, runner, thyra_logs
+    ):
+        """The narrowed-range route into the same empty store.
+
+        The source's peaks are between 100 and 1000 m/z; resampling onto
+        2000-3000 keeps none of them. That is a different thing to tell
+        the user than "every spectrum was empty", so the message has to
+        say which one happened.
+        """
+        imzml_path, _, _, _ = create_minimal_imzml
+        output_path = temp_dir / "out.zarr"
+
+        with thyra_logs(_REFUSAL_LOGGER, logging.ERROR) as records:
+            result = _invoke(
+                runner,
+                imzml_path,
+                output_path,
+                "--resample-min-mz",
+                "2000",
+                "--resample-max-mz",
+                "3000",
+            )
+
+        assert result.exit_code == 1, result.output
+        assert not output_path.exists()
+        messages = [r.getMessage() for r in records]
+        assert any(
+            "outside the target mass axis" in m and "--resample-min-mz" in m
+            for m in messages
+        ), messages
+
+    def test_a_source_with_spectra_still_converts(
+        self, create_minimal_imzml, temp_dir, runner
+    ):
+        """The guard must not fire on an ordinary conversion."""
+        imzml_path, _, _, _ = create_minimal_imzml
+        output_path = temp_dir / "out.zarr"
+
+        result = _invoke(runner, imzml_path, output_path)
+
+        assert result.exit_code == 0, result.output
+        assert output_path.is_dir()
 
 
 class TestPartialOutputQuarantine:

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -897,6 +897,24 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         self._unusable_intensities: int = 0
         self._unusable_intensities_warned: bool = False
         self._pixel_size_detection_info = pixel_size_detection_info
+        # ``convert.py`` detects an (x, y) pair, hands the converter the x
+        # half as ``pixel_size_um`` and puts both in the detection info.
+        # Reading the y half back here is what stops the store describing
+        # an anisotropic raster as square (issue #228); everything the
+        # converter writes takes its y pitch from this attribute.
+        #
+        # Only for a pitch that was actually detected. A caller who states
+        # one gets it on both axes -- that is what stating it means -- and
+        # a source ``convert.py`` could not detect leaves the placeholder,
+        # which :meth:`_adopt_detected_pixel_size` settles from the reader
+        # once its metadata is loaded.
+        detected_y = (pixel_size_detection_info or {}).get("detected_y_um")
+        if (
+            detected_y is not None
+            and pixel_size_source is PixelSizeSource.AUTO_DETECTED
+        ):
+            self.pixel_size_y_um = float(detected_y)
+            self._log_anisotropic_raster()
         self._resampling_config = (
             _normalize_resampling_config(resampling_config)
             if resampling_config is not None
@@ -1890,16 +1908,20 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
     def _resolved_pixel_size_xy(self) -> Tuple[float, float]:
         """The in-plane pixel pitch as ``(x_um, y_um)``.
 
-        The converter itself carries a single float (auto-detection
-        keeps the source's x pitch), but the detection info still has
-        the true per-axis values for anisotropic rasters -- the
-        metadata block records those, since it describes the
-        acquisition rather than the rendering.
+        One pair, and every block of the store is written from it: the
+        root attrs, ``coordinate_systems.global`` and its affine, the
+        image and shapes transformations, the pixel footprints,
+        ``obs["spatial_x"]``/``["spatial_y"]`` and the ``msi_metadata``
+        block.
+
+        It used to be only the last of those. The converter carried a
+        single float -- detection kept the source's x pitch and discarded
+        the y one -- while this method read the true pair back out of the
+        detection info for the metadata block alone. A raster acquired at
+        30 x 50 um was then rendered at 30 x 30 and the store's own blocks
+        contradicted each other (issue #228).
         """
-        info = self._pixel_size_detection_info or {}
-        if "detected_x_um" in info and "detected_y_um" in info:
-            return (float(info["detected_x_um"]), float(info["detected_y_um"]))
-        return (float(self.pixel_size_um), float(self.pixel_size_um))
+        return (float(self.pixel_size_um), float(self.pixel_size_y_um))
 
     def _collect_msi_metadata_block(self, uns: Dict[str, Any], comp_meta: Any) -> None:
         """Add the versioned ``msi_metadata`` schema block.
@@ -2397,19 +2419,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             self._estimated_memory_gb = essential.estimated_memory_gb
 
             # Override pixel size only if using default and metadata is available
-            if (
-                self.pixel_size_source == PixelSizeSource.DEFAULT
-                and essential.pixel_size
-            ):
-                old_size = self.pixel_size_um
-                self.pixel_size_um = essential.pixel_size[0]
-                self.pixel_size_source = PixelSizeSource.AUTO_DETECTED
-                logger.info(
-                    f"Auto-detected pixel size: {self.pixel_size_um} um "
-                    f"(was default: {old_size} um)"
-                )
-            elif self.pixel_size_source == PixelSizeSource.USER_PROVIDED:
-                logger.info(f"Using user-specified pixel size: {self.pixel_size_um} um")
+            self._adopt_detected_pixel_size(essential)
 
             # After pixel size, because the fallback is the pixel size.
             self._resolve_z_spacing(essential)
@@ -3182,7 +3192,8 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
 
             x_coords: NDArray[np.float64] = adata.obs["spatial_x"].values
             y_coords: NDArray[np.float64] = adata.obs["spatial_y"].values
-            half_pixel_um = self.pixel_size_um / 2
+            half_x_um = self.pixel_size_um / 2
+            half_y_um = self.pixel_size_y_um / 2
 
             # Footprints are flat, on every route including volumes. A
             # slice's depth lives on the TIC image's Scale and in
@@ -3191,10 +3202,10 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             # constructor -- one C call for the whole table instead of one
             # Python-level geometry per pixel.
             geometries = shapely_box_vectorized(
-                x_coords - half_pixel_um,
-                y_coords - half_pixel_um,
-                x_coords + half_pixel_um,
-                y_coords + half_pixel_um,
+                x_coords - half_x_um,
+                y_coords - half_y_um,
+                x_coords + half_x_um,
+                y_coords + half_y_um,
             )
 
         # Create GeoDataFrame with appropriate index
@@ -3441,10 +3452,10 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 "a tic_to_image_matrix; check call-site guard."
             )
         inv = np.linalg.inv(self._tic_to_image_matrix)
-        # Scale matrix: [[ps, 0, 0], [0, ps, 0], [0, 0, 1]]
-        ps = float(self.pixel_size_um)
+        # Scale matrix: [[ps_x, 0, 0], [0, ps_y, 0], [0, 0, 1]]
+        ps_x, ps_y = self._resolved_pixel_size_xy()
         scale_mat = np.array(
-            [[ps, 0.0, 0.0], [0.0, ps, 0.0], [0.0, 0.0, 1.0]],
+            [[ps_x, 0.0, 0.0], [0.0, ps_y, 0.0], [0.0, 0.0, 1.0]],
             dtype=np.float64,
         )
         matrix = scale_mat @ inv
@@ -3768,7 +3779,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         # Base pixel size metadata
         pixel_size_attrs = {
             "pixel_size_x_um": float(self.pixel_size_um),
-            "pixel_size_y_um": float(self.pixel_size_um),
+            "pixel_size_y_um": float(self.pixel_size_y_um),
             "pixel_size_units": "micrometers",
             "coordinate_system": "physical_micrometers",
             "msi_converter_version": version,
@@ -3864,7 +3875,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         else:
             unit = "micrometer"
             pixel_size_um_x = float(self.pixel_size_um)
-            pixel_size_um_y = float(self.pixel_size_um)
+            pixel_size_um_y = float(self.pixel_size_y_um)
             reference_element = None
 
         global_cs: Dict[str, Any] = {
@@ -3892,10 +3903,10 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 [float(v) for v in row] for row in self._tic_to_image_matrix
             ]
         else:
-            in_plane = float(self.pixel_size_um)
+            px, py = self._resolved_pixel_size_xy()
             global_cs["raster_to_global_affine"] = [
-                [in_plane, 0.0, 0.0],
-                [0.0, in_plane, 0.0],
+                [px, 0.0, 0.0],
+                [0.0, py, 0.0],
                 [0.0, 0.0, 1.0],
             ]
         offsets = self._source_coordinate_offsets()
@@ -3904,7 +3915,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             if unit == "micrometer":
                 global_cs["stage_offset_um"] = [
                     float(offsets[0]) * float(self.pixel_size_um),
-                    float(offsets[1]) * float(self.pixel_size_um),
+                    float(offsets[1]) * float(self.pixel_size_y_um),
                 ]
 
         if self._is_volume:
@@ -3974,6 +3985,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         metadata_dict["conversion_options"] = {
             "handle_3d": self.handle_3d,
             "pixel_size_um": self.pixel_size_um,
+            "pixel_size_y_um": self.pixel_size_y_um,
             "z_spacing_um": self.z_spacing_um,
             "z_spacing_source": self.z_spacing_source.value,
             "dataset_id": self.dataset_id,

--- a/thyra/converters/spatialdata/csc_assembly.py
+++ b/thyra/converters/spatialdata/csc_assembly.py
@@ -83,11 +83,12 @@ SORT_CHUNK_ENTRIES = 16_000_000
 #: Process memory one m/z bin of the summed table costs, everything the
 #: conversion builds per bin included. :data:`MAX_COUNT_BYTES` sizes the
 #: 4 B/bin count array alone, and that is 2 percent of the real figure:
-#: around it sit the axis itself and ``total_intensity`` and
-#: ``avg_spectrum`` (8 B/bin each), the ``var`` frame with its index, the
-#: ``indptr`` and the write cursor, and anndata's own copies during the
-#: write. Measured 2026-09-09 with a six-pixel conversion at a forced bin
-#: count, peak working set above the pre-conversion baseline:
+#: around it sit the axis itself, each table's ``average_spectrum`` and
+#: the column sums it is divided out of (8 B/bin each), the ``var`` frame
+#: with its index, the ``indptr`` and the write cursor, and anndata's own
+#: copies during the write. Measured 2026-09-09 with a six-pixel
+#: conversion at a forced bin count, peak working set above the
+#: pre-conversion baseline:
 #:
 #: =============  ==================  ==========
 #: bins           peak above baseline bytes/bin
@@ -110,6 +111,14 @@ SORT_CHUNK_ENTRIES = 16_000_000
 #: either way and the peak is the conversion, not the labels. So the cost
 #: is real, it is inherent to a string ``var`` index, and the answer is to
 #: refuse an axis that cannot afford it rather than to shave the index.
+#:
+#: The figure is per bin of *one* table. A multi-slice source converted as
+#: 2D writes one table per plane and each carries its own ``var`` copy and
+#: its own mean spectrum, so its real per-bin cost is a multiple of this
+#: and the guard under-projects it. That predates the per-table mean
+#: (#243), which is close to neutral here: it dropped one dataset-wide
+#: accumulator and one dataset-wide mean (8 B/bin each) and added 8 B/bin
+#: per table.
 AXIS_BYTES_PER_BIN = 200
 
 #: Fractions of the machine's free memory the projected mass axis may

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -483,19 +483,21 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
             "shapes": {},
             "images": {},
             "var_df": self._create_mass_dataframe(),
-            "total_intensity": np.zeros(n_cols, dtype=np.float64),
             "pixel_count": 0,
-            "avg_spectrum": None,
             "avg_spectrum_per_region": None,
         }
 
-        # Per-region accumulators for multi-region datasets
+        # Per-region accumulators for multi-region datasets. Unlike the
+        # per-table average these stay dataset-wide, because a region is:
+        # ``get_region_map`` is keyed on ``(x, y)`` with no z, so one
+        # region is one in-plane footprint sampled on every plane. See
+        # _finalize_table for what that means for a multi-plane store.
         if self._region_map is not None:
             unique_regions = sorted(set(self._region_map.values()))
             data_structures["region_total_intensity"] = {
                 r: np.zeros(n_cols, dtype=np.float64) for r in unique_regions
             }
-            data_structures["region_pixel_count"] = {r: 0 for r in unique_regions}
+            data_structures["region_row_count"] = {r: 0 for r in unique_regions}
 
         return data_structures
 
@@ -560,11 +562,6 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         logger.info("Step 2/3: Allocating memory-mapped CSC arrays...")
         for unit in units:
             unit.finish_counting()
-            unit.assembly.allocate(
-                self._register_table_scratch("summed", unit.assembly)
-            )
-
-        self._matrix_size_gb(units)
 
         # The rows that are written, not the spectra that were read: a
         # position measured twice is one row, and an empty or out-of-grid
@@ -572,6 +569,19 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         # ``non_empty_pixels``, where it used to be the reader's spectrum
         # count and so disagreed with the table it described (#241).
         self._non_empty_pixel_count = sum(unit.n_rows for unit in units)
+
+        # Before anything is allocated and before the source is read a
+        # second time: a conversion with no row has nothing left to do
+        # and no store to write (#242).
+        self._refuse_an_empty_conversion(data_structures)
+        self._finish_region_averages(data_structures)
+
+        for unit in units:
+            unit.assembly.allocate(
+                self._register_table_scratch("summed", unit.assembly)
+            )
+
+        self._matrix_size_gb(units)
 
         if passes is not None:
             passes.finish_counting(units[0].n_rows, self._register_table_scratch)
@@ -586,20 +596,152 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
             passes.finish_scattering()
             self._take_fused_results(passes)
 
+    def _kept_in_plane_xy(
+        self, unit: _TableUnit
+    ) -> Tuple[NDArray[np.int64], NDArray[np.int64]]:
+        """The in-plane ``(x, y)`` of one table's rows, in row order."""
+        if unit.kept_grid is None or self._dimensions is None:
+            raise RuntimeError("The row layout is not decided yet")
+        n_x, n_y, _ = self._dimensions
+        kept = unit.kept_grid
+        in_plane = kept % (n_x * n_y) if unit.plane is None else kept
+        return in_plane % n_x, in_plane // n_x
+
+    def _refuse_an_empty_conversion(self, data_structures: Dict[str, Any]) -> None:
+        """Refuse a conversion in which no position carries a spectrum.
+
+        Such a run used to report success: ``convert_msi`` returned
+        ``True``, the CLI exited 0, and a store was written with no table,
+        no image and no shapes -- while the log said "No non-zero entries
+        found!" and, per plane, "no position carries a spectrum". A
+        calling script saw a finished conversion and a zarr it could not
+        read a spectrum out of (issue #242).
+
+        Checked here, on the row count, rather than on the empty
+        ``tables`` mapping in ``_save_output``: the pre-scan has just
+        settled every table's rows, a full second read of the source is
+        still ahead, and the same count covers every route into the empty
+        store -- an all-zero source, every spectrum empty, every peak
+        outside a narrowed resampling range, every coordinate off the
+        grid.
+
+        A **multi-plane** source with some empty planes is not refused.
+        Those planes are dropped with a warning and the rest are written,
+        which is the #88 behaviour: an acquisition is polygon-shaped and
+        its bounding box has empty corners. Only a conversion with no row
+        anywhere is refused.
+
+        Raises:
+            ConversionRefused: When no table would have a single row.
+        """
+        if self._non_empty_pixel_count > 0:
+            return
+
+        raise ConversionRefused(
+            f"{self.dataset_id}: no pixel carries a spectrum, so there is no "
+            f"table to write -- {self._why_nothing_survived(data_structures)}. "
+            f"Nothing was written to {self.output_path}."
+        )
+
+    def _why_nothing_survived(self, data_structures: Dict[str, Any]) -> str:
+        """Which of the routes into an empty store this conversion took.
+
+        "Every spectrum was empty" and "every peak fell outside
+        250-1200 m/z" send a user to different places, so the refusal has
+        to tell them apart rather than name the possibilities. Each test
+        is on a total rather than on a counter being non-zero: a
+        resampled axis lands a few tenths of a mDa inside the source's
+        own range, so two of a spectrum's twenty peaks falling off its
+        ends is routine and says nothing about why the store is empty.
+
+        Both peak counters are read after pass 1 and before pass 2, so
+        they hold that one pass's totals -- they count resample calls,
+        and an ordinary conversion resamples every spectrum twice.
+        """
+        pixel_count = int(data_structures.get("pixel_count", 0))
+        off_grid = int(data_structures.get("out_of_grid_spectra", 0))
+        peaks_in = int(data_structures.get("input_peaks", 0))
+
+        if pixel_count == 0:
+            return "the reader yielded no spectra at all"
+        if off_grid == pixel_count:
+            n_x, n_y, n_z = self._dimensions
+            return (
+                f"all {pixel_count} spectra sat outside the declared "
+                f"{n_x}x{n_y}x{n_z} grid"
+            )
+        if peaks_in == 0:
+            return "every spectrum the reader yielded was empty"
+        if self._unusable_intensities >= peaks_in:
+            return (
+                "every intensity was dropped as not a measurement "
+                "(non-finite, or negative)"
+            )
+        usable = peaks_in - self._unusable_intensities
+        if self._out_of_range_peaks >= usable and self._common_mass_axis is not None:
+            return (
+                "every peak fell outside the target mass axis "
+                f"[{float(self._common_mass_axis[0]):.4f}, "
+                f"{float(self._common_mass_axis[-1]):.4f}] m/z -- widen the "
+                "resampling range (--resample-min-mz / --resample-max-mz) to "
+                "keep them"
+            )
+        return "every intensity in the source is zero"
+
+    def _finish_region_averages(self, data_structures: Dict[str, Any]) -> None:
+        """Divide each region's summed intensity by the rows it covers.
+
+        The numerator is every spectrum that got a row in the region, so
+        the denominator has to be rows too, exactly as for the per-table
+        average (#243): counting the spectra fed in instead made a region
+        holding a position the source measured twice come out low by that
+        position's share.
+
+        Regions stay dataset-wide, spanning z. That is what a region *is*
+        here -- ``get_region_map`` is keyed on ``(x, y)`` and has no z
+        component, so one region is one in-plane footprint sampled on
+        every plane, and splitting it per plane would answer a question
+        the source never asked.
+        """
+        region_total = data_structures.get("region_total_intensity")
+        if region_total is None:
+            return
+
+        rows: Dict[int, int] = data_structures["region_row_count"]
+        for unit in data_structures["units"]:
+            x_idx, y_idx = self._kept_in_plane_xy(unit)
+            numbers, counts = np.unique(
+                self.build_region_numbers(x_idx, y_idx), return_counts=True
+            )
+            for region, count in zip(numbers.tolist(), counts.tolist()):
+                if region in rows:
+                    rows[region] += int(count)
+
+        data_structures["avg_spectrum_per_region"] = {
+            str(region): total / max(rows.get(region, 0), 1)
+            for region, total in region_total.items()
+        }
+
     def _count_pass(self, data_structures: Dict[str, Any]) -> None:
-        """Pass 1: count entries per column, TIC, occupancy, average spectrum.
+        """Pass 1: count entries per column, TIC, occupancy, region totals.
+
+        The mean spectrum is *not* accumulated here. It is each table's
+        own column sums divided by its own rows, and both are read off the
+        finished matrix in :meth:`_finalize_table` (#243).
 
         Also feeds the sibling tables' pass-1 sinks, when ``passes`` is
         set, from the same frame read (see ``fused_passes.py``).
         """
         units: List[_TableUnit] = data_structures["units"]
         passes = data_structures["passes"]
-        total_intensity: NDArray[np.float64] = data_structures["total_intensity"]
         region_total = data_structures.get("region_total_intensity")
-        region_count = data_structures.get("region_pixel_count")
 
         pixel_count = 0
         n_out_of_bounds = 0
+        # Peaks handed in, before anything is dropped. The empty-store
+        # refusal tells its causes apart by comparing the dropped totals
+        # with this one (see _why_nothing_survived).
+        n_input_peaks = 0
         self._suppress_reader_progress()
 
         with tqdm(
@@ -611,6 +753,7 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                 passes, "count"
             ):
                 x, y, z = coords
+                n_input_peaks += int(np.size(mzs))
                 mz_indices, values = self._process_spectrum(mzs, intensities)
                 nnz = int(mz_indices.size)
                 unit, grid = self._locate(units, x, y, z)
@@ -626,12 +769,6 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                     passes.count(frame, grid if gets_row else None)
 
                 if nnz > 0:
-                    # The average is over every spectrum read rather than
-                    # every spectrum stored, so it sits outside the bounds
-                    # check. Indices are unique within a spectrum, so the
-                    # fancy-indexed add is exact.
-                    total_intensity[mz_indices] += values
-
                     # Column counts, TIC and occupancy all describe a
                     # spectrum that is going to get a row, so all three sit
                     # behind the bounds check: a reader yielding a
@@ -642,14 +779,20 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                     # scipy reports as a non-canonical matrix.
                     if unit is not None:
                         unit.count(grid, mz_indices, values)
+
+                        # Behind the same check, and for the same reason
+                        # the per-table average is taken over rows: the
+                        # numerator has to be the current the store
+                        # actually holds. A spectrum off the grid is
+                        # written nowhere, so it belongs in no mean
+                        # (#243). Indices are unique within a spectrum,
+                        # so the fancy-indexed add is exact.
+                        if region_total is not None:
+                            region = self._region_map.get((x, y), -1)
+                            if region in region_total:
+                                region_total[region][mz_indices] += values
                     else:
                         n_out_of_bounds += 1
-
-                    if region_total is not None:
-                        region = self._region_map.get((x, y), -1)
-                        if region in region_total:
-                            region_total[region][mz_indices] += values
-                            region_count[region] += 1
 
                 pixel_count += 1
                 pbar.update(1)
@@ -660,7 +803,7 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
         logger.info(
             "  Pre-scan complete: %s entries across %s columns",
             f"{total_nnz:,}",
-            f"{total_intensity.size:,}",
+            f"{len(self._common_mass_axis):,}",
         )
         if n_out_of_bounds:
             n_x, n_y, n_z = self._dimensions
@@ -674,18 +817,16 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                 n_z,
             )
 
-        # ``pixel_count`` is every spectrum the reader yielded, which is what
-        # the average is over. It is not the table's row count -- an empty
-        # spectrum gets no row, an out-of-grid one gets no row, and a
-        # position measured twice gets one -- so ``non_empty_pixels`` is
-        # set from the rows in _process_spectra rather than from here (#241).
+        # ``pixel_count`` is every spectrum the reader yielded. It is not
+        # the table's row count -- an empty spectrum gets no row, an
+        # out-of-grid one gets no row, and a position measured twice gets
+        # one -- so ``non_empty_pixels`` is set from the rows in
+        # _process_spectra rather than from here (#241), and no average is
+        # taken over it any more (#243). All it sizes now is pass 2's
+        # progress bar, which counts the same spectra pass 1 walked.
         data_structures["pixel_count"] = pixel_count
-        data_structures["avg_spectrum"] = total_intensity / max(pixel_count, 1)
-        if region_total is not None:
-            data_structures["avg_spectrum_per_region"] = {
-                str(r): total / max(region_count.get(r, 0), 1)
-                for r, total in region_total.items()
-            }
+        data_structures["out_of_grid_spectra"] = n_out_of_bounds
+        data_structures["input_peaks"] = n_input_peaks
 
     def _scatter_pass(self, data_structures: Dict[str, Any]) -> None:
         """Pass 2: resample every spectrum again and scatter it into its table.
@@ -796,10 +937,22 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
             var=data_structures["var_df"].copy(),
         )
 
-        # Add average spectrum to .uns. The dataset-wide mean, the same
-        # on every table: it is the per-pixel mean everywhere, including
-        # the per-region block below.
-        adata.uns["average_spectrum"] = data_structures["avg_spectrum"]
+        # This table's own mean spectrum, taken from this table's own
+        # matrix: the column sums over the rows that were written. Until
+        # #243 a multi-slice source converted as 2D put one dataset-wide
+        # vector in every plane's table, and the ratio to the plane's real
+        # mean was measured at 1.96 / 0.996 / 0.67 across three planes of
+        # a source scaled by z. Read off the matrix rather than
+        # accumulated alongside it so it *is* ``X.mean(axis=0)``, which is
+        # what docs/output-format.md promises and what Ousia reads, rather
+        # than a second number that has to be kept in step with it.
+        adata.uns["average_spectrum"] = np.asarray(
+            matrix.sum(axis=0), dtype=np.float64
+        ).ravel() / max(unit.n_rows, 1)
+        # The per-region means stay dataset-wide, because a region has no
+        # z: see _finish_region_averages. On a multi-plane store they
+        # therefore describe a wider population than the key above, which
+        # docs/output-format.md says out loud.
         per_region = data_structures.get("avg_spectrum_per_region")
         if per_region is not None:
             adata.uns["average_spectrum_per_region"] = per_region
@@ -862,7 +1015,7 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                     "instance_id": kept.astype(str),
                     "region": pd.Categorical(np.full(kept.size, unit.region_key)),
                     "spatial_x": x_idx * self.pixel_size_um,
-                    "spatial_y": y_idx * self.pixel_size_um,
+                    "spatial_y": y_idx * self.pixel_size_y_um,
                     "spatial_z": (
                         z_idx * self.z_spacing_um
                         if n_z > 1
@@ -880,7 +1033,7 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                     "instance_id": kept.astype(str),
                     "region": pd.Categorical(np.full(kept.size, unit.region_key)),
                     "spatial_x": x_idx * self.pixel_size_um,
-                    "spatial_y": y_idx * self.pixel_size_um,
+                    "spatial_y": y_idx * self.pixel_size_y_um,
                 }
             )
         obs.set_index("instance_id", inplace=True)
@@ -906,7 +1059,7 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
             # pairs values with axis *names*, so ("x", "y", "z") against
             # a (c, z, y, x) image is deliberate.
             transform: Any = Scale(
-                [self.pixel_size_um, self.pixel_size_um, self.z_spacing_um],
+                [self.pixel_size_um, self.pixel_size_y_um, self.z_spacing_um],
                 axes=("x", "y", "z"),
             )
             return Image3DModel.parse(
@@ -926,7 +1079,9 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
                 output_axes=("x", "y"),
             )
         else:
-            transform = Scale([self.pixel_size_um, self.pixel_size_um], axes=("x", "y"))
+            transform = Scale(
+                [self.pixel_size_um, self.pixel_size_y_um], axes=("x", "y")
+            )
         return Image2DModel.parse(
             xr.DataArray(plane[np.newaxis, ...], dims=("c", "y", "x")),
             transformations={self.dataset_id: transform, "global": transform},

--- a/thyra/core/base_converter.py
+++ b/thyra/core/base_converter.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from abc import ABC, abstractmethod
 from enum import Enum
 from os import PathLike
@@ -74,7 +75,10 @@ class BaseMSIConverter(ABC):
             reader: MSI data reader instance
             output_path: Path for output file
             dataset_id: Identifier for the dataset
-            pixel_size_um: In-plane pixel pitch in micrometers
+            pixel_size_um: In-plane pixel pitch in micrometers **along
+                x**. The y pitch starts equal to it and is replaced by
+                the detected one when the source declares an anisotropic
+                raster -- see :attr:`pixel_size_y_um`.
             pixel_size_source: How pixel size was determined
             compression_level: Compression level for output
             handle_3d: Whether to process as 3D data
@@ -99,6 +103,19 @@ class BaseMSIConverter(ABC):
         self.output_path = Path(output_path)
         self.dataset_id = dataset_id
         self.pixel_size_um = pixel_size_um
+        #: The pitch along y, in micrometers. A raster is usually square
+        #: and then this is :attr:`pixel_size_um`; a DESI method with
+        #: ``DesiXStep != DesiYStep`` is not, and until issue #228 only
+        #: the ``msi_metadata`` block recorded the difference while the
+        #: root attrs, the affines, the pixel footprints and
+        #: ``obs["spatial_y"]`` all carried the x pitch on both axes --
+        #: so an anisotropic raster rendered squashed by y/x and the
+        #: store contradicted itself. Settled from the detected pair (see
+        #: ``BaseSpatialDataConverter.__init__`` and
+        #: :meth:`_initialize_conversion`); a pitch the caller states with
+        #: ``--pixel-size`` applies to both axes, which is how someone
+        #: declares a raster square whatever the file says.
+        self.pixel_size_y_um: float = float(pixel_size_um)
         self.pixel_size_source = pixel_size_source
         self.compression_level = compression_level
         self.handle_3d = handle_3d
@@ -212,19 +229,7 @@ class BaseMSIConverter(ABC):
 
             # Override pixel size only if using default value and metadata
             # is available
-            if (
-                self.pixel_size_source == PixelSizeSource.DEFAULT
-                and essential.pixel_size
-            ):
-                old_size = self.pixel_size_um
-                self.pixel_size_um = essential.pixel_size[0]
-                self.pixel_size_source = PixelSizeSource.AUTO_DETECTED
-                logger.info(
-                    f"Auto-detected pixel size: {self.pixel_size_um} um "
-                    f"(was default: {old_size} um)"
-                )
-            elif self.pixel_size_source == PixelSizeSource.USER_PROVIDED:
-                logger.info(f"Using user-specified pixel size: {self.pixel_size_um} um")
+            self._adopt_detected_pixel_size(essential)
 
             # After pixel size, because the fallback is the pixel size.
             self._resolve_z_spacing(essential)
@@ -264,6 +269,50 @@ class BaseMSIConverter(ABC):
         """
         return bool(self.handle_3d and self._dimensions and self._dimensions[2] > 1)
 
+    def _adopt_detected_pixel_size(self, essential: "EssentialMetadata") -> None:
+        """Take the source's pitch when nobody supplied one, on both axes.
+
+        ``essential.pixel_size`` is an ``(x, y)`` pair and both halves are
+        kept: taking only ``[0]`` is how an anisotropic raster came to be
+        rendered square (issue #228). A pitch the caller stated applies to
+        both axes and is not overridden here.
+        """
+        if self.pixel_size_source == PixelSizeSource.DEFAULT and essential.pixel_size:
+            old_size = self.pixel_size_um
+            self.pixel_size_um = essential.pixel_size[0]
+            self.pixel_size_y_um = float(essential.pixel_size[1])
+            self.pixel_size_source = PixelSizeSource.AUTO_DETECTED
+            logger.info(
+                f"Auto-detected pixel size: {self.pixel_size_um} um "
+                f"(was default: {old_size} um)"
+            )
+        elif self.pixel_size_source == PixelSizeSource.USER_PROVIDED:
+            logger.info(f"Using user-specified pixel size: {self.pixel_size_um} um")
+        self._log_anisotropic_raster()
+
+    def _log_anisotropic_raster(self) -> None:
+        """Say so, once, when the two in-plane pitches differ.
+
+        Only a genuine difference: the comparison is exact up to float
+        noise, because a detector that computes the pitch by dividing an
+        extent by a position count can land a few ULP apart on two axes
+        of a square raster and that is not news. A real anisotropy is a
+        percent or more -- a DESI method with ``DesiXStep != DesiYStep``.
+        """
+        if math.isclose(
+            float(self.pixel_size_um), float(self.pixel_size_y_um), rel_tol=1e-9
+        ):
+            return
+        logger.info(
+            "Anisotropic raster: %g um in x, %g um in y. Both pitches are "
+            "carried through the store -- the root attrs, the element "
+            "transforms, the pixel footprints, obs['spatial_x']/['spatial_y'] "
+            "and the msi_metadata block. Pass --pixel-size to declare the "
+            "raster square instead.",
+            self.pixel_size_um,
+            self.pixel_size_y_um,
+        )
+
     def _resolve_z_spacing(self, essential: "EssentialMetadata") -> None:
         """Settle the slice-to-slice spacing, and record where it came from.
 
@@ -282,6 +331,13 @@ class BaseMSIConverter(ABC):
         coincidence -- for 3D MSI usually not at all, and often by an
         order of magnitude. A consumer reading the volume in micrometres
         renders the stack at the wrong depth.
+
+        On an anisotropic raster there is no single in-plane pitch to
+        reuse, and the x one is taken. That choice is arbitrary, which is
+        the point: nothing about the raster predicts the section
+        thickness either way, and ``z_spacing_source`` already marks the
+        number as assumed rather than measured. Supply ``--z-spacing``
+        and the question does not arise.
 
         Args:
             essential: Metadata for the dataset being converted.
@@ -519,6 +575,7 @@ class BaseMSIConverter(ABC):
             "conversion_info": {
                 "dataset_id": self.dataset_id,
                 "pixel_size_um": self.pixel_size_um,
+                "pixel_size_y_um": self.pixel_size_y_um,
                 "handle_3d": self.handle_3d,
                 "compression_level": self.compression_level,
                 "converter_class": self.__class__.__name__,
@@ -620,7 +677,7 @@ class BaseMSIConverter(ABC):
 
         # Add spatial coordinates
         coords_df["spatial_x"] = coords_df["x"] * self.pixel_size_um
-        coords_df["spatial_y"] = coords_df["y"] * self.pixel_size_um
+        coords_df["spatial_y"] = coords_df["y"] * self.pixel_size_y_um
         coords_df["spatial_z"] = coords_df["z"] * self.z_spacing_um
 
         return coords_df

--- a/thyra/preview.py
+++ b/thyra/preview.py
@@ -146,6 +146,11 @@ def _pixel_size_um(pixel_size: Optional[Tuple[float, float]]) -> Optional[float]
     Real MSI rasters are essentially always isotropic.  A debug log
     fires if ``|x - y| > 0.01 um`` so anomalies are visible without
     surfacing a UX-confusing flag in the preview.
+
+    Deliberately unlike the converter, which carries both pitches into
+    every block of the store that states one (issue #228). This is a
+    one-line summary of a folder someone is deciding whether to convert,
+    not a coordinate system; the conversion it precedes reads the pair.
     """
     if pixel_size is None:
         return None


### PR DESCRIPTION
Batch 4 of six from the 2026-09-08 robustness sweep. Three stores that were
*wrong* rather than three conversions that failed, so all three change what a
conversion does — see **What changes for users** at the end before cutting a
release.

Baseline on `main` at `46d7837` in this environment, re-measured before
starting: **2454 passed / 13 skipped** and **54 passed / 11 skipped**
(integration). After: **2484 / 13** and **54 / 11**, `pre-commit run
--all-files` clean.

---

## #243 — each table stores its own average spectrum

A multi-slice source converted as 2D (the default, one table per plane) put
one dataset-wide vector in every plane's table. On a 3-plane source scaled by
z the ratio of the stored vector to that plane's real mean was
**1.96 / 0.996 / 0.67**, identical in all three.

`uns["average_spectrum"]` is now read off **that table's own matrix** — the
column sums over the rows that were written — so it *is* `X.mean(axis=0)`,
which is what `docs/output-format.md` promises and what Ousia reads. Taking it
from the matrix rather than accumulating it alongside means there is no second
number to keep in step: the tests compare against `X.mean(axis=0)` because
that is the promise, and it holds by construction.

That also settles the denominator the issue's sub-finding names. It used to be
every spectrum the reader yielded, so a plane with a dropped all-zero row came
out low by the dropped fraction (0.75 with one of four rows dropped). It is
rows now:

- a position the acquisition never reached has **no row**, so it is in neither
  the sum nor the count;
- a position the source measured **twice** is one row holding the sum of both
  spectra since #241, so it contributes two spectra of ion current over one
  row — which is the current that row really holds. Checked, ratio 1.0.

**`average_spectrum_per_region`: decided, and written down.** It stays
**dataset-wide, spanning z**, because that is what a region is here —
`get_region_map()` is keyed on `(x, y)` and has no z component, so one region
is one in-plane footprint sampled on every plane, and splitting it per plane
would invent "region ∩ slice", which no source defines. Its denominator moves
to rows on the same rule, and its numerator moves behind the bounds check (a
spectrum off the grid is written nowhere, so it belongs in no mean). On a
multi-plane store this key therefore describes a wider population than
`average_spectrum` beside it — the one place the two schemes differ, now
stated in `docs/output-format.md` and pinned by a test rather than left for a
consumer to discover. On single-table stores, which is where regions actually
occur, the two are over the same rows.

Memory: the dataset-wide `total_intensity` and `avg_spectrum` (8 B/bin each)
are gone from the passes and each table now carries its own mean at write time
— roughly neutral for one table, and the `csc_assembly.AXIS_BYTES_PER_BIN`
note now says that the 200 B/bin figure is per bin of *one* table and that a
multi-plane conversion costs a multiple of it. That was already true of the
per-table `var` copy, which is over half the figure; it is recorded rather
than newly introduced.

## #242 — an empty conversion is refused

No position carrying a spectrum used to return `True`, exit 0, and write a
store with **no table, no image and no shapes** — while the log said both "No
non-zero entries found!" and, per plane, "no position carries a spectrum". A
calling script saw a finished conversion and a zarr with nothing to read.

**Where: after the pre-scan**, on `sum(unit.n_rows for unit in units) == 0`,
before anything is allocated and before the source is read a second time —
rather than on the empty `tables` mapping in `_save_output`. The pre-scan has
just settled every table's rows, so the same count covers every route into the
empty store, and a source that has already shown it has nothing to give is not
read twice. It raises `ConversionRefused` (batch 2's convention), so the
message prints once without a traceback, `convert()` returns `False`, and the
CLI's existing quarantine path exits 1 with nothing left at the output path.

**The message names which route was taken**, because "every spectrum was
empty" and "every peak fell outside 250–1200 m/z" send a user to different
places: no spectra at all / every spectrum empty / every intensity zero /
every intensity dropped as unusable / every peak outside the mass axis (with
the range, and `--resample-min-mz`/`--resample-max-mz` named) / every
coordinate off the declared grid.

Each of those is decided on a **total**, not on a counter being non-zero. That
matters: a resampled axis lands a few tenths of a mDa inside the source's own
range, so an all-zero imzML drops two of every twenty peaks off the axis ends
and a naive `_out_of_range_peaks > 0` blamed the resampling range for a source
whose problem was that every intensity is zero. Pass 1 now counts the peaks
handed in and the causes are compared against that.

**Not refused:** a multi-slice source where *some* planes are empty. Those are
dropped with a warning and the rest of the store is written — the #88
behaviour batch 3's tests pin. Only a conversion with no row anywhere is
refused. There is a test for each side.

`min_mz > max_mz` (#239, batch 5) is untouched here, but this refusal is what
stops it producing an empty store in the meantime.

## #228 — anisotropic pixel size: fixed, not refused

**The decision, recorded as design decision D12.** The store carried two
answers: detection kept only the x pitch (`# Use X size`), the root attrs
wrote it as `pixel_size_y_um` too, and the single float went on into
`coordinate_systems.global` and its affine, the image and shapes transforms,
the pixel footprints and `obs["spatial_y"]` — while
`msi_metadata.ms_analysis.pixel_size_um` carried the true `(x, y)`. A 30 × 50
um raster was stored as 30 × 30 in one block and (30, 50) in another, and
rendered squashed by y/x.

Fixed rather than refused, on the two facts the issue supplies:

- **The format is already per-axis.** `pixel_size_um` is `{x, y}` and
  *required*, mapped to `IMS:1000046`/`IMS:1000047`. Nothing needs adding and
  no schema version moves — the converter was the only thing carrying one
  number where the format carries two. Refusing would be declining to write a
  store the format already describes.
- **The only escape from a refusal would be a false statement.**
  `--pixel-size` applies one number to both axes, so the way out would be to
  declare a 30 × 50 um raster square — a worse store than the one the refusal
  was protecting against, because nothing in it records that a number was
  invented.

The converter now carries `pixel_size_y_um` beside `pixel_size_um`, settled
from the detected pair on both routes (`convert.py`'s detection info, and the
converter's own `essential.pixel_size` when nothing supplied a pitch — that
one took `[0]` too, the same defect a layer down). All 31 `self.pixel_size_um`
sites were read; eleven meant y and now take the y pitch. Two judgement calls:

- `_resolve_z_spacing`'s fallback takes **x**. There is no single in-plane
  pitch to reuse on an anisotropic raster and the choice is arbitrary — which
  is the point, since nothing about the raster predicts section thickness
  either way, and `z_spacing_source` already marks the number as assumed.
- `stage_offset_um` multiplies each raw offset by its own axis.

`_resolved_pixel_size_xy`'s docstring described the split as intended; it now
states the new rule and is the single source both the metadata block and the
transforms read.

**Tolerance.** Nothing is refused, so the tolerance only decides a log line:
the anisotropy is reported when the two pitches differ by more than float
noise (`rel_tol=1e-9`). Deliberately tight — a real anisotropy is a percent or
more, and the near-misses a detector used to produce were not noise but a bug
(until #217 the Waters extractor returned 29.66 × 28.93 for *every* square
raster, which this code would have carried faithfully into the affine). That
was fixed at the extractor, where it belonged.

**Tested synthetically.** No dataset in the registry is anisotropic, so a
reader is asked for a 30 × 50 um pitch and the *written store* is read back —
root attrs, `coordinate_systems.global` and its affine, the image
transformation, the pixel footprints, `obs["spatial_x"]`/`["spatial_y"]` and
the metadata block — because the point of the issue is that those blocks
disagreed with each other. A DESI method with `DesiXStep != DesiYStep` would
be the first real case and none has been run.

---

## Verification

- `pytest`: 2484 passed / 13 skipped / 0 failed (baseline 2454 / 13; the 30
  new tests are 7 + 6 + 13 + 4).
- `pytest -m integration`: 54 passed / 11 skipped / 0 failed, unchanged.
- `pre-commit run --all-files`: clean.
- #243 is checked against `X.mean(axis=0)` per table, on a store with a
  dropped row and one with a repeated coordinate, plus the per-region key.
- #242 is checked through the CLI in `tests/unit/test_cli_exit_status.py`
  (exit status, and that nothing is left at the output path), with the
  converter-level routes and the must-not-refuse case beside it.
- #228 is checked on the stored artefacts, not on the helper's return value.
- Log assertions use the named-logger fixture, never `caplog` — and never
  `"thyra"` itself across a CLI invocation, since `setup_logging` clears that
  logger's handlers on every call.

## What changes for users

Three behaviour changes that no commit subject can carry in full, for the
release notes when a release is cut:

1. **A conversion that would store nothing now exits 1** instead of 0, and
   leaves no store. A script that treated the old exit 0 as success will now
   see a failure — correctly.
2. **`uns["average_spectrum"]` changes on every multi-plane store** (it is now
   the plane's own mean) and on **any** store with a dropped or repeated row
   (the denominator is rows). Single-table stores with neither are unchanged.
3. **An anisotropic raster changes shape**: its transforms, footprints and
   `obs["spatial_y"]` now use the real y pitch, so it stops rendering squashed.
   Square rasters — every registry dataset — are byte-identical.

New root attr `pixel_size_y_um` may now differ from `pixel_size_x_um`; a
consumer reading only x as *the* pixel size should read both.

Closes #228
Closes #242
Closes #243
