### PR TITLE
fix(convert): keep bound peaks, rebase a 0-based imzML, warn on overrides

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -203,12 +203,12 @@ the table after this one says when each option is actually needed.
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--resample-method METHOD` | `auto` | `auto`, `nearest_neighbor`, or `tic_preserving` |
+| `--resample-method METHOD` | `auto` | `auto`, `nearest_neighbor`, or `tic_preserving`. A value that contradicts the detector's own choice is applied, and warned about |
 | `--mass-axis-type TYPE` | `auto` | `auto`, `constant`, `linear_tof`, `reflector_tof`, `tof`, `orbitrap`, `fticr` |
 | `--tof-law A B` | auto | Coefficients of the `tof` width law `sqrt(A m + B m^2)` mDa (`A` in mDa<sup>2</sup>/Da, `B` dimensionless). Only for an instrument Thyra has no pair for; an MRT centroid run or a timsTOF supplies its own |
 | `--resample-bins INTEGER` | auto | Number of bins (mutually exclusive with `--resample-width-at-mz`) |
-| `--resample-min-mz FLOAT` | auto | Minimum m/z value |
-| `--resample-max-mz FLOAT` | auto | Maximum m/z value |
+| `--resample-min-mz FLOAT` | auto | Minimum m/z value. Inclusive: a peak sitting exactly on it lands in the first bin |
+| `--resample-max-mz FLOAT` | auto | Maximum m/z value. Inclusive, as above; peaks outside the range are dropped, never folded into the edge bins |
 | `--resample-width-at-mz FLOAT` | auto | Mass width in Da at reference m/z for physics-based binning |
 | `--resample-reference-mz FLOAT` | `1000.0` | Reference m/z for width specification |
 | `--resample-gap-tolerance FLOAT` | none | `tic_preserving` only: discard target bins farther than this many Da from any measured m/z, instead of interpolating across the gap |
@@ -228,7 +228,7 @@ cases the defaults cannot know about.
 | A narrower mass window | `--resample-min-mz` / `--resample-max-mz` | |
 | An axis law for an instrument Thyra could not identify | `--mass-axis-type` | Note that a manual axis type also resets the width to the axis type's own default (5 mDa at m/z 1000; 17 mDa at 300 for `linear_tof`), since a width tuned for one law is not a default for another |
 | The measured `tof` law on a timsTOF, or on a new TOF you have fitted | `--mass-axis-type tof`, plus `--tof-law A B` only when Thyra has no pair for the instrument | |
-| Force interpolation on data Thyra would bin | `--resample-method tic_preserving`, and `--resample-gap-tolerance` if the m/z arrays are sparse | |
+| Force interpolation on data Thyra would bin | `--resample-method tic_preserving`, and `--resample-gap-tolerance` if the m/z arrays are sparse | The conversion warns when the method contradicts the detector, and names the tolerance flag. Take it seriously: on a sparse source, interpolation without a tolerance filled the axis and stored 1,400x the non-zeros |
 | The raw m/z values, no common axis | `--no-resample` | |
 
 The bin width of a `tof` axis is set the same way as any other: the width at

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1131,3 +1131,217 @@ the affine. That is fixed at the extractor, which is where it belonged.
 tested synthetically: a reader is asked for a 30 x 50 um pitch and the
 written store is read back. A DESI method with `DesiXStep != DesiYStep`
 would be the first real case, and nothing here has been run against one.
+
+---
+
+## D13. A peak on a declared mass-range bound lands in the edge bin
+
+**Status:** Implemented (2026-09-09), issue #239.
+
+**Decision.** A peak is in range when it is inside the **declared**
+`[min_mz, max_mz]`, not when it is inside `[axis[0], axis[-1]]`. Both
+resampling methods use that range: nearest-neighbour keeps the peak and
+maps it to its nearest bin, TIC-preserving measures the preserved share
+against it. Peaks outside the declared range are still dropped, not
+clamped.
+
+**The defect this replaces.** Every physics generator lays
+`target_bins + 1` bin *edges* across the requested range and returns the
+midpoints, so the first and last axis point sit half a bin inside what was
+asked for. A source declaring 50-1000 m/z built the axis
+`[50.0001, 999.9975]`, and a peak sitting exactly on a declared bound was
+below `axis[0]` and discarded. It costs most where a source declares its
+range *as* its first and last sample: `phi_extractor` takes `mass_range`
+from the first and last detector channel, so both were dropped in every
+pixel — the mock fixture stored 12 counts against 14 in the source, where
+`--no-resample` stored all 14.
+
+**Why not widen the axis.** Widening so that
+`axis[0] <= min_mz <= max_mz <= axis[-1]` was the other candidate the
+issue named. It changes the axis itself, so `var["mz"]` and the bin count
+move on **every** resampled store, and two stores of the same acquisition
+written either side of the change no longer share a feature axis. Edge
+bins change only which bin a boundary peak lands in — nothing else about
+any store moves, and a store with no peak on a bound is byte-identical.
+
+**Why it cannot become the clamp again.** `_nearest_neighbor_resample`
+used to clip every out-of-range index into the axis and accumulate, so
+narrowing the range piled the discarded part of the spectrum onto two
+bins: on real `pea.imzML` resampled to 400-800 m/z, bin 0 held 654,158
+counts where a real peak there is around 80, with the total conserved
+exactly so no TIC check could see it. The new rule reaches at most half a
+bin beyond the first and last centre, because the declared range *is* the
+outer bin edges. A peak further out is still dropped.
+
+**Where nothing changes.** A uniform axis is
+`np.linspace(min_mz, max_mz, n)`, whose end points already are the
+declared bounds, so `constant` stores are untouched. `--no-resample` is
+untouched too: no axis is built, and the range falls back to the axis's
+own span, which is what the rule was before.
+
+**What it is worth, measured.** On `tims_msms_pos_brain1` (713 PASEF
+frames, 302,107 peaks, declared 50-1000 m/z) **zero** peaks lie in the
+half-bin skirt; the one peak the warning reports is genuinely above 1000
+and is still dropped. So on data whose peaks are interior this is a
+correctness fix that recovers nothing. The sources it pays on are the ones
+whose declared range is a detector channel rather than an acquisition
+setting.
+
+---
+
+## D14. A 0-based imzML folds its base down; a cropped one does not move
+
+**Status:** Implemented (2026-09-09), issue #244.
+
+**Decision.** x and y are rebased on `min(observed_minimum, 1)`. A file
+whose smallest coordinate is 0 is 0-based and is rebased on 0; a file
+starting at 1, or at 5, keeps the specification's base of 1. z keeps its
+own rule — the smallest value present. What was subtracted is reported as
+`EssentialMetadata.coordinate_offsets` and written to
+`coordinate_systems.global.coordinate_offsets_px`.
+
+**The defect this replaces.** Three sites subtracted a constant 1 (the
+reader's cached coordinate array, its per-spectrum fallback, and the
+extractor's grid sizing). On a file written 0-based that produced
+`x = -1` and `y = -1` for the first row and column, which the converter's
+`_locate` guard dropped. A 3x3 file at coordinates 0..2 previewed as
+`grid (2, 2)`, warned that "5 spectra sat outside the declared 2x2x1
+grid", stored 4 rows, and exited 0.
+
+**Why not rebase on the observed minimum, as z does.** `_z_base` measures
+its base off the file and its docstring argues the case well — imzML
+guarantees nothing about the base and pyimzml is inconsistent about it.
+The argument does not carry over, because **z has no physical origin and
+x and y do.** An acquisition cropped to a region of the slide legitimately
+starts at `x = 5`; rebasing on the observed minimum would slide it to
+`x = 0`, changing the grid width, every `obs["spatial_x"]`, the TIC image
+extent and the pixel footprint — on a file that converts correctly today.
+Nothing in the file distinguishes that acquisition from a 0-based export
+whose first column happens to be empty. Folding only a 0 down fixes the
+reported defect and moves nothing else, which is the whole point: the only
+files whose stored coordinates change are the ones that were losing a row
+and a column.
+
+**Why not the declared pixel counts.** `IMS:1000042` / `IMS:1000043` were
+the third option. Nothing in Thyra reads them today except
+`mzpeak_extractor`, which carries a comment about a declared extent
+disagreeing with the coordinates it ships with. Trusting a declared extent
+over the coordinates is a larger change with a wider blast radius than the
+defect it would fix.
+
+**What the warning says now.** Nothing, on this path: a 0-based file is no
+longer off-grid, so the out-of-grid warning does not fire for it and keeps
+its meaning for a reader whose coordinates genuinely disagree with the
+grid it declares. The base itself is reported once, at INFO, naming the
+smallest coordinate found.
+
+**Known limit.** No 0-based imzML is in the registry, so this is tested
+against a written fixture (`zero_based_imzml`), alongside a 1-based one
+and a cropped 1-based one — the last being the file the rejected
+alternative would have moved.
+
+---
+
+## D15. An override that contradicts the detector warns; it does not refuse or self-correct
+
+**Status:** Implemented (2026-09-09), issue #246.
+
+**Decision.** When `--resample-method` is given explicitly, the detector
+is asked what it would have chosen and a WARNING is logged if the two
+differ. Nothing stored changes. For a `tic_preserving` override the
+warning names `--resample-gap-tolerance`, or reports the tolerance already
+in force.
+
+**The defect this replaces.** The detector has a verdict for every source
+and only the `auto` path ever asked for it, so an explicit method was
+applied with nothing checked and nothing said.
+`--resample-method tic_preserving` on a Bruker TDF — for which the
+detector chooses nearest-neighbour — interpolates across the gaps of a
+sparse centroid list and fills the axis. Measured on
+`tims_msms_pos_brain1`:
+
+| | nearest_neighbor (default) | tic_preserving |
+|---|---|---|
+| stored non-zeros | 302,106 | **423,386,757** |
+| table | 7.6 MB | 583 MB |
+| peak RSS | 0.5 GB | 5.9 GB |
+| wall | 26 s | 57 s |
+
+Per-pixel TIC is identical either way, so the TIC identity cannot see it.
+What breaks is the siblings, quietly: MS/MS blocks against the summed TIC
+come to 0.998711 per pixel, and the heatmap marginal against the stored
+mean spectrum to rel 68 with nothing recorded at all.
+
+This is the same bug class as #168 on PHI ToF-SIMS, which was fixed *by*
+adding a detector — and that is precisely why a detector is not enough on
+its own. A detector only ever steers `auto`.
+
+**Why not refuse.** A refusal would have to fire on "points per spectrum
+is a small fraction of the axis", which is true of *any* centroid source
+against a fine axis, including the ones where `tic_preserving` with a gap
+tolerance is exactly what the user wants. The threshold would be arbitrary
+and the refusal would break working commands.
+
+**Why not an automatic gap tolerance.** It changes stored values on every
+sparse `tic_preserving` conversion, including ones somebody is relying on,
+and there is no principled value to choose: half the widest source gap is
+per-spectrum and data-dependent, so the stored numbers would depend on a
+heuristic no flag records. The remedy already has a flag, and one flag per
+concept is the rule.
+
+**That the remedy works, measured.** The same conversion with
+`--resample-gap-tolerance 0.01`: **4,801,946** stored non-zeros, an 88x
+reduction against the unguarded override.
+
+**Where the size is already reported.** Batch 3's `_matrix_size_gb` logs
+the counted non-zeros after pass 1 — 423,386,757 entries, before pass 2
+writes anything. The axis guard (`AXIS_BYTES_PER_BIN`) does not fire and
+should not: 599,146 columns is an ordinary axis. What exploded is the
+matrix.
+
+---
+
+## D16. A preview that cannot count spectra says so rather than reporting the raster
+
+**Status:** Implemented (2026-09-09), issue #240.
+
+**Decision.** `MsiPreview.n_pixels` is `Optional[int]`, and is `None` when
+the format cannot count spectra without decoding them.
+`EssentialMetadata` gains `n_spectra_counted`, false only on that path,
+where `n_spectra` and `total_peaks` are 0 meaning "not counted". PHI is
+the only format that takes it, and only under `metadata_only=True`.
+
+**The defect this replaces.** `preview_msi` promises "No spectra are
+decoded" and passes `metadata_only=True` for that purpose.
+`PhiReader.__init__` swallowed the kwarg through `**kwargs`, and
+`PhiMetadataExtractor` called `get_peak_counts_per_pixel()`, which
+aggregates every 8-byte event in the stream. Measured at 0.16 s for a
+16 MB file with 2.02 M events and 0.14 s for a 14 MB one — linear, so a
+multi-gigabyte SmartSoft acquisition previewed as slowly as it converted.
+
+**Why not report the raster size.** From the header alone PHI knows the
+tile geometry (`n_x * n_y`) but not which pixels carry events: it stores a
+stream of ion arrivals, not a list of spectra. Every other reader reports
+spectra *present*, and cheaply — imzML `len(coords)`, Bruker a SQL count —
+so putting `n_x * n_y` in `n_pixels` would make that field mean "positions
+the raster covers" for one format and "spectra present" for every other.
+The raster extent is already reported, in `grid_dims`, so nothing is lost
+by declining to answer twice.
+
+**Why a flag rather than `Optional[int]` on `n_spectra`.** `n_spectra` is
+read on the conversion path in half a dozen places where it is always a
+real count; widening its type would push a `None` check into all of them
+to describe a state none of them can reach. A default-true boolean beside
+it says the same thing and is inert everywhere else.
+
+**Precedent.** Bruker already does this for the other half:
+`skip_total_peaks=self._metadata_only` reports `total_peaks` as 0 without
+scanning the Frames table. `skip_event_aggregate` is the same idea, and
+`n_spectra_counted` retro-fits the missing part — a way to tell
+0-not-counted from 0-none-present.
+
+**What the preview still answers.** Dimensions, coordinate bounds, m/z
+range, pixel size and both detector verdicts, all from the header and the
+block chain. `PhiToFSIMSDetector` matches on the format flag rather than
+on peak density, so zeroing the counts does not cost the preview its
+nearest-neighbour verdict — which would have been a regression of #168.

--- a/docs/imzml-parser-notes.md
+++ b/docs/imzml-parser-notes.md
@@ -187,6 +187,45 @@ succeeding. That is exactly where SCiLS puts `MS:1000127`.
 
 ---
 
+## The coordinate base is not a constant
+
+The specification numbers x and y from 1, and pyimzml passes through whatever
+the document holds. Exports numbered from **0** exist, so subtracting a
+constant 1 -- which Thyra did until v3.24.0 -- produced `x = -1` for the first
+column of one. A negative index is a legal *negative* numpy index, so the
+converter's grid guard dropped those spectra rather than crashing: a 3x3
+acquisition at coordinates 0..2 previewed as `grid (2, 2)`, warned that "5
+spectra sat outside the declared 2x2x1 grid", stored 4 rows and exited 0.
+
+The base is now measured, by `thyra.utils.imzml_coordinate_base`, and the rule
+is deliberately **not** the one z uses:
+
+| axis | rule | why |
+|---|---|---|
+| x, y | `min(observed_minimum, 1)` | 0 folds down; 1 and anything above it keep the spec base |
+| z | `observed_minimum` | z has no physical origin to preserve |
+
+Rebasing x and y on their observed minimum would move a legitimately **cropped**
+acquisition. A file whose leftmost occupied column is `x = 5` is a region of a
+larger slide, not a 0-based export, and nothing in the document distinguishes
+the two; sliding it to the origin would change its grid width, every
+`obs["spatial_x"]`, the TIC image extent and its pixel footprint. Folding only
+a 0 down leaves every such file exactly where it was.
+
+The declared `IMS:1000042` / `IMS:1000043` pixel counts were the third
+candidate and are still unread here. `mzpeak_extractor` is the only place in
+Thyra that reads them at all, and it carries a comment about a declared extent
+disagreeing with the coordinates shipped beside it.
+
+Whatever is subtracted is reported as
+`EssentialMetadata.coordinate_offsets` and written to
+`coordinate_systems.global.coordinate_offsets_px`, so a store can say where its
+origin came from. Before this the imzML extractor set no offsets at all.
+
+Pinned by `tests/unit/readers/test_imzml_zero_based.py`, which converts a
+0-based file, a 1-based one and a cropped 1-based one -- the last being the
+file the rejected alternative would have moved.
+
 ## Fixed in Thyra, still true of pyimzml
 
 One finding was real enough to grow code: **`imzmldict` discards

--- a/docs/phi-tofsims-notes.md
+++ b/docs/phi-tofsims-notes.md
@@ -222,6 +222,21 @@ sitting at 44% of the base peak. Use `nearest_neighbor`, or if the method is
 forced, set `ResamplingConfig.gap_tolerance_da` (see
 [Resampling](resampling.md) and `thyra.resampling.gaps`).
 
+Forcing it no longer happens silently: since v3.24.0 an explicit
+`--resample-method` that contradicts the detector is warned about, and the
+warning names `--resample-gap-tolerance`. The detector alone was never enough,
+because a detector only steers `auto`.
+
+**The first and last channel.** `mass_range` here is literally
+`(axis.mz[0], axis.mz[-1])` -- the first and last detector channel, not an
+acquisition setting. A physics axis stores bin centres, which stop half a bin
+short of the range they were built across, so testing membership against the
+axis points discarded both channels in every pixel: the mock fixture stored 12
+counts against the source's 14, on all six resampled variants, where
+`--no-resample` stored all 14. Since v3.24.0 the test is the declared range, so
+a peak on either bound lands in the edge bin. See
+[What "in range" means](resampling.md#what-in-range-means).
+
 ### Choosing a bin width
 
 The instrument's measured resolving power on the reference file is **R ~ 4,000**
@@ -245,6 +260,30 @@ C₂H₂⁻ -- 12.6 mDa apart, or 1.94 FWHM, genuinely resolved by this instrume
     It is roughly 19x the peak width at m/z 26, so CN⁻ and C₂H₂⁻ land in the
     same bin along with everything else between them. Constant-width axes suit
     profile MALDI-TOF; they do not suit ToF-SIMS.
+
+## Previewing without decoding events
+
+`preview_msi` promises that no spectra are decoded, and passes
+`metadata_only=True` to the reader to keep that promise. `PhiReader` used to
+swallow the kwarg, and the extractor called `get_peak_counts_per_pixel()`,
+which walks every 8-byte event in the file: 0.16 s for a 16 MB acquisition with
+2.02 M events, 0.14 s for a 14 MB one -- linear, so previewing a multi-gigabyte
+SmartSoft file cost what converting it costs.
+
+`PhiReader(path, metadata_only=True)` now answers from the acquisition header
+and the block chain alone. Everything header-derived is still exact --
+dimensions, coordinate bounds, m/z range, pixel size, and both detector
+verdicts. What it cannot answer is which pixels carry an event, because that is
+a property of the stream rather than the header, so `n_spectra` comes back as 0
+with `n_spectra_counted=False` and `preview_msi` reports `n_pixels` as `None`.
+
+It is reported as unknown rather than as `n_x * n_y` on purpose. Every other
+reader's `n_spectra` counts spectra *present*, cheaply -- imzML the length of
+its coordinate list, Bruker a SQL count -- and filling this one in with the
+raster size would make the same field mean two different things. The raster is
+already reported, as `grid_dims`.
+
+A reader built for conversion is unaffected and still counts every pixel.
 
 ## Pixel size
 

--- a/docs/resampling.md
+++ b/docs/resampling.md
@@ -206,6 +206,28 @@ INFO - Selected resampling method: NEAREST_NEIGHBOR
 INFO - Selected axis type: REFLECTOR_TOF
 ```
 
+### Overriding the detector
+
+`--resample-method` overrules the detector, and the detector is still asked
+what it would have picked. When the two disagree, the conversion says so and
+carries on:
+
+```
+WARNING - Resampling method TIC_PRESERVING was given explicitly, but this
+source's detector chose NEAREST_NEIGHBOR for it. Interpolating a source the
+detector reads as sparse fills the whole axis: [...] Pass
+--resample-gap-tolerance to discard bins no measured m/z vouches for, or drop
+the override.
+```
+
+Nothing about the output changes -- the method you asked for is the method
+used. The warning exists because the failure it points at is invisible in the
+totals: on a 713-frame PASEF acquisition, `--resample-method tic_preserving`
+stored **423,386,757** non-zeros against 302,106 for the detector's choice, a
+583 MB table against 7.6 MB, and per-pixel TIC identical to the last digit.
+Adding `--resample-gap-tolerance 0.01` to the same command brings it down to
+4,801,946. See [Gaps in the source m/z values](#gaps-in-the-source-mz-values).
+
 ---
 
 ## Methods
@@ -279,6 +301,44 @@ asking for `tic_preserving` anyway.
 
 `nearest_neighbor` needs no such parameter: it only ever fills a bin some peak
 was snapped into.
+
+---
+
+## What "in range" means
+
+Both methods keep a peak when it lies inside the **declared** mass range --
+`--resample-min-mz` and `--resample-max-mz`, or the source's own range when you
+set neither. Peaks outside it are **discarded**, not folded into the first or
+last bin.
+
+The declared range is not quite the same as the span of the axis points. Every
+physics axis type lays its bins as `target_bins + 1` edges across the range and
+stores the **centres**, so the first and last centre sit half a bin inside the
+range you asked for: a source declaring 50-1000 m/z builds an axis running
+`50.0001` to `999.9975`. A peak at exactly 50.0 belongs in the first bin, and
+until v3.24.0 it was thrown away instead. That mattered most for sources whose
+declared range *is* their first and last sample -- PHI ToF-SIMS takes its mass
+range from the first and last detector channel, so both channels were lost in
+every pixel.
+
+`constant` axes are unaffected either way: they are laid out with
+`np.linspace(min_mz, max_mz, n)`, whose end points already are the declared
+bounds. `--no-resample` is unaffected too -- the axis there is the source's own
+values.
+
+Dropping is deliberate and is reported once per conversion:
+
+```
+WARNING - Dropping peaks that fall outside the target mass range
+[250.0000, 1200.0000] m/z -- 2 of 20 in the first spectrum affected. They are
+discarded, not folded into the edge bins. Widen the resampling range to keep
+them.
+```
+
+Folding them in instead would be worse, and used to happen: clamping every
+out-of-range peak onto the nearest edge bin put 654,158 counts in bin 0 of
+`pea.imzML` cropped to 400-800 m/z, where a real peak there is around 80. The
+total was conserved exactly, so no TIC check could see it.
 
 ---
 

--- a/docs/supported-formats.md
+++ b/docs/supported-formats.md
@@ -83,6 +83,17 @@ The open interchange format, read through
 An `.imzML` without its `.ibd` beside it is rejected up front, because the XML
 holds only offsets and the binary holds the data.
 
+**Pixel numbering.** The specification numbers x and y from 1, and Thyra
+subtracts that to reach the 0-based indices the store uses. Exports numbered
+from **0** exist, and on those the subtraction used to produce `x = -1` for the
+first column, which the grid guard then dropped -- a 3x3 acquisition stored as
+4 pixels, with a warning naming a 2x2 grid the file never declared. Since
+v3.24.0 the base is measured: a file whose smallest coordinate is 0 is rebased
+on 0, and a file starting at 1 -- or at 5, because it is a crop of a larger
+slide -- keeps the base of 1 and does not move. z is separate and rebases on
+the smallest plane present, because z has no origin to preserve. Whatever was
+subtracted is recorded in `coordinate_systems.global.coordinate_offsets_px`.
+
 **Ion mobility.** imzML defines two binary arrays, but TIMSCONVERT and
 TIMSImaging add a third for mobility, declared through a param group bound to
 `MS:1003006` (mean inverse reduced ion mobility array, unit `MS:1002814`).
@@ -400,6 +411,15 @@ reconstructed bit-exactly, and the exported peak images to 99.7%. Mosaic,
 MS/MS and depth-profiling acquisitions are implemented but have only been
 tested against synthetic files -- if you have real data in one of those modes,
 please [open an issue](https://github.com/M4i-Imaging-Mass-Spectrometry/thyra/issues).
+
+**Previewing costs nothing.** Recording events rather than spectra means the
+header cannot say which pixels carry one; counting them means decoding the
+whole stream, which `preview_msi` used to do despite promising otherwise --
+linear in file size, so a multi-gigabyte acquisition previewed as slowly as it
+converted. Since v3.24.0 a preview answers from the header and the block chain
+alone, and reports `n_pixels` as `None`: unknown, rather than quietly filled in
+with the raster size that `grid_dims` already carries. A conversion is
+unaffected and still counts every pixel exactly.
 
 See [PHI ToF-SIMS Notes](phi-tofsims-notes.md) for the file layout, the
 calibration behaviour, and why the time axis is binned the way it is.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,6 +159,71 @@ def create_minimal_imzml(temp_dir):
     return imzml_path, ibd_path, mzs, all_intensities
 
 
+def _write_square_imzml(path, origin, side):
+    """Write a ``side`` x ``side`` imzML whose lowest coordinate is ``origin``.
+
+    Every pixel carries one peak whose intensity encodes its position, so a
+    row that moved can be told from a row that went missing.
+
+    Args:
+        path: Where to write the ``.imzML`` (the ``.ibd`` goes beside it).
+        origin: The smallest x and y written to the file. ``1`` is what the
+            specification says; ``0`` is what some exporters write.
+        side: Pixels per side.
+
+    Returns:
+        ``(path, mzs, expected)`` where ``expected`` maps the 0-based
+        ``(x, y)`` the store should hold to that pixel's intensity.
+    """
+    mzs = np.linspace(100.0, 200.0, 5)
+    expected = {}
+
+    with ImzMLWriter(str(path), mode="processed") as writer:
+        for row in range(side):
+            for col in range(side):
+                intensity = np.zeros_like(mzs)
+                # Distinct per pixel, and never zero: a pixel whose only
+                # peak is zero gets no row at all, which would hide the
+                # very loss this fixture exists to detect.
+                intensity[2] = 100.0 + 10.0 * row + col
+                writer.addSpectrum(mzs, intensity, (origin + col, origin + row, 1))
+                expected[(col, row)] = intensity[2]
+
+    return path, mzs, expected
+
+
+@pytest.fixture
+def zero_based_imzml(temp_dir):
+    """A 3x3 imzML numbered from 0 -- the shape of issue #244.
+
+    The imzML specification numbers pixels from 1, and the reader used to
+    subtract a constant 1. On a file written 0-based that produced
+    ``x = -1`` for the first column, which the converter's grid guard
+    dropped: the store came out 4 rows of a 3x3 acquisition, with a
+    warning naming a 2x2 grid the file never declared, and exit 0.
+    """
+    return _write_square_imzml(temp_dir / "zero_based.imzML", origin=0, side=3)
+
+
+@pytest.fixture
+def one_based_imzml(temp_dir):
+    """The same 3x3 acquisition written the way the specification says."""
+    return _write_square_imzml(temp_dir / "one_based.imzML", origin=1, side=3)
+
+
+@pytest.fixture
+def cropped_one_based_imzml(temp_dir):
+    """A 1-based acquisition whose leftmost column is x = 5, not x = 1.
+
+    The reason x and y do not simply rebase on their observed minimum the
+    way z does: this file is a legitimately cropped region of the slide,
+    and sliding it to the origin would change its grid width, every
+    ``obs`` coordinate and its pixel footprint -- on a file that converts
+    correctly today.
+    """
+    return _write_square_imzml(temp_dir / "cropped.imzML", origin=5, side=3)
+
+
 @pytest.fixture
 def mock_bruker_data(temp_dir):
     """

--- a/tests/unit/converters/test_declared_range_edge_bins.py
+++ b/tests/unit/converters/test_declared_range_edge_bins.py
@@ -1,0 +1,339 @@
+# tests/unit/converters/test_declared_range_edge_bins.py
+"""A peak exactly on a declared mass-range bound lands in the edge bin.
+
+Every physics generator lays ``target_bins + 1`` bin *edges* across the
+requested ``[min_mz, max_mz]`` and returns the midpoints, so the first and
+last axis point sit half a bin inside the range that was asked for: a
+source declaring 50-1000 built the axis ``[50.0001, 999.9975]``. The keep
+rule tested membership against those axis points, so a peak sitting
+exactly on a declared bound was always discarded (issue #239).
+
+It costs most on the sources that declare their range *as* their first and
+last sample. PHI TOF-SIMS sets ``mass_range`` from the first and last
+detector channel, so both were dropped in every pixel of every resampled
+variant of the mock fixture -- 12 counts stored against 14 in the source,
+where ``--no-resample`` stored all 14.
+
+The fix must not become the clamp it replaced
+---------------------------------------------
+
+``_nearest_neighbor_resample`` used to clip every out-of-range index into
+the axis and accumulate, so narrowing the range piled the whole discarded
+part of the spectrum onto two bins: on real ``pea.imzML`` resampled to
+400-800 m/z, bin 0 held 654,158 counts where a real peak there is around
+80. The total was conserved exactly, so no TIC check could see it.
+
+The new rule is bounded to the **declared** range -- at most half a bin
+beyond the first and last centre -- which is why
+:class:`TestBinZeroIsStillNotADumpingGround` sits alongside the
+edge-bin tests rather than instead of them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import anndata
+import numpy as np
+import pytest
+
+from thyra.converters.spatialdata.base_spatialdata_converter import (
+    SPATIALDATA_AVAILABLE,
+    BaseSpatialDataConverter,
+    _kept_mz_range,
+)
+from thyra.converters.spatialdata.streaming_converter import (
+    StreamingSpatialDataConverter,
+)
+from thyra.readers.imzml import ImzMLReader
+from thyra.resampling.common_axis import CommonAxisBuilder
+from thyra.resampling.types import AxisType
+
+MIN_MZ = 100.0
+MAX_MZ = 1000.0
+N_BINS = 5_000
+
+
+def _physics_axis() -> np.ndarray:
+    """A linear-TOF axis over ``[MIN_MZ, MAX_MZ]``, as the converter builds it."""
+    return (
+        CommonAxisBuilder()
+        .build_physics_axis(
+            min_mz=MIN_MZ,
+            max_mz=MAX_MZ,
+            num_bins=N_BINS,
+            axis_type=AxisType.LINEAR_TOF,
+        )
+        .mz_values.astype(np.float64)
+    )
+
+
+def _stub(axis, axis_range):
+    """The converter's resampling surface, without building a converter.
+
+    The same ``SimpleNamespace`` pattern the other resampling tests use,
+    with the reporting helper bound on so the count and the one-shot
+    warning are the real ones.
+    """
+    stub = SimpleNamespace(
+        _common_mass_axis=np.asarray(axis, float),
+        _axis_range=axis_range,
+        _gap_tolerance_da=None,
+        _out_of_range_peaks=0,
+        _out_of_range_warned=False,
+    )
+    stub._count_out_of_range = (
+        lambda n_dropped, n_total: BaseSpatialDataConverter._count_out_of_range(
+            stub, n_dropped, n_total
+        )
+    )
+    return stub
+
+
+def _nearest_neighbor(stub, mzs, intensities):
+    return BaseSpatialDataConverter._nearest_neighbor_resample(
+        stub, np.asarray(mzs, float), np.asarray(intensities, float)
+    )
+
+
+def _tic_preserving(stub, mzs, intensities):
+    return BaseSpatialDataConverter._tic_preserving_resample(
+        stub, np.asarray(mzs, float), np.asarray(intensities, float)
+    )
+
+
+class TestTheAxisReallyStopsShortOfTheDeclaredRange:
+    """Guard the guard: without this gap there is nothing to fix."""
+
+    def test_the_first_and_last_centre_sit_inside_the_range(self):
+        axis = _physics_axis()
+
+        assert axis[0] > MIN_MZ
+        assert axis[-1] < MAX_MZ
+
+    def test_the_gap_is_no_more_than_half_a_bin(self):
+        """The bound the fix is allowed to reach, and no further."""
+        axis = _physics_axis()
+
+        assert axis[0] - MIN_MZ < (axis[1] - axis[0])
+        assert MAX_MZ - axis[-1] < (axis[-1] - axis[-2])
+
+
+class TestAPeakOnTheBoundSurvives:
+    """Both methods, because a rule only one follows is a disagreement."""
+
+    def test_nearest_neighbor_puts_the_bounds_in_the_edge_bins(self):
+        axis = _physics_axis()
+        stub = _stub(axis, (MIN_MZ, MAX_MZ))
+
+        indices, values = _nearest_neighbor(stub, [MIN_MZ, MAX_MZ], [7.0, 11.0])
+
+        assert sorted(indices.tolist()) == [0, len(axis) - 1]
+        assert values.sum() == pytest.approx(18.0)
+        assert stub._out_of_range_peaks == 0
+        assert not stub._out_of_range_warned
+
+    def test_nearest_neighbor_dropped_them_before(self):
+        """The same call with no declared range is the old behaviour."""
+        axis = _physics_axis()
+        stub = _stub(axis, None)
+
+        indices, _ = _nearest_neighbor(stub, [MIN_MZ, MAX_MZ], [7.0, 11.0])
+
+        assert indices.size == 0
+        assert stub._out_of_range_peaks == 2
+
+    def test_tic_preserving_keeps_the_bound_peaks_too(self):
+        axis = _physics_axis()
+        stub = _stub(axis, (MIN_MZ, MAX_MZ))
+
+        resampled = _tic_preserving(stub, [MIN_MZ, 500.0, MAX_MZ], [7.0, 5.0, 11.0])
+
+        assert resampled.sum() == pytest.approx(23.0)
+        assert resampled[0] > 0.0
+        assert resampled[-1] > 0.0
+
+    def test_the_two_methods_preserve_the_same_total(self):
+        """#248's rule: they must agree on what the axis covers."""
+        axis = _physics_axis()
+        mzs = [MIN_MZ, 250.0, 700.0, MAX_MZ]
+        intensities = [7.0, 3.0, 5.0, 11.0]
+
+        _, nn_values = _nearest_neighbor(
+            _stub(axis, (MIN_MZ, MAX_MZ)), mzs, intensities
+        )
+        tic_values = _tic_preserving(_stub(axis, (MIN_MZ, MAX_MZ)), mzs, intensities)
+
+        assert nn_values.sum() == pytest.approx(sum(intensities))
+        assert tic_values.sum() == pytest.approx(sum(intensities))
+
+    def test_the_shared_axis_cache_agrees_with_the_generic_path(self):
+        """The fast path for a shared m/z array carries its own keep rule.
+
+        It slices the in-range subset with ``searchsorted`` rather than a
+        mask, so the two rules are written twice and can disagree once.
+        """
+        axis = _physics_axis()
+        mzs = np.array([MIN_MZ, 300.0, MAX_MZ])
+        intensities = np.array([7.0, 3.0, 11.0])
+
+        cached = _stub(axis, (MIN_MZ, MAX_MZ))
+        cached._nn_shared_cache = None
+        cached._nn_cache_misses = 0
+        cached._build_nn_shared_cache = (
+            lambda a, m: BaseSpatialDataConverter._build_nn_shared_cache(cached, a, m)
+        )
+        cached._nn_resample_via_cache = (
+            lambda a, m, i: BaseSpatialDataConverter._nn_resample_via_cache(
+                cached, a, m, i
+            )
+        )
+
+        # First call builds the cache, second one hits it.
+        first = _nearest_neighbor(cached, mzs, intensities)
+        second = _nearest_neighbor(cached, mzs, intensities)
+        generic = _nearest_neighbor(_stub(axis, (MIN_MZ, MAX_MZ)), mzs, intensities)
+
+        for got in (first, second):
+            assert got[0].tolist() == generic[0].tolist()
+            assert got[1] == pytest.approx(generic[1])
+
+
+class TestBinZeroIsStillNotADumpingGround:
+    """The regression the current rule exists to prevent."""
+
+    def test_a_peak_below_the_declared_minimum_is_dropped(self):
+        axis = _physics_axis()
+        stub = _stub(axis, (MIN_MZ, MAX_MZ))
+
+        indices, values = _nearest_neighbor(
+            stub, [50.0, 500.0, 5_000.0], [654_158.0, 80.0, 654_158.0]
+        )
+
+        assert values.sum() == pytest.approx(80.0)
+        assert 0 not in indices.tolist()
+        assert stub._out_of_range_peaks == 2
+
+    def test_the_slack_stops_at_the_declared_bound(self):
+        """Half a bin outside the *centre*, not half a bin outside the range."""
+        axis = _physics_axis()
+        stub = _stub(axis, (MIN_MZ, MAX_MZ))
+
+        indices, _ = _nearest_neighbor(stub, [MIN_MZ - 1e-6, MAX_MZ + 1e-6], [3.0, 4.0])
+
+        assert indices.size == 0
+
+    def test_a_spectrum_wholly_outside_the_range_stores_nothing(self):
+        """Both methods, and the one assertion they can share here.
+
+        The clamp only ever existed on the nearest-neighbour path, so
+        "bin 0 does not collect the floor" is a claim about that method
+        alone. ``tic_preserving`` interpolates *between* source points by
+        construction, so a peak below the range still raises the bins
+        between it and the next measured point -- that is the method
+        working as documented, and the hazard
+        ``--resample-gap-tolerance`` exists for (issue #246), not this
+        one. What both must agree on is a spectrum the range does not
+        reach at all.
+        """
+        axis = _physics_axis()
+
+        indices, values = _nearest_neighbor(
+            _stub(axis, (MIN_MZ, MAX_MZ)), [10.0, 20.0], [654_158.0, 9.0]
+        )
+        resampled = _tic_preserving(
+            _stub(axis, (MIN_MZ, MAX_MZ)), [10.0, 20.0], [654_158.0, 9.0]
+        )
+
+        assert indices.size == 0
+        assert values.size == 0
+        assert resampled.sum() == 0.0
+
+
+class TestAUniformAxisIsUnchanged:
+    """``np.linspace`` end points *are* the declared bounds, so nothing moves."""
+
+    def test_the_kept_range_is_the_axis_span(self):
+        axis = np.linspace(100.0, 110.0, 11)
+
+        assert _kept_mz_range(axis, (100.0, 110.0)) == (100.0, 110.0)
+        assert _kept_mz_range(axis, None) == (100.0, 110.0)
+
+    def test_a_peak_just_outside_is_still_out(self):
+        axis = np.linspace(100.0, 110.0, 11)
+        stub = _stub(axis, (100.0, 110.0))
+
+        indices, _ = _nearest_neighbor(stub, [100.0 - 1e-9, 110.0 + 1e-9], [3.0, 4.0])
+
+        assert indices.size == 0
+
+
+class TestTheKeptRangeNeverNarrowsTheAxis:
+    def test_a_range_inside_the_axis_is_widened_to_it(self):
+        """A generator that overshot must not cost a peak with a bin waiting."""
+        axis = np.linspace(100.0, 110.0, 11)
+
+        assert _kept_mz_range(axis, (101.0, 109.0)) == (100.0, 110.0)
+
+
+@pytest.mark.skipif(
+    not SPATIALDATA_AVAILABLE, reason="SpatialData dependencies not available"
+)
+class TestEndToEndOnAPhysicsAxis:
+    """A conversion whose only peaks sit on the declared bounds.
+
+    Before #239 this stored nothing at all, and batch 4's empty-store
+    guard turned that into a refusal: the whole spectrum was "outside the
+    target mass axis" although every peak was inside the range asked for.
+    """
+
+    @staticmethod
+    def _convert(imzml_path: Path, output_path: Path, mzs) -> bool:
+        reader = ImzMLReader(imzml_path)
+        try:
+            return StreamingSpatialDataConverter(
+                reader=reader,
+                output_path=output_path,
+                dataset_id="edge",
+                pixel_size_um=10.0,
+                resampling_config={
+                    "method": "nearest_neighbor",
+                    "axis_type": "linear_tof",
+                    "target_bins": 2_000,
+                    # The two m/z the fixture actually puts intensity on.
+                    "min_mz": float(mzs[10]),
+                    "max_mz": float(mzs[30]),
+                },
+            ).convert()
+        finally:
+            reader.close()
+
+    def test_the_bound_peaks_reach_the_store(self, create_minimal_imzml, temp_dir):
+        imzml_path, _, mzs, all_intensities = create_minimal_imzml
+        output_path = temp_dir / "edges.zarr"
+
+        assert self._convert(imzml_path, output_path, mzs) is True
+
+        adata = anndata.read_zarr(output_path / "tables" / "edge_z0")
+        stored_total = float(np.asarray(adata.X.sum()))
+        expected = sum(
+            float(intensities[10] + intensities[30]) for intensities in all_intensities
+        )
+
+        assert adata.n_obs == 4
+        assert stored_total == pytest.approx(expected)
+
+    def test_both_bounds_land_in_the_edge_bins(self, create_minimal_imzml, temp_dir):
+        """Not merely kept: kept in the bin the declared range gives them."""
+        imzml_path, _, mzs, _ = create_minimal_imzml
+        output_path = temp_dir / "edge_bins.zarr"
+
+        assert self._convert(imzml_path, output_path, mzs) is True
+
+        adata = anndata.read_zarr(output_path / "tables" / "edge_z0")
+        occupied = sorted(
+            int(c) for c in np.unique(adata.X.tocoo().col)  # type: ignore[union-attr]
+        )
+
+        assert occupied == [0, adata.n_vars - 1]

--- a/tests/unit/converters/test_out_of_grid_guard.py
+++ b/tests/unit/converters/test_out_of_grid_guard.py
@@ -10,7 +10,7 @@ the guard stored 39,508.05 for pixel (3, 3) against a truth of 47,363.47.
 
 **Reachability.** ``imzml_reader`` subtracts 1 from the 1-based positions
 an imzML declares, so a file that is already 0-based yields ``x = -1``
--- the same base-convention hazard ``_z_base()`` documents for z. That
+-- the same base-convention hazard ``_coordinate_bases()`` settles. That
 route is inferred from the reader source rather than measured against a
 vendor file, so the fixture reproduces the coordinate directly.
 

--- a/tests/unit/converters/test_out_of_range_peaks.py
+++ b/tests/unit/converters/test_out_of_range_peaks.py
@@ -1,5 +1,5 @@
 # tests/unit/converters/test_out_of_range_peaks.py
-"""Peaks outside the target mass axis are dropped, not folded into the edges.
+"""Peaks outside the target mass range are dropped, not folded into the edges.
 
 ``_nearest_neighbor_resample`` clipped every source index into
 ``[0, len(axis) - 1]`` and then accumulated with ``np.bincount``, so a peak
@@ -14,11 +14,13 @@ against a median interior bin of 118 -- and the stored pixel total was the
 *whole* input TIC, 1,090,866, rather than the 364,816 that actually lies in
 range.
 
-"In range" is the strict axis span: a peak is kept when
-``axis[0] <= mz <= axis[-1]``, not when it is within half a bin of an end.
-That matches ``_tic_preserving_resample``, whose ``np.interp(left=0,
-right=0)`` and ``preserved_tic`` both cut at the endpoints -- so the two
-methods now agree on which peaks the axis covers.
+"In range" is the **declared** ``[min_mz, max_mz]``, which for the uniform
+``np.linspace`` axes used throughout this file is exactly the axis span
+``[axis[0], axis[-1]]`` -- so every case here reads the same either way. On a
+physics axis the two differ by half a bin, and
+``tests/unit/converters/test_declared_range_edge_bins.py`` covers that (issue
+#239). Both resampling methods follow the one rule, which is what stops them
+disagreeing about what the axis covers.
 """
 
 from __future__ import annotations
@@ -127,7 +129,13 @@ class TestEdgeBinsHoldOnlyWhatBelongsThere:
         assert values.sum() == pytest.approx(7.0)
 
     def test_a_peak_just_outside_is_out(self):
-        """Half a bin of slack would have kept these; the rule is the span."""
+        """A peak outside the declared range is dropped, however close.
+
+        On this uniform axis the declared range *is* the axis span, so a
+        peak a nanodalton below 100.0 is outside both. Half a bin of slack
+        would have kept these; the rule reaches the declared bound and
+        stops.
+        """
         indices, _ = _resample(_stub(self.AXIS), [100.0 - 1e-9, 110.0 + 1e-9], [3, 4])
 
         assert indices.size == 0
@@ -186,9 +194,9 @@ class TestTicPreservingAlreadyAgreed:
 
     ``_tic_preserving_resample`` never had this bug -- ``np.interp`` is
     given ``left=0, right=0`` and the rescale target comes from
-    ``preserved_tic``, which integrates only over the axis span. Pinning it
-    here so a future change cannot make nearest-neighbour the odd one out
-    again in the other direction.
+    ``preserved_tic``, which integrates only over the range the axis
+    covers. Pinning it here so a future change cannot make
+    nearest-neighbour the odd one out again in the other direction.
     """
 
     def test_tic_preserving_keeps_only_the_in_range_share(self):

--- a/tests/unit/converters/test_resample_override_contradiction.py
+++ b/tests/unit/converters/test_resample_override_contradiction.py
@@ -1,0 +1,175 @@
+# tests/unit/converters/test_resample_override_contradiction.py
+"""An explicit ``--resample-method`` that overrules the detector says so.
+
+The detector has a verdict for every source, and until #246 only the
+``auto`` path ever asked for it. An explicit method was applied with
+nothing checked and nothing said, which is how ``tic_preserving`` on a
+Bruker TDF -- for which the detector chooses nearest-neighbour --
+interpolated across the gaps of a sparse centroid list and filled the
+axis. Measured on a 713-frame PASEF acquisition:
+
+======================  ==================  ===============
+                          nearest_neighbor   tic_preserving
+======================  ==================  ===============
+stored non-zeros                   302,106      423,386,757
+table                              7.6 MB           583 MB
+peak RSS                            0.5 GB           5.9 GB
+======================  ==================  ===============
+
+Per-pixel TIC is identical either way, so the TIC identity cannot see it.
+What breaks is the siblings, quietly: the heatmap marginal against the
+stored mean spectrum came to rel 68, with nothing recorded anywhere.
+
+Same bug class as #168 on PHI ToF-SIMS -- which was fixed *by* adding a
+detector, and that is exactly why a detector is not enough on its own. A
+detector only ever steers ``auto``.
+
+Nothing stored changes here (design decision D15): the warning names
+``--resample-gap-tolerance``, which already exists and, measured on the
+same acquisition, brings those 423,386,757 entries down to 4,801,946.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from thyra.converters.spatialdata.base_spatialdata_converter import (
+    BaseSpatialDataConverter,
+)
+from thyra.resampling.types import ResamplingMethod
+
+_LOGGER = "thyra.converters.spatialdata.base_spatialdata_converter"
+
+
+class _Converter:
+    """Just enough converter to run ``_setup_resampling``.
+
+    The metadata dict is what the decision tree reads; everything else on
+    the real converter is irrelevant to the check under test.
+    """
+
+    def __init__(self, metadata):
+        self._metadata = metadata
+        self._resampling_method = None
+
+    def _get_reader_metadata_for_resampling(self):
+        return self._metadata
+
+    _setup_resampling = BaseSpatialDataConverter._setup_resampling
+    _warn_if_override_contradicts_detector = (
+        BaseSpatialDataConverter._warn_if_override_contradicts_detector
+    )
+
+
+#: A sparse centroid source the detector reads as nearest-neighbour. The
+#: PHI format flag is the cheapest unambiguous way to get that verdict
+#: without a vendor file; ``PhiToFSIMSDetector`` matches on it alone.
+_SPARSE_SOURCE = {
+    "source_path": "acquisition.raw",
+    "essential_metadata": {
+        "spectrum_type": "profile spectrum",
+        "dimensions": (4, 4, 1),
+        "mass_range": (1.0, 100.0),
+        "source_path": "acquisition.raw",
+        "total_peaks": 64,
+        "n_spectra": 16,
+    },
+    "format_specific": {"format": "PHI SmartSoft-TOF raw"},
+}
+
+
+def _run(config, metadata=None):
+    converter = _Converter(metadata if metadata is not None else _SPARSE_SOURCE)
+    converter._resampling_config = config
+    converter._setup_resampling()
+    return converter
+
+
+def _config(**overrides):
+    from thyra.converters.spatialdata.base_spatialdata_converter import (
+        _normalize_resampling_config,
+    )
+
+    settings = {"method": "nearest_neighbor", "axis_type": "auto"}
+    settings.update(overrides)
+    return _normalize_resampling_config(settings)
+
+
+def _contradictions(records):
+    return [r.getMessage() for r in records if "detector chose" in r.getMessage()]
+
+
+class TestTheDetectorIsConsultedOnAnOverride:
+    def test_it_warns_when_the_override_contradicts(self, thyra_logs):
+        with thyra_logs(_LOGGER, logging.WARNING) as records:
+            converter = _run(_config(method="tic_preserving"))
+
+        messages = _contradictions(records)
+        assert len(messages) == 1, [r.getMessage() for r in records]
+        assert "TIC_PRESERVING" in messages[0]
+        assert "NEAREST_NEIGHBOR" in messages[0]
+        # The override still applies: this reports, it does not overrule.
+        assert converter._resampling_method is ResamplingMethod.TIC_PRESERVING
+
+    def test_it_names_the_flag_that_fixes_it(self, thyra_logs):
+        """A warning with no way out is just noise."""
+        with thyra_logs(_LOGGER, logging.WARNING) as records:
+            _run(_config(method="tic_preserving"))
+
+        assert "--resample-gap-tolerance" in _contradictions(records)[0]
+
+    def test_it_says_so_when_the_tolerance_is_already_set(self, thyra_logs):
+        """Do not tell someone to pass a flag they have already passed."""
+        with thyra_logs(_LOGGER, logging.WARNING) as records:
+            _run(_config(method="tic_preserving", gap_tolerance_da=0.01))
+
+        message = _contradictions(records)[0]
+        assert "0.01" in message
+        assert "discarded rather than interpolated" in message
+
+    def test_it_is_silent_when_the_override_agrees(self, thyra_logs):
+        """No noise on an explicit flag that matches the detector."""
+        with thyra_logs(_LOGGER, logging.WARNING) as records:
+            converter = _run(_config(method="nearest_neighbor"))
+
+        assert _contradictions(records) == []
+        assert converter._resampling_method is ResamplingMethod.NEAREST_NEIGHBOR
+
+    def test_it_is_silent_on_auto(self, thyra_logs):
+        """``auto`` *is* the detector; it cannot contradict itself."""
+        with thyra_logs(_LOGGER, logging.WARNING) as records:
+            converter = _run(_config(method="auto"))
+
+        assert _contradictions(records) == []
+        assert converter._resampling_method is ResamplingMethod.NEAREST_NEIGHBOR
+
+
+class TestTheCheckNeverBreaksAConversion:
+    def test_a_source_the_detector_cannot_classify_still_converts(self, thyra_logs):
+        """Detection is advisory here, so a failure is a debug line.
+
+        The method the caller asked for has to be applied either way: a
+        conversion that refused because an advisory check raised would be
+        a worse bug than the one being fixed.
+        """
+
+        class _Exploding(_Converter):
+            def _get_reader_metadata_for_resampling(self):
+                raise RuntimeError("no metadata")
+
+        converter = _Exploding(None)
+        converter._resampling_config = _config(method="tic_preserving")
+
+        with thyra_logs(_LOGGER, logging.WARNING) as records:
+            converter._setup_resampling()
+
+        assert converter._resampling_method is ResamplingMethod.TIC_PRESERVING
+        assert _contradictions(records) == []
+
+    def test_the_gap_tolerance_is_still_configured(self):
+        """The warning sits in the middle of ``_setup_resampling``."""
+        converter = _run(_config(method="tic_preserving", gap_tolerance_da=0.25))
+
+        assert converter._gap_tolerance_da == pytest.approx(0.25)

--- a/tests/unit/readers/test_imzml_zero_based.py
+++ b/tests/unit/readers/test_imzml_zero_based.py
@@ -1,0 +1,242 @@
+# tests/unit/readers/test_imzml_zero_based.py
+"""A 0-based imzML keeps its first row and column.
+
+The imzML specification numbers pixels from 1, and three sites subtracted
+a constant 1 to reach the 0-based indices everything downstream uses: the
+reader's cached coordinate array, its per-spectrum fallback, and the
+extractor's grid sizing. Files written 0-based exist, and on one of those
+the constant produced ``x = -1`` and ``y = -1`` for the first row and
+column. A negative index is a legal *negative* numpy index, so the
+converter's ``_locate`` guard dropped those spectra:
+
+    preview_msi: n_pixels 9, grid (2, 2)
+    WARNING - 5 spectra sat outside the declared 2x2x1 grid and were skipped
+    store: 4 rows, x in {0, 1}, y in {0, 1}
+
+Exit 0, with the warning blaming a grid the file never declared (#244).
+
+The rule that replaced the constant is **not** the one z uses. z rebases on
+its observed minimum because z has no origin; x and y do, so they fold a 0
+down and otherwise keep the specification's base of 1. The
+three fixtures below are the whole argument: the 0-based file must gain
+its lost row and column, the ordinary 1-based file must not move, and the
+*cropped* 1-based file -- the one an observed-minimum rebase would slide
+to the origin -- must not move either.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import anndata
+import numpy as np
+import pytest
+
+from thyra.converters.spatialdata.streaming_converter import (
+    SPATIALDATA_AVAILABLE,
+    StreamingSpatialDataConverter,
+)
+from thyra.readers.imzml import ImzMLReader
+
+pytestmark = pytest.mark.skipif(
+    not SPATIALDATA_AVAILABLE,
+    reason="SpatialData dependencies not available",
+)
+
+_TABLE_KEY = "imzml_z0"
+_OUT_OF_GRID_LOGGER = "thyra.converters.spatialdata.streaming_converter"
+
+
+def _convert(imzml_path: Path, output_path: Path) -> bool:
+    reader = ImzMLReader(imzml_path)
+    try:
+        return StreamingSpatialDataConverter(
+            reader=reader,
+            output_path=output_path,
+            dataset_id="imzml",
+            pixel_size_um=10.0,
+        ).convert()
+    finally:
+        reader.close()
+
+
+def _stored(output_path: Path) -> dict:
+    """Stored intensity per ``(x, y)``, keyed by the obs coordinates."""
+    adata = anndata.read_zarr(output_path / "tables" / _TABLE_KEY)
+    row_sums = np.asarray(adata.X.sum(axis=1)).ravel()
+    xs = np.asarray(adata.obs["x"]).astype(int)
+    ys = np.asarray(adata.obs["y"]).astype(int)
+    return {(int(x), int(y)): float(v) for x, y, v in zip(xs, ys, row_sums)}
+
+
+class TestTheReaderRebasesOnWhatTheFileHolds:
+    def test_a_zero_based_file_yields_every_pixel_at_or_above_the_origin(
+        self, zero_based_imzml
+    ):
+        """No coordinate is negative, and all nine are distinct."""
+        path, _, _ = zero_based_imzml
+        reader = ImzMLReader(path)
+        try:
+            coords = [c for c, _mzs, _its in reader.iter_spectra()]
+        finally:
+            reader.close()
+
+        assert len(coords) == 9
+        assert len(set(coords)) == 9
+        assert min(x for x, _y, _z in coords) == 0
+        assert min(y for _x, y, _z in coords) == 0
+        assert max(x for x, _y, _z in coords) == 2
+        assert max(y for _x, y, _z in coords) == 2
+
+    def test_a_one_based_file_is_unchanged(self, one_based_imzml):
+        """The ordinary case, and the whole risk of the rebase decision."""
+        path, _, _ = one_based_imzml
+        reader = ImzMLReader(path)
+        try:
+            coords = [c for c, _mzs, _its in reader.iter_spectra()]
+        finally:
+            reader.close()
+
+        assert min(x for x, _y, _z in coords) == 0
+        assert max(x for x, _y, _z in coords) == 2
+
+    def test_a_cropped_acquisition_keeps_its_offset(self, cropped_one_based_imzml):
+        """x = 5 stays at 4, it does not slide to 0.
+
+        This is what separates the x/y rule from z's. Rebasing on the
+        observed minimum would report this three-pixel-wide crop at the
+        origin, changing its grid width and every stored coordinate.
+        """
+        path, _, _ = cropped_one_based_imzml
+        reader = ImzMLReader(path)
+        try:
+            coords = [c for c, _mzs, _its in reader.iter_spectra()]
+        finally:
+            reader.close()
+
+        assert min(x for x, _y, _z in coords) == 4
+        assert max(x for x, _y, _z in coords) == 6
+
+    def test_the_fallback_path_agrees_with_the_cached_array(self, zero_based_imzml):
+        """``_get_spectrum_coordinates`` has two routes; both are rebased.
+
+        The cached numpy array is the fast one. The per-spectrum fallback
+        recomputes, and carried its own copy of the constant.
+        """
+        path, _, _ = zero_based_imzml
+        reader = ImzMLReader(path)
+        try:
+            reader._ensure_parser_initialized()
+            cached = [
+                reader._get_spectrum_coordinates(reader.parser, i) for i in range(9)
+            ]
+            reader._coordinates_array = None
+            fallback = [
+                reader._get_spectrum_coordinates(reader.parser, i) for i in range(9)
+            ]
+        finally:
+            reader.close()
+
+        assert cached == fallback
+
+
+class TestTheGridIsSizedFromTheSameBase:
+    def test_a_zero_based_file_declares_its_full_grid(self, zero_based_imzml):
+        """The 2x2 in the warning came from sizing a 0..2 file by its max."""
+        path, _, _ = zero_based_imzml
+        reader = ImzMLReader(path)
+        try:
+            essential = reader.get_essential_metadata()
+        finally:
+            reader.close()
+
+        assert essential.dimensions == (3, 3, 1)
+        assert essential.n_spectra == 9
+
+    def test_a_one_based_file_declares_the_same_grid(self, one_based_imzml):
+        path, _, _ = one_based_imzml
+        reader = ImzMLReader(path)
+        try:
+            essential = reader.get_essential_metadata()
+        finally:
+            reader.close()
+
+        assert essential.dimensions == (3, 3, 1)
+
+    def test_a_cropped_file_is_sized_from_the_spec_base(self, cropped_one_based_imzml):
+        """Seven columns wide, of which the first four are empty.
+
+        Not three: the acquisition sits at x = 5..7 on a slide whose origin
+        is x = 1, and that offset is real.
+        """
+        path, _, _ = cropped_one_based_imzml
+        reader = ImzMLReader(path)
+        try:
+            essential = reader.get_essential_metadata()
+        finally:
+            reader.close()
+
+        assert essential.dimensions == (7, 7, 1)
+
+    def test_what_was_subtracted_is_recorded(self, zero_based_imzml, one_based_imzml):
+        """A shift nothing records is a shift nobody can undo.
+
+        The imzML extractor never set ``coordinate_offsets`` before #244,
+        so the store could not say where its origin came from. The
+        converter writes this to
+        ``coordinate_systems.global.coordinate_offsets_px``.
+        """
+        offsets = {}
+        for name, fixture in (("zero", zero_based_imzml), ("one", one_based_imzml)):
+            path, _, _ = fixture
+            reader = ImzMLReader(path)
+            try:
+                offsets[name] = reader.get_essential_metadata().coordinate_offsets
+            finally:
+                reader.close()
+
+        assert offsets["zero"][:2] == (0, 0)
+        assert offsets["one"][:2] == (1, 1)
+
+
+class TestTheStoreKeepsEveryPixel:
+    def test_a_zero_based_file_stores_all_nine_rows(self, zero_based_imzml, temp_dir):
+        """Four rows before the fix, and no error to say so."""
+        path, _, expected = zero_based_imzml
+        output_path = temp_dir / "zero.zarr"
+
+        assert _convert(path, output_path) is True
+
+        stored = _stored(output_path)
+        assert len(stored) == 9
+        assert set(stored) == set(expected)
+        for position, value in expected.items():
+            assert stored[position] == pytest.approx(value), position
+
+    def test_nothing_is_reported_as_off_grid(
+        self, zero_based_imzml, temp_dir, thyra_logs
+    ):
+        """The warning blamed a grid the file never declared."""
+        path, _, _ = zero_based_imzml
+        output_path = temp_dir / "quiet.zarr"
+
+        with thyra_logs(_OUT_OF_GRID_LOGGER, logging.WARNING) as records:
+            assert _convert(path, output_path) is True
+
+        off_grid = [
+            r.getMessage() for r in records if "outside the declared" in r.getMessage()
+        ]
+        assert off_grid == []
+
+    def test_a_one_based_file_stores_the_same_thing(self, one_based_imzml, temp_dir):
+        """The two files describe one acquisition; the stores must match."""
+        path, _, expected = one_based_imzml
+        output_path = temp_dir / "one.zarr"
+
+        assert _convert(path, output_path) is True
+
+        stored = _stored(output_path)
+        assert len(stored) == 9
+        for position, value in expected.items():
+            assert stored[position] == pytest.approx(value), position

--- a/tests/unit/readers/test_phi_preview_is_header_only.py
+++ b/tests/unit/readers/test_phi_preview_is_header_only.py
@@ -1,0 +1,160 @@
+# tests/unit/readers/test_phi_preview_is_header_only.py
+"""``preview_msi`` on a PHI ``.raw`` decodes no ion events.
+
+``preview_msi`` promises "No spectra are decoded" and passes
+``metadata_only=True`` for that purpose. ``PhiReader.__init__`` swallowed
+the kwarg through ``**kwargs``, and ``PhiMetadataExtractor`` called
+``get_peak_counts_per_pixel()``, which aggregates every 8-byte event in
+the stream to learn which pixels carry one. Measured at 0.16 s for a 16 MB
+file with 2.02 M events and linear in file size, so a multi-gigabyte
+SmartSoft acquisition previewed as slowly as it converted (issue #240).
+
+The assertion here is that the event stream is never touched, not that the
+preview was quick: a wall-clock threshold on a synthetic file measures the
+machine, not the fix. ``iter_event_batches`` is the single door into the
+stream -- :meth:`PhiReader._aggregate` is its only caller -- so counting
+calls to it settles the question exactly.
+
+What the preview reports instead is the second half of the fix. The header
+knows the tile geometry but not which pixels fired, and PHI is the only
+format that cannot answer that cheaply (imzML counts its coordinate list,
+Bruker runs a SQL count). Rather than quietly reporting the raster size in
+a column that means "spectra present" everywhere else, ``n_pixels`` comes
+back as ``None``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from thyra.preview import preview_msi
+from thyra.readers.phi import PhiReader
+
+from .test_phi_reader import block, event, events_block, write_raw
+
+
+@pytest.fixture
+def phi_raw(tmp_path):
+    """A 4x4 raster in which only two of the sixteen pixels fired."""
+    blocks = (
+        events_block([event(0, 0, 3_000_000), event(0, 0, 3_000_000)])
+        + events_block([event(1, 2, 5_000_000)])
+        + block(2)
+    )
+    return write_raw(tmp_path / "preview.raw", blocks)
+
+
+@pytest.fixture
+def event_reads(monkeypatch):
+    """Count every entry into the ion-event stream."""
+    from thyra.readers.phi import phi_reader as phi_reader_module
+
+    calls: list[str] = []
+    original = phi_reader_module.iter_event_batches
+
+    def counting(path, index):
+        calls.append(str(path))
+        return original(path, index)
+
+    monkeypatch.setattr(phi_reader_module, "iter_event_batches", counting)
+    return calls
+
+
+class TestThePreviewNeverReachesTheEventStream:
+    def test_preview_decodes_no_events(self, phi_raw, event_reads):
+        """The whole point: a preview reads the header, not the file."""
+        preview = preview_msi(phi_raw)
+
+        assert preview.readable, preview.error
+        assert event_reads == [], "preview aggregated the event stream"
+
+    def test_a_real_read_still_decodes_them(self, phi_raw, event_reads):
+        """Guard the guard: the counter must be able to see an aggregate.
+
+        Without this, a fixture that silently stopped intercepting
+        ``iter_event_batches`` would make the test above pass for the
+        wrong reason.
+        """
+        reader = PhiReader(phi_raw)
+        try:
+            counts = reader.get_peak_counts_per_pixel()
+        finally:
+            reader.close()
+
+        assert event_reads, "the counter never saw the aggregate"
+        assert counts is not None
+        assert int(np.count_nonzero(counts)) == 2
+
+
+class TestWhatThePreviewReportsWithoutTheAggregate:
+    def test_n_pixels_is_unknown_rather_than_the_raster_size(self, phi_raw):
+        """``None`` means "not counted"; it must not be filled in with 16.
+
+        The raster extent is already reported, in ``grid_dims``. Putting it
+        in ``n_pixels`` as well would make that field mean "positions the
+        raster covers" for PHI and "spectra present" for every other
+        format, which is the one outcome worse than not answering.
+        """
+        preview = preview_msi(phi_raw)
+
+        assert preview.n_pixels is None
+        assert preview.grid_dims == (4, 4)
+
+    def test_the_header_derived_fields_are_still_answered(self, phi_raw):
+        """Everything the header knows still comes back."""
+        preview = preview_msi(phi_raw)
+
+        assert preview.readable
+        assert preview.mz_range[0] < preview.mz_range[1]
+        assert preview.pixel_size_um == pytest.approx(2.0)
+        assert preview.error is None
+
+    def test_the_resampling_verdict_survives(self, phi_raw):
+        """The detector matches on the format flag, not on peak density.
+
+        ``PhiToFSIMSDetector`` exists because interpolating PHI's sparse
+        pixels fabricates signal (#168), so the preview losing its
+        nearest-neighbour verdict would be a regression of that fix -- and
+        the detector reads ``total_peaks``/``n_spectra`` off the same
+        metadata this change zeroes.
+        """
+        from thyra.resampling.types import ResamplingMethod
+
+        preview = preview_msi(phi_raw)
+
+        assert preview.resampling_method is ResamplingMethod.NEAREST_NEIGHBOR
+
+
+class TestAFullReadIsUnchanged:
+    """A reader built for conversion still counts everything it used to."""
+
+    def test_counts_are_exact_without_metadata_only(self, phi_raw):
+        reader = PhiReader(phi_raw)
+        try:
+            essential = reader.get_essential_metadata()
+        finally:
+            reader.close()
+
+        assert essential.n_spectra_counted is True
+        assert essential.n_spectra == 2
+        # Two events in one channel of pixel (0, 0), one in pixel (1, 2):
+        # two occupied channels in total.
+        assert essential.total_peaks == 2
+        assert essential.peak_counts_per_pixel is not None
+
+    def test_metadata_only_says_the_counts_are_absent(self, phi_raw):
+        """0 with the flag down, never 0 pretending to be a measurement."""
+        reader = PhiReader(phi_raw, metadata_only=True)
+        try:
+            essential = reader.get_essential_metadata()
+        finally:
+            reader.close()
+
+        assert essential.n_spectra_counted is False
+        assert essential.n_spectra == 0
+        assert essential.total_peaks == 0
+        assert essential.peak_counts_per_pixel is None
+        # Header-derived, so still exact.
+        assert essential.dimensions == (4, 4, 1)
+        assert essential.coordinate_bounds == (0.0, 3.0, 0.0, 3.0)

--- a/tests/unit/test_cli_exit_status.py
+++ b/tests/unit/test_cli_exit_status.py
@@ -176,7 +176,7 @@ class TestAConversionThatStoresNothing:
         assert not output_path.exists()
         messages = [r.getMessage() for r in records]
         assert any(
-            "outside the target mass axis" in m and "--resample-min-mz" in m
+            "outside the target mass range" in m and "--resample-min-mz" in m
             for m in messages
         ), messages
 

--- a/thyra/converters/spatialdata/base_spatialdata_converter.py
+++ b/thyra/converters/spatialdata/base_spatialdata_converter.py
@@ -404,6 +404,57 @@ def _current_ratio_block(
     }
 
 
+def _kept_mz_range(
+    axis: NDArray[np.float64],
+    axis_range: Optional[Tuple[float, float]],
+) -> Tuple[float, float]:
+    """The m/z range a peak has to be inside to survive resampling.
+
+    Every physics generator lays ``target_bins + 1`` bin *edges* across the
+    requested ``[min_mz, max_mz]`` and returns the midpoints, so the first
+    and last axis point sit half a bin *inside* the range that was asked
+    for -- ``[50.0001, 999.9975]`` for a source declaring 50-1000. Testing
+    membership against the axis points therefore discarded peaks the caller
+    had asked to keep, and did it worst on the sources that declare their
+    range *as* their first and last sample: PHI TOF-SIMS takes
+    ``mass_range`` from the first and last detector channel, so both were
+    dropped in every pixel (issue #239).
+
+    The rule is the **declared** range, which is the outer bin edges, which
+    is at most half a bin beyond the first and last centre. That bound is
+    what keeps this from becoming the clamp
+    :meth:`BaseSpatialDataConverter._nearest_neighbor_resample` documents:
+    a peak further out than the range is still dropped, so narrowing the
+    range with ``--resample-min-mz`` cannot pile the discarded part of the
+    spectrum onto bin 0.
+
+    A uniform axis is ``np.linspace(min_mz, max_mz, n)``, whose end points
+    *are* the declared bounds, so nothing changes there -- nor for
+    ``--no-resample``, where no axis was built and ``axis_range`` is None.
+
+    A module-level function rather than a method for the reason
+    :func:`_nn_map_to_bins` is: the unbound-call test harnesses drive the
+    resampling surface on a ``SimpleNamespace`` that has no methods.
+
+    Args:
+        axis: The target mass axis, ascending.
+        axis_range: The declared ``(min_mz, max_mz)``, or None when no
+            resampled axis was built.
+
+    Returns:
+        ``(min_mz, max_mz)``, always covering ``axis`` itself.
+    """
+    if axis_range is None:
+        return float(axis[0]), float(axis[-1])
+    # Never narrower than the axis: a generator that returned points
+    # outside the range it was handed must not cost anyone a peak that has
+    # a bin waiting for it.
+    return (
+        min(float(axis_range[0]), float(axis[0])),
+        max(float(axis_range[1]), float(axis[-1])),
+    )
+
+
 def _nn_map_to_bins(
     axis: NDArray[np.float64], mzs: NDArray[np.float64]
 ) -> NDArray[np.int_]:
@@ -417,7 +468,9 @@ def _nn_map_to_bins(
 
     Args:
         axis: The target mass axis, ascending.
-        mzs: m/z values, all within ``[axis[0], axis[-1]]``.
+        mzs: m/z values, all within the range :func:`_kept_mz_range`
+            reports -- so within half a bin of ``axis``, not necessarily
+            within ``[axis[0], axis[-1]]``.
 
     Returns:
         The nearest-bin index of each m/z value, same length as ``mzs``.
@@ -425,9 +478,10 @@ def _nn_map_to_bins(
     # Find insertion points using vectorized binary search
     indices = np.searchsorted(axis, mzs)
 
-    # Clip to valid range. Everything reaching here is inside the axis,
-    # so this only pins searchsorted's one-past-the-end result for a
-    # value equal to axis[-1]; it can no longer pull an outside peak in.
+    # Clip to valid range. Everything reaching here is inside the declared
+    # range, so this pins searchsorted's one-past-the-end result and sends
+    # a peak in the half-bin skirt of either end into the edge bin it
+    # belongs to; it can no longer pull in a peak from outside the range.
     indices_clipped = np.clip(indices, 0, len(axis) - 1)
 
     # For non-boundary points, check if left is closer
@@ -621,6 +675,7 @@ def _tic_preserving_sparse(
     mzs: NDArray[np.float64],
     intensities: NDArray[np.float64],
     gap_tolerance_da: Optional[float],
+    axis_range: Optional[Tuple[float, float]] = None,
 ) -> Tuple[NDArray[np.int_], NDArray[np.float64]]:
     """TIC-preserving resampling, evaluated only where it can be non-zero.
 
@@ -643,6 +698,12 @@ def _tic_preserving_sparse(
         mzs: Source m/z values, any order.
         intensities: Source intensities, parallel to ``mzs``.
         gap_tolerance_da: See :func:`thyra.resampling.gaps.zero_across_gaps`.
+        axis_range: The declared ``(min_mz, max_mz)`` the axis was built
+            across, which is the share of the spectrum the result is
+            entitled to carry. ``None`` falls back to the axis's own span.
+            See :func:`_kept_mz_range`: the two resampling methods have to
+            agree on what the axis covers, so this is the same range
+            ``_nearest_neighbor_resample`` keeps peaks inside.
 
     Returns:
         ``(bin_indices, intensities)`` holding only the non-zero bins,
@@ -651,6 +712,8 @@ def _tic_preserving_sparse(
     empty = (np.array([], dtype=np.int_), np.array([], dtype=np.float64))
     if mzs.size == 0:
         return empty
+
+    kept_range = _kept_mz_range(axis, axis_range)
 
     if np.all(mzs[:-1] <= mzs[1:]):
         mzs_sorted = mzs
@@ -666,7 +729,7 @@ def _tic_preserving_sparse(
         # Place it in its nearest bin, as the nearest_neighbor path and
         # TICPreservingStrategy both do.
         target_tic = preserved_tic(
-            mzs_sorted, intensities_sorted, float(axis[0]), float(axis[-1])
+            mzs_sorted, intensities_sorted, kept_range[0], kept_range[1]
         )
         if target_tic <= 0.0:
             return empty
@@ -689,9 +752,9 @@ def _tic_preserving_sparse(
     zero_across_gaps(values, targets, mzs_sorted, gap_tolerance_da)
 
     # Rescale to the required TIC -- the step that makes the method live up
-    # to its name. Reads only the axis endpoints and the sum of ``values``,
-    # so the subset evaluation rescales exactly as the dense one would.
-    rescale_to_preserved_tic(values, axis, mzs_sorted, intensities_sorted)
+    # to its name. Reads only the kept range and the sum of ``values``, so
+    # the subset evaluation rescales exactly as the dense one would.
+    rescale_to_preserved_tic(values, axis, mzs_sorted, intensities_sorted, kept_range)
 
     keep = values != 0
     return indices[keep], values[keep]
@@ -887,11 +950,17 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         )
 
         self._non_empty_pixel_count: int = 0
-        # Peaks discarded for falling outside the target mass axis, and
+        # Peaks discarded for falling outside the target mass range, and
         # whether the one-line summary has been emitted yet. See
         # _count_out_of_range().
         self._out_of_range_peaks: int = 0
         self._out_of_range_warned: bool = False
+        # The m/z range a peak has to be inside to be kept, as opposed to
+        # the span of the axis points themselves. Filled by
+        # _build_resampled_mass_axis(); ``None`` means "no resampled axis
+        # was built", and the span is then the axis's own. See
+        # :func:`_kept_mz_range`.
+        self._axis_range: Optional[Tuple[float, float]] = None
         # Intensities dropped for being non-finite or negative, and
         # whether that has been said yet. See _count_unusable_intensities().
         self._unusable_intensities: int = 0
@@ -1039,6 +1108,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         else:
             # Use provided method directly (already an enum)
             self._resampling_method = method
+            self._warn_if_override_contradicts_detector(method, config)
 
         logger.info(f"Using resampling method: {self._resampling_method}")
 
@@ -1066,6 +1136,81 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
                 f"Interpolation gap tolerance: {self._gap_tolerance_da} Da "
                 "(target bins farther than this from any source m/z are zeroed)"
             )
+
+    def _warn_if_override_contradicts_detector(
+        self, method: ResamplingMethod, config: Any
+    ) -> None:
+        """Say so when an explicit ``--resample-method`` overrules the detector.
+
+        The detector has a verdict for every source; until #246 only the
+        ``auto`` path ever asked for it, so an explicit method was applied
+        with nothing checked and nothing said. The asymmetry is the whole
+        defect: ``tic_preserving`` on a Bruker TDF -- for which the
+        detector chooses nearest-neighbour -- interpolates across the gaps
+        of a sparse centroid list and fills the axis. Measured on a
+        713-frame PASEF acquisition: 423,386,757 stored non-zeros against
+        302,106, a 583 MB table against 7.6 MB, 5.9 GB of peak RSS against
+        0.5. Per-pixel TIC is identical either way, so the TIC identity
+        cannot see it; what breaks is the siblings, and quietly (the
+        heatmap marginal against the stored mean spectrum came to rel 68).
+
+        This is the same bug class as #168 on PHI ToF-SIMS, which was fixed
+        *by* adding a detector -- which is exactly why a detector is not
+        enough on its own. A detector only steers ``auto``.
+
+        Why a warning and not a refusal or an automatic gap tolerance is
+        design decision D15 in ``docs/design-decisions.md``. In short: the
+        remedy already has a flag, and nothing stored changes.
+
+        Args:
+            method: The method the caller asked for.
+            config: The resampling config, read for a gap tolerance that
+                is already in force (``self._gap_tolerance_da`` is not
+                assigned until later in :meth:`_setup_resampling`).
+        """
+        try:
+            detected = ResamplingDecisionTree().select_strategy(
+                self._get_reader_metadata_for_resampling()
+            )
+        except Exception as exc:
+            # Detection is advisory here. A source it cannot classify must
+            # still convert with the method that was actually asked for.
+            logger.debug(
+                "Could not check --resample-method against the detector: %s",
+                str(exc),
+            )
+            return
+
+        if detected is method:
+            return
+
+        message = (
+            "Resampling method %s was given explicitly, but this source's "
+            "detector chose %s for it. "
+        )
+        args: List[Any] = [method.name, detected.name]
+
+        if method is ResamplingMethod.TIC_PRESERVING:
+            tolerance = getattr(config, "gap_tolerance_da", None)
+            if tolerance is None:
+                message += (
+                    "Interpolating a source the detector reads as sparse "
+                    "fills the whole axis: every bin between two measured "
+                    "points gets a fabricated intensity, the stored matrix "
+                    "grows by orders of magnitude, and per-pixel TIC still "
+                    "balances so no total reveals it. Pass "
+                    "--resample-gap-tolerance to discard bins no measured "
+                    "m/z vouches for, or drop the override."
+                )
+            else:
+                message += (
+                    "--resample-gap-tolerance %s Da is set, so bins further "
+                    "than that from a measured m/z are discarded rather "
+                    "than interpolated across."
+                )
+                args.append(tolerance)
+
+        logger.warning(message, *args)
 
     def _get_cached_metadata_for_resampling(self) -> Dict[str, Any]:
         """Get cached metadata for resampling decision tree to avoid multiple reader calls."""
@@ -2384,6 +2529,12 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         if self._common_mass_axis is None:
             raise RuntimeError("Common mass axis is None after assignment")
 
+        # The range the bins were laid across, kept because a physics axis
+        # reports bin *centres* and so stops half a bin short of it at
+        # either end. It, not the axis's own span, is what decides whether
+        # a peak is in range -- see _kept_mz_range() (issue #239).
+        self._axis_range = (float(min_mz), float(max_mz))
+
         # Bin sizes for the log line, in chunks. ``np.diff`` over the whole
         # axis is another float64 array of its length -- 1.6 GB on a 200M
         # bin axis, allocated for two numbers in one INFO line (#251).
@@ -2683,7 +2834,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         return unique.astype(indices.dtype, copy=False), summed
 
     def _count_out_of_range(self, n_dropped: int, n_total: int) -> None:
-        """Record peaks discarded for lying outside the target mass axis.
+        """Record peaks discarded for lying outside the target mass range.
 
         Narrowing the mass range is deliberate, so dropping the peaks
         outside it is the correct answer and not an error -- but it is not
@@ -2708,13 +2859,16 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         if self._out_of_range_warned or self._common_mass_axis is None:
             return
         self._out_of_range_warned = True
+        lo_mz, hi_mz = _kept_mz_range(
+            self._common_mass_axis, getattr(self, "_axis_range", None)
+        )
         logger.warning(
-            "Dropping peaks that fall outside the target mass axis "
+            "Dropping peaks that fall outside the target mass range "
             "[%.4f, %.4f] m/z -- %d of %d in the first spectrum affected. "
             "They are discarded, not folded into the edge bins. Widen the "
             "resampling range to keep them.",
-            float(self._common_mass_axis[0]),
-            float(self._common_mass_axis[-1]),
+            lo_mz,
+            hi_mz,
             n_dropped,
             n_total,
         )
@@ -2738,11 +2892,13 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
         not see it; the peak was simply in the wrong place, 1,634x the
         median interior bin.
 
-        "In range" is the strict axis span, ``[axis[0], axis[-1]]``: a peak
-        is kept when the axis covers it, not when it is within half a bin of
-        the end. That is the same rule ``_tic_preserving_resample`` already
-        follows -- ``np.interp(..., left=0, right=0)`` and
-        ``thyra.resampling.tic.preserved_tic`` both cut at the endpoints.
+        "In range" is the **declared** ``[min_mz, max_mz]``, which is the
+        outer bin edges and so at most half a bin beyond the first and last
+        centre -- see :func:`_kept_mz_range` for why the axis points
+        themselves are the wrong test and why the rule stops there. A peak
+        further out is dropped, not clamped. ``_tic_preserving_resample``
+        follows the same range, so the two methods agree on what the axis
+        covers.
 
         Args:
             mzs: Original m/z values from spectrum
@@ -2775,7 +2931,8 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             if result is not None:
                 return result
 
-        in_range = (mzs >= axis[0]) & (mzs <= axis[-1])
+        lo_mz, hi_mz = _kept_mz_range(axis, getattr(self, "_axis_range", None))
+        in_range = (mzs >= lo_mz) & (mzs <= hi_mz)
         if not in_range.all():
             self._count_out_of_range(int(mzs.size - in_range.sum()), int(mzs.size))
             mzs = mzs[in_range]
@@ -2800,9 +2957,11 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             return None
 
         # Ascending m/z makes the in-range subset one contiguous slice,
-        # with the same inclusive endpoints as the generic path's mask.
-        lo = int(np.searchsorted(mzs, axis[0], side="left"))
-        hi = int(np.searchsorted(mzs, axis[-1], side="right"))
+        # with the same inclusive endpoints as the generic path's mask --
+        # the declared range, not the axis's own span (_kept_mz_range).
+        lo_mz, hi_mz = _kept_mz_range(axis, getattr(self, "_axis_range", None))
+        lo = int(np.searchsorted(mzs, lo_mz, side="left"))
+        hi = int(np.searchsorted(mzs, hi_mz, side="right"))
 
         cache = _SharedAxisNNCache()
         cache.key = mzs.copy()
@@ -2918,7 +3077,11 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
 
         axis = self._common_mass_axis
         indices, values = _tic_preserving_sparse(
-            axis, mzs, intensities, getattr(self, "_gap_tolerance_da", None)
+            axis,
+            mzs,
+            intensities,
+            getattr(self, "_gap_tolerance_da", None),
+            getattr(self, "_axis_range", None),
         )
         resampled = np.zeros(len(axis))
         resampled[indices] = values
@@ -2945,6 +3108,7 @@ class BaseSpatialDataConverter(BaseMSIConverter, ABC):
             mzs,
             intensities,
             getattr(self, "_gap_tolerance_da", None),
+            getattr(self, "_axis_range", None),
         )
 
     def build_region_numbers(self, x_values, y_values) -> NDArray[np.int32]:

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -24,7 +24,11 @@ from tqdm import tqdm
 
 from ...errors import ConversionRefused
 from ...resampling import ResamplingMethod
-from .base_spatialdata_converter import SPATIALDATA_AVAILABLE, BaseSpatialDataConverter
+from .base_spatialdata_converter import (
+    SPATIALDATA_AVAILABLE,
+    BaseSpatialDataConverter,
+    _kept_mz_range,
+)
 from .csc_assembly import CscAssembly, index_dtype
 
 if SPATIALDATA_AVAILABLE:
@@ -679,10 +683,10 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
             )
         usable = peaks_in - self._unusable_intensities
         if self._out_of_range_peaks >= usable and self._common_mass_axis is not None:
+            lo_mz, hi_mz = _kept_mz_range(self._common_mass_axis, self._axis_range)
             return (
-                "every peak fell outside the target mass axis "
-                f"[{float(self._common_mass_axis[0]):.4f}, "
-                f"{float(self._common_mass_axis[-1]):.4f}] m/z -- widen the "
+                "every peak fell outside the target mass range "
+                f"[{lo_mz:.4f}, {hi_mz:.4f}] m/z -- widen the "
                 "resampling range (--resample-min-mz / --resample-max-mz) to "
                 "keep them"
             )

--- a/thyra/metadata/extractors/imzml_extractor.py
+++ b/thyra/metadata/extractors/imzml_extractor.py
@@ -15,6 +15,7 @@ from ...resampling.constants import (
     SpectrumType,
     normalize_spectrum_type,
 )
+from ...utils.imzml_coordinate_base import coordinate_bases
 from ...utils.pyimzml_direct import read_spectrum_mzs_only
 from ..ontology.cache import ONTOLOGY
 from ..types import ComprehensiveMetadata, EssentialMetadata
@@ -174,7 +175,8 @@ class ImzMLMetadataExtractor(MetadataExtractor):
         # Normalised at construction so a typo fails here rather than silently
         # falling through to auto-detection during extraction.
         self.spectrum_type_override = normalize_spectrum_type(spectrum_type)
-        self._z_base_value: Optional[int] = None  # See _z_base()
+        # See _coordinate_bases(): one memoised pass gives all three.
+        self._coordinate_bases_value: Optional[Tuple[int, int, int]] = None
 
     def _extract_essential_impl(self) -> EssentialMetadata:
         """Extract essential metadata optimized for speed."""
@@ -206,6 +208,12 @@ class ImzMLMetadataExtractor(MetadataExtractor):
             total_peaks=total_peaks,
             estimated_memory_gb=estimated_memory,
             source_path=str(self.imzml_path),
+            # What normalising the file's coordinates subtracted, so the
+            # store can say where its origin came from: the converter
+            # writes it to coordinate_systems.global.coordinate_offsets_px.
+            # (1, 1, 1) for an ordinary 1-based file, (0, 0, ...) for a
+            # 0-based one -- see _coordinate_bases() (issue #244).
+            coordinate_offsets=self._coordinate_bases(coords),
             spectrum_type=spectrum_type,
             peak_counts_per_pixel=peak_counts,
         )
@@ -225,31 +233,42 @@ class ImzMLMetadataExtractor(MetadataExtractor):
     def _calculate_dimensions(self, coords: NDArray[np.int_]) -> Tuple[int, int, int]:
         """Calculate dataset dimensions from coordinates.
 
-        x and y are 1-based by the imzML specification. z is rebased on the
-        smallest value present (see :meth:`_z_base`), because pyimzml
-        reports either base depending on whether ``IMS:1000052`` is
-        declared. Assuming 1 there under-counted a 0-based two-plane file
-        as ``n_z = 1``, which is the same collision as the coordinate
-        clamp, one layer up.
+        Every axis is sized from the maximum *above its own base* (see
+        :meth:`_coordinate_bases`), never from the maximum alone. Assuming
+        1 for x and y under-counted a 0-based file by one row and one
+        column, and the spectra that fell off the resulting grid were
+        dropped with a warning naming a grid the file never declared
+        (issue #244); assuming it for z under-counted a 0-based two-plane
+        file as ``n_z = 1``.
         """
         if len(coords) == 0:
             return (0, 0, 0)
 
         max_coords = np.max(coords, axis=0)
+        x_base, y_base, z_base = self._coordinate_bases(coords)
         return (
-            int(max_coords[0]),
-            int(max_coords[1]),
-            int(max_coords[2]) - self._z_base(coords) + 1,
+            int(max_coords[0]) - x_base + 1,
+            int(max_coords[1]) - y_base + 1,
+            int(max_coords[2]) - z_base + 1,
         )
 
     def _calculate_bounds(
         self, coords: NDArray[np.int_]
     ) -> Tuple[float, float, float, float]:
-        """Calculate coordinate bounds (min_x, max_x, min_y, max_y)."""
+        """Calculate coordinate bounds (min_x, max_x, min_y, max_y).
+
+        The file's **own** coordinates, not the 0-based indices the reader
+        yields: a 1-based file reports ``1..n`` where :meth:`_calculate_dimensions`
+        counts ``n``. Left that way deliberately when #244 rebased
+        everything else -- nothing places a pixel from this field, and
+        normalising it would move the stored metadata of every imzML that
+        converts correctly today for no gain. What was subtracted to reach
+        the store's indices is reported separately, and exactly, as
+        ``EssentialMetadata.coordinate_offsets``.
+        """
         if len(coords) == 0:
             return (0.0, 0.0, 0.0, 0.0)
 
-        # Convert to spatial coordinates (assuming 1-based indexing)
         x_coords = coords[:, 0].astype(float)
         y_coords = coords[:, 1].astype(float)
 
@@ -530,15 +549,16 @@ class ImzMLMetadataExtractor(MetadataExtractor):
             logger.debug(f"Failed to read spectrum {idx}: {e}")
             return None
 
-    def _z_base(self, coords: List) -> int:
-        """The z value in this file that maps onto plane 0.
+    def _coordinate_bases(self, coords: List) -> Tuple[int, int, int]:
+        """The ``(x, y, z)`` values in this file that map onto index 0.
 
-        The same rebasing :meth:`ImzMLReader._z_base` does, and for the
-        same reason: pyimzml synthesises ``z = 1`` when ``IMS:1000052`` is
-        absent but passes an explicit ``z = 0`` through, so a constant base
-        is wrong for one of the two conventions. ``max(z - 1, 0)`` folded
-        plane 1 onto plane 0, and these counts become the CSR ``indptr``
-        -- landing a pixel's peak count on another pixel's row.
+        The same rebasing :meth:`ImzMLReader._coordinate_bases` does, and
+        it has to agree with it: these counts become the CSR ``indptr``, so
+        a base the reader does not share lands a pixel's peak count on
+        another pixel's row. Both call
+        :func:`thyra.utils.imzml_coordinate_base.coordinate_bases`, which
+        holds the rule and the reasoning -- a 0 folds down on x and y, z
+        takes the smallest value present.
 
         Memoised; the scan is one pass over the coordinate list.
 
@@ -546,13 +566,11 @@ class ImzMLMetadataExtractor(MetadataExtractor):
             coords: The parser's coordinate list.
 
         Returns:
-            The smallest z present, or 0 for an empty list.
+            ``(x_base, y_base, z_base)``.
         """
-        if self._z_base_value is None:
-            self._z_base_value = (
-                int(min(coord[2] for coord in coords)) if len(coords) else 0
-            )
-        return self._z_base_value
+        if self._coordinate_bases_value is None:
+            self._coordinate_bases_value = coordinate_bases(coords)
+        return self._coordinate_bases_value
 
     def _store_pixel_peak_count(
         self,
@@ -571,9 +589,10 @@ class ImzMLMetadataExtractor(MetadataExtractor):
             peak_counts: Array to store counts.
             n_peaks: Number of peaks in this spectrum.
         """
-        # ImzML x/y are 1-based; z is rebased on the file -- see _z_base().
+        # Every axis is rebased on the file -- see _coordinate_bases().
         x, y, z = coords[idx]
-        x, y, z = x - 1, y - 1, z - self._z_base(coords)
+        x_base, y_base, z_base = self._coordinate_bases(coords)
+        x, y, z = x - x_base, y - y_base, z - z_base
         n_x, n_y, n_z = dimensions
         pixel_idx = z * (n_x * n_y) + y * n_x + x
         if 0 <= pixel_idx < len(peak_counts):

--- a/thyra/metadata/extractors/phi_extractor.py
+++ b/thyra/metadata/extractors/phi_extractor.py
@@ -27,25 +27,53 @@ class PhiMetadataExtractor(MetadataExtractor):
         reader: The :class:`PhiReader` to describe.
     """
 
-    def __init__(self, reader: "PhiReader"):
+    def __init__(self, reader: "PhiReader", skip_event_aggregate: bool = False):
         """Initialise the extractor.
 
         Args:
             reader: The :class:`PhiReader` to describe.
+            skip_event_aggregate: If True, answer from the acquisition
+                header and the block chain alone -- ``n_spectra`` and
+                ``total_peaks`` come back as 0 with
+                ``n_spectra_counted=False``, and ``peak_counts_per_pixel``
+                as None. Used by metadata-only callers (``preview_msi``)
+                to avoid the pass over every ion event that
+                :meth:`PhiReader.get_peak_counts_per_pixel` performs, which
+                is linear in file size and so made a preview cost what a
+                conversion costs (issue #240). The same role
+                ``skip_total_peaks`` plays for Bruker.
         """
         super().__init__(reader)
         self._reader = reader
+        self._skip_event_aggregate = bool(skip_event_aggregate)
 
     def _extract_essential_impl(self) -> EssentialMetadata:
-        """Extract metadata needed to drive conversion."""
+        """Extract metadata needed to drive conversion.
+
+        The header knows the tile geometry, so ``dimensions`` and
+        ``coordinate_bounds`` are free. It does **not** know which of those
+        pixels recorded an ion: PHI stores a stream of events, not a list
+        of spectra, so the only way to count occupied pixels is to decode
+        every event. When ``skip_event_aggregate`` is set that count is
+        reported as absent rather than guessed at -- see
+        :attr:`EssentialMetadata.n_spectra_counted`. Reporting the raster
+        size instead would have made ``n_spectra`` mean "positions the
+        raster covers" for PHI and "spectra present" for every other
+        format.
+        """
         reader = self._reader
         dimensions = reader.dimensions
         n_x, n_y, _ = dimensions
 
-        peak_counts = reader.get_peak_counts_per_pixel()
-        assert peak_counts is not None
-        total_peaks = int(peak_counts.sum())
-        n_spectra = int(np.count_nonzero(peak_counts))
+        if self._skip_event_aggregate:
+            peak_counts = None
+            total_peaks = 0
+            n_spectra = 0
+        else:
+            peak_counts = reader.get_peak_counts_per_pixel()
+            assert peak_counts is not None
+            total_peaks = int(peak_counts.sum())
+            n_spectra = int(np.count_nonzero(peak_counts))
 
         pixel_size = None
         size_um = reader.pixel_size_um
@@ -58,6 +86,7 @@ class PhiMetadataExtractor(MetadataExtractor):
             mass_range=reader.mass_axis.mass_range,
             pixel_size=pixel_size,
             n_spectra=n_spectra,
+            n_spectra_counted=not self._skip_event_aggregate,
             total_peaks=total_peaks,
             estimated_memory_gb=(total_peaks * 2 * 8) / (1024**3),
             source_path=str(reader.data_path),

--- a/thyra/metadata/types.py
+++ b/thyra/metadata/types.py
@@ -17,7 +17,17 @@ class EssentialMetadata:
         pixel_size: In-plane pixel dimensions as ``(x_um, y_um)`` in
             micrometres, or ``None`` when not detected.  This is the
             raster pitch and says nothing about z; see ``z_spacing_um``.
-        n_spectra: Total number of spectra in the dataset.
+        n_spectra: Total number of spectra in the dataset -- the ones
+            actually present, not the positions the raster covers.
+            Meaningless unless ``n_spectra_counted`` is True.
+        n_spectra_counted: Whether ``n_spectra`` was counted at all. False
+            only on the metadata-only path of a format that cannot count
+            spectra without decoding them: PHI stores a stream of ion
+            events rather than a list of spectra, so which pixels carry one
+            is a property of the data, not of the header (issue #240). When
+            False, ``n_spectra`` and ``total_peaks`` are 0 meaning "not
+            counted", which is not the same as "none present" -- callers
+            that display a count must say so rather than print the zero.
         total_peaks: Total number of peaks across all spectra (used for
             sparse matrix pre-allocation).
         estimated_memory_gb: Estimated dense memory footprint in GB.
@@ -54,6 +64,7 @@ class EssentialMetadata:
     spectrum_type: Optional[str] = None
     peak_counts_per_pixel: Optional[NDArray[np.int32]] = None
     z_spacing_um: Optional[float] = None
+    n_spectra_counted: bool = True
 
     @property
     def has_pixel_size(self) -> bool:

--- a/thyra/preview.py
+++ b/thyra/preview.py
@@ -37,8 +37,18 @@ class MsiPreview:
     Attributes:
         mz_range: ``(min_mz, max_mz)`` of the source mass axis, in Da.
             ``(0.0, 0.0)`` when ``readable=False``.
-        n_pixels: Total number of spectra (pixels) in the dataset.
-            ``0`` when ``readable=False``.
+        n_pixels: Number of spectra (pixels) the dataset actually holds --
+            the positions that carry a measurement, not the extent of the
+            raster, which is :attr:`grid_dims`.  ``0`` when
+            ``readable=False``.  ``None`` when the format cannot report it
+            without decoding spectra, which a preview will not do: PHI
+            SmartSoft-TOF stores a stream of ion events rather than a list
+            of spectra, so counting occupied pixels means reading the whole
+            file, and previewing a multi-gigabyte acquisition cost what
+            converting it costs (issue #240).  ``None`` is deliberately not
+            filled in with ``n_x * n_y``: that number is the raster, already
+            in :attr:`grid_dims`, and putting it here would make this field
+            mean one thing for PHI and another for every other format.
         grid_dims: Grid dimensions as ``(width, height)`` in pixels --
             i.e. ``(x, y)`` from :attr:`EssentialMetadata.dimensions`.
             ``(0, 0)`` when ``readable=False``.
@@ -77,7 +87,7 @@ class MsiPreview:
     """
 
     mz_range: Tuple[float, float]
-    n_pixels: int
+    n_pixels: Optional[int]
     grid_dims: Tuple[int, int]
     instrument_type: Optional[AxisType]
     pixel_size_um: Optional[float]
@@ -302,7 +312,11 @@ def preview_msi(path: Path) -> MsiPreview:
         dims = essential.dimensions
         return MsiPreview(
             mz_range=(float(essential.mass_range[0]), float(essential.mass_range[1])),
-            n_pixels=int(essential.n_spectra),
+            n_pixels=(
+                int(essential.n_spectra)
+                if getattr(essential, "n_spectra_counted", True)
+                else None
+            ),
             grid_dims=(int(dims[0]), int(dims[1])),
             instrument_type=_guess_axis_type(essential, comprehensive),
             pixel_size_um=_pixel_size_um(essential.pixel_size),

--- a/thyra/readers/imzml/imzml_reader.py
+++ b/thyra/readers/imzml/imzml_reader.py
@@ -21,6 +21,7 @@ from ...core.registry import register_reader
 from ...errors import ConversionRefused
 from ...metadata.extractors.imzml_extractor import ImzMLMetadataExtractor
 from ...resampling.constants import normalize_spectrum_type
+from ...utils.imzml_coordinate_base import coordinate_bases
 from ...utils.pyimzml_direct import read_spectrum_mzs_only
 from ._pyimzml_compat import ensure_lenient_cv_param_values
 from .mobility_array import (
@@ -556,7 +557,8 @@ class ImzMLReader(BaseMSIReader):
         self._coordinates_array: Optional[NDArray[np.int32]] = (
             None  # Fast numpy array cache
         )
-        self._z_base_value: Optional[int] = None  # See _z_base()
+        # See _coordinate_bases(): one memoised pass gives all three.
+        self._coordinate_bases_value: Optional[Tuple[int, int, int]] = None
 
         # Continuous-mode fast read: the shared m/z block, and whether the
         # file really does point every spectrum at one block -- verified
@@ -1056,13 +1058,15 @@ class ImzMLReader(BaseMSIReader):
     def _cache_all_coordinates(self) -> None:
         """Cache all coordinates for faster access.
 
-        Converts 1-based coordinates from imzML to 0-based coordinates
-        for internal use. Uses vectorized numpy operations for speed.
-        Stores as numpy array for O(1) index lookup without dict overhead.
+        Converts the file's coordinates to 0-based coordinates for internal
+        use. Uses vectorized numpy operations for speed. Stores as numpy
+        array for O(1) index lookup without dict overhead.
 
-        x and y are 1-based by the imzML specification. z is not reliably
-        either, so its base comes from :meth:`_z_base` rather than from a
-        constant.
+        No axis gets a constant base. x and y are 1-based by the imzML
+        specification, but 0-based exports exist and subtracting a constant
+        1 cost them their first row and column (issue #244); z is not
+        reliably either base. All three come from
+        :meth:`_coordinate_bases`.
         """
         # Parser should already be initialized when this is called from
         # _initialize_parser
@@ -1072,15 +1076,16 @@ class ImzMLReader(BaseMSIReader):
         n_coords = len(self.parser.coordinates)
         logger.info(f"Caching {n_coords:,} coordinates...")
 
-        z_base = self._z_base()
+        x_base, y_base, z_base = self._coordinate_bases()
 
         # Vectorized conversion using numpy (much faster than Python loop)
         # np.array() on the coordinates list is the main cost here
         self._coordinates_array = np.array(self.parser.coordinates, dtype=np.int32)
 
         # Convert to 0-based in place
-        self._coordinates_array[:, :2] -= 1  # x and y
-        self._coordinates_array[:, 2] -= z_base  # z
+        self._coordinates_array[:, 0] -= x_base
+        self._coordinates_array[:, 1] -= y_base
+        self._coordinates_array[:, 2] -= z_base
 
         logger.info(f"Cached {n_coords:,} coordinates as numpy array")
 
@@ -1211,8 +1216,8 @@ class ImzMLReader(BaseMSIReader):
         logger.info(f"Created common mass axis with {axis.size} unique m/z values")
         return axis
 
-    def _z_base(self) -> int:
-        """The z value in this file that maps onto plane 0.
+    def _coordinate_bases(self) -> Tuple[int, int, int]:
+        """The ``(x, y, z)`` values in this file that map onto index 0.
 
         Measured off the file rather than assumed, because imzML gives no
         guarantee about the base and pyimzml is inconsistent about it:
@@ -1220,16 +1225,20 @@ class ImzMLReader(BaseMSIReader):
         explicit ``z = 0`` is passed through verbatim -- contradicting its
         own docstring, which promises zero.
 
-        Both were previously folded onto plane 0 by ``np.maximum(z - 1, 0)``.
-        On a file written 0-based that merges planes 0 and 1: a two-plane
-        acquisition converts to a two-row table whose rows are the union of
-        both planes, with nothing logged. Subtracting the observed minimum
-        is correct for either convention.
+        Both z conventions were previously folded onto plane 0 by
+        ``np.maximum(z - 1, 0)``. On a file written 0-based that merges
+        planes 0 and 1: a two-plane acquisition converts to a two-row table
+        whose rows are the union of both planes, with nothing logged.
+
+        x and y are **not** rebased the same way, and
+        :mod:`thyra.utils.imzml_coordinate_base` holds the reasoning: they
+        have a physical origin that z does not, so only a 0 is folded down
+        (issue #244).
 
         Neither ``bellini``, ``pea`` nor ``xenium`` declares ``IMS:1000052``,
         so all three go through pyimzml's synthesised ``z = 1`` and this
-        returns 1 -- the same answer the clamp gave. The whole z path is
-        exercised only in the shape real data does not have, which is why
+        returns 1 for z -- the same answer the clamp gave. The whole z path
+        is exercised only in the shape real data does not have, which is why
         this went unnoticed.
 
         Memoised: the scan is one pass over ``parser.coordinates``
@@ -1237,19 +1246,16 @@ class ImzMLReader(BaseMSIReader):
         below would otherwise repeat it per spectrum.
 
         Returns:
-            The smallest z present in the file's coordinates.
+            ``(x_base, y_base, z_base)``.
 
         Raises:
             RuntimeError: If the parser is not initialised.
         """
-        if self._z_base_value is None:
+        if self._coordinate_bases_value is None:
             if self.parser is None:
                 raise RuntimeError("Parser is not initialized")
-            coordinates = self.parser.coordinates
-            self._z_base_value = (
-                int(min(coord[2] for coord in coordinates)) if coordinates else 0
-            )
-        return self._z_base_value
+            self._coordinate_bases_value = coordinate_bases(self.parser.coordinates)
+        return self._coordinate_bases_value
 
     def _get_spectrum_coordinates(
         self, parser: ImzMLParser, idx: int
@@ -1260,12 +1266,13 @@ class ImzMLReader(BaseMSIReader):
             row = self._coordinates_array[idx]
             return (int(row[0]), int(row[1]), int(row[2]))
 
-        # Fallback: compute on the fly. z is rebased on what the file
-        # actually contains -- see _z_base().
+        # Fallback: compute on the fly. Every axis is rebased on what the
+        # file actually contains -- see _coordinate_bases().
         x, y, z = parser.coordinates[idx]
+        x_base, y_base, z_base = self._coordinate_bases()
         return cast(
             Tuple[int, int, int],
-            (x - 1, y - 1, z - self._z_base()),
+            (x - x_base, y - y_base, z - z_base),
         )
 
     def _read_spectrum_arrays(

--- a/thyra/readers/phi/phi_reader.py
+++ b/thyra/readers/phi/phi_reader.py
@@ -46,6 +46,7 @@ class PhiReader(BaseMSIReader):
         pixel_size_um: Optional[float] = None,
         use_appended_calibration: bool = True,
         intensity_threshold: Optional[float] = None,
+        metadata_only: bool = False,
         **kwargs: object,
     ) -> None:
         """Initialise a PHI reader.
@@ -61,6 +62,15 @@ class PhiReader(BaseMSIReader):
                 values describe the flight times actually stored, so this
                 should only be disabled to reproduce a legacy conversion.
             intensity_threshold: Minimum intensity to retain.
+            metadata_only: Answer metadata from the header and the block
+                chain alone, without aggregating the event stream. Used by
+                ``preview_msi``, which promises no spectra are decoded and
+                was until #240 paying a pass over every 8-byte event to
+                learn how many pixels carry one -- 0.16 s for a 16 MB file
+                and linear in file size, so a multi-gigabyte SmartSoft
+                acquisition previewed as slowly as it converted. A reader
+                built this way cannot be used for a conversion: the counts
+                it reports are the "not counted" sentinel, not zero.
             **kwargs: Passed to :class:`BaseMSIReader`.
         """
         super().__init__(data_path, intensity_threshold=intensity_threshold, **kwargs)
@@ -73,6 +83,7 @@ class PhiReader(BaseMSIReader):
 
         self._pixel_size_override = pixel_size_um
         self._use_appended_calibration = use_appended_calibration
+        self._metadata_only = bool(metadata_only)
 
         self._header: Optional[PhiHeader] = None
         self._index: Optional[BlockIndex] = None
@@ -269,7 +280,7 @@ class PhiReader(BaseMSIReader):
         from ...metadata.extractors.phi_extractor import PhiMetadataExtractor
 
         self._ensure_initialized()
-        return PhiMetadataExtractor(self)
+        return PhiMetadataExtractor(self, skip_event_aggregate=self._metadata_only)
 
     @property
     def has_shared_mass_axis(self) -> bool:

--- a/thyra/resampling/tic.py
+++ b/thyra/resampling/tic.py
@@ -44,7 +44,7 @@ The common case, where the axis spans the whole spectrum, is short-circuited
 so it returns the input TIC exactly rather than to within rounding.
 """
 
-from typing import Any, TypeVar
+from typing import Any, Optional, Tuple, TypeVar
 
 import numpy as np
 import numpy.typing as npt
@@ -116,6 +116,7 @@ def rescale_to_preserved_tic(
     axis: npt.NDArray[np.floating[Any]],
     mzs: npt.NDArray[np.floating[Any]],
     intensities: npt.NDArray[np.floating[Any]],
+    axis_range: Optional[Tuple[float, float]] = None,
 ) -> npt.NDArray[_FloatT]:
     """Scale an interpolated spectrum onto the TIC it is meant to carry.
 
@@ -127,11 +128,24 @@ def rescale_to_preserved_tic(
         axis: The target mass axis, ascending.
         mzs: Source m/z values, ascending.
         intensities: Source intensities, parallel to ``mzs``.
+        axis_range: The m/z range the axis was built to cover, when that is
+            wider than the axis points themselves. A physics axis holds bin
+            *centres*, so it stops half a bin short of the range it was
+            asked for at either end, and measuring the preserved share
+            against the end points alone would forfeit a peak sitting
+            exactly on a declared bound (issue #239). ``None`` -- what
+            ``TICPreservingStrategy`` passes, since it is handed a bare
+            axis and has no declared range -- uses the axis's own span, the
+            behaviour this function has always had.
 
     Returns:
         ``resampled``, scaled so that its sum is the preserved TIC.
     """
-    target = preserved_tic(mzs, intensities, float(axis[0]), float(axis[-1]))
+    if axis_range is None:
+        axis_min, axis_max = float(axis[0]), float(axis[-1])
+    else:
+        axis_min, axis_max = float(axis_range[0]), float(axis_range[1])
+    target = preserved_tic(mzs, intensities, axis_min, axis_max)
     if target <= 0.0:
         resampled.fill(0.0)
         return resampled

--- a/thyra/utils/imzml_coordinate_base.py
+++ b/thyra/utils/imzml_coordinate_base.py
@@ -1,0 +1,102 @@
+"""Which coordinate value an imzML file means by "the first pixel".
+
+The imzML specification says x and y count from 1, and until issue #244 the
+reader took it at its word and subtracted a constant 1. Files written
+0-based exist, and on one of those the constant produced ``x = -1`` and
+``y = -1`` for the first row and column. A negative index is a legal
+*negative* numpy index, so the converter's grid guard dropped those
+spectra: a 3x3 file at coordinates 0..2 stored 4 rows and reported
+"5 spectra sat outside the declared 2x2x1 grid" -- blaming a grid the file
+never declared, and exiting 0.
+
+Why not rebase on the observed minimum, the way z does
+-----------------------------------------------------
+
+The z rule -- subtract the smallest z the file holds -- rests on an
+argument that is good for z and does not carry over: imzML guarantees
+nothing about the base and pyimzml is inconsistent about it. It stops at
+z because **z has no physical origin and x and y do**. An
+acquisition cropped to a region of the slide legitimately starts at
+``x = 5``; rebasing on the observed minimum would slide it to ``x = 0``,
+changing the grid width, every ``obs["spatial_x"]``, the TIC image extent
+and the pixel footprint of a file that converts correctly today. Nothing
+in the file distinguishes that acquisition from a 0-based export whose
+first column happens to be empty.
+
+So the rule folds down a 0 and nothing else: ``base = min(observed, 1)``.
+A file starting at 0 is 0-based and keeps all its pixels; a file starting
+at 1, or at 5, is 1-based and is offset by exactly 1, which is what
+happened before. The only files whose stored coordinates move are the ones
+that were losing a row and a column.
+
+The declared ``IMS:1000042`` / ``IMS:1000043`` pixel counts are the third
+option and are deliberately not used: nothing in Thyra reads them today
+except ``mzpeak_extractor``, which carries a comment about a declared
+extent disagreeing with the coordinates it ships with. Trusting a declared
+extent over the coordinates would be a larger change with a wider blast
+radius than the defect it fixes.
+
+Whatever is subtracted is recorded: the imzML extractor reports it as
+``EssentialMetadata.coordinate_offsets``, which the converter writes to
+``coordinate_systems.global.coordinate_offsets_px``.
+"""
+
+import logging
+from typing import Iterable, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+#: The base the imzML specification declares for x and y. A file whose
+#: smallest coordinate is larger than this is a cropped acquisition, not a
+#: different convention, so it keeps this base.
+SPEC_BASE = 1
+
+
+def coordinate_bases(
+    coordinates: Iterable[Sequence[int]],
+) -> Tuple[int, int, int]:
+    """The ``(x, y, z)`` values in this file that map onto index 0.
+
+    One pass over the coordinate list, which is what makes it worth
+    memoising at the call site: ~60 ms at 900k spectra, against a 63 s
+    parse.
+
+    Args:
+        coordinates: The parser's coordinate list -- ``(x, y, z)`` triples.
+
+    Returns:
+        ``(x_base, y_base, z_base)``. x and y fold a 0 down and otherwise
+        keep the specification's base of 1; z is the smallest value present,
+        because it has no origin to preserve. ``(1, 1, 0)`` for an empty
+        list, so an empty file still normalises the way the spec says.
+    """
+    min_x: Optional[int] = None
+    min_y: Optional[int] = None
+    min_z: Optional[int] = None
+    for coord in coordinates:
+        x, y, z = int(coord[0]), int(coord[1]), int(coord[2])
+        if min_x is None or x < min_x:
+            min_x = x
+        if min_y is None or y < min_y:
+            min_y = y
+        if min_z is None or z < min_z:
+            min_z = z
+
+    if min_x is None or min_y is None or min_z is None:
+        return SPEC_BASE, SPEC_BASE, 0
+
+    x_base = min(min_x, SPEC_BASE)
+    y_base = min(min_y, SPEC_BASE)
+
+    if x_base < SPEC_BASE or y_base < SPEC_BASE:
+        logger.info(
+            "This imzML numbers its pixels from 0, not from 1 as the "
+            "specification says (smallest coordinate x=%d, y=%d). Rebasing "
+            "on %d so the first row and column are kept; a file numbered "
+            "from 1 is unaffected.",
+            min_x,
+            min_y,
+            min(x_base, y_base),
+        )
+
+    return x_base, y_base, int(min_z)


### PR DESCRIPTION
Batch 5 of six from the 2026-09-08 robustness sweep. Not one of these four is a
crash: every one is a conversion that *succeeded* and stored something slightly
or wildly wrong. Three change what a conversion does or reports — see
**What changes for users** at the end before cutting a release.

Baseline on `main` at `b085659` in this environment, re-measured before
starting: **2484 passed / 13 skipped** and **54 passed / 11 skipped**
(integration). After: **2524 / 13** and **54 / 11**, `pre-commit run
--all-files` clean.

Three of the four needed a decision, and two of those are about how much of a
correct-today store you are allowed to move. Each is written up as a design
decision (D13–D16) so the premise can be argued with rather than the number.

---

## #239 — a peak on a declared mass-range bound was always dropped

Every physics generator lays `target_bins + 1` bin **edges** across the
requested `[min_mz, max_mz]` and returns the midpoints, so the first and last
axis point sit half a bin *inside* the range that was asked for. A source
declaring 50–1000 m/z builds the axis `[50.0001, 999.9975]`. The keep rule
tested membership against those axis points, so a peak sitting exactly on a
declared bound was below `axis[0]` and discarded.

**Edge bins, not a wider axis** (D13). Widening so that
`axis[0] <= min_mz <= max_mz <= axis[-1]` was the issue's other candidate, and
it changes the axis itself: `var["mz"]` and the bin count would move on *every*
resampled store, and two stores of one acquisition written either side of the
change would no longer share a feature axis. The rule is now the **declared**
range, which is the outer bin edges and so at most half a bin beyond the first
and last centre. Only the bin a boundary peak lands in changes.

That half-bin bound is the whole safety argument. This must not become the
clamp it replaces — clamping everything below the floor onto bin 0 put 654,158
counts there on `pea.imzML` cropped to 400–800 m/z, where a real peak is around
80, with the total conserved exactly so no TIC check could see it. A peak
further out than the declared range is still dropped, and
`TestBinZeroIsStillNotADumpingGround` pins that.

Both methods follow the one rule, or they disagree in kind — the failure #248
fixed. `_nearest_neighbor_resample` keeps the peak and maps it to its nearest
bin; `_tic_preserving_sparse` measures the preserved share against the same
range (`rescale_to_preserved_tic` gained an optional `axis_range`, which
`TICPreservingStrategy` does not pass because it is handed a bare axis and has
no declared range).

**Measured, and it is smaller than the issue suggests.** On
`tims_msms_pos_brain1` (713 PASEF frames, 302,107 peaks, declared 50–1000):

| | |
|---|---|
| peaks in the low half-bin skirt | **0** |
| peaks in the high half-bin skirt | **0** |
| peaks genuinely above `max_mz` | 1 — still dropped, correctly |

So on data whose peaks are interior this recovers nothing; it is a correctness
fix at the bound. What it pays on is a source whose declared range *is* a
detector channel rather than an acquisition setting: `phi_extractor` sets
`mass_range` from `(axis.mz[0], axis.mz[-1])`, so the first and last channel of
every PHI pixel were lost on all six resampled variants of the mock fixture —
12 counts stored against 14, where `--no-resample` stored all 14.

**Unchanged:** `constant` axes are `np.linspace(min_mz, max_mz, n)`, whose end
points already *are* the declared bounds. `--no-resample` builds no axis, so
the range falls back to the axis's own span — exactly the old rule.

The one-line warning now says "target mass **range**" rather than "target mass
axis", because the numbers in it are no longer the axis endpoints. Batch 4's
`_why_nothing_survived` branch moves with it and stays reachable.

---

## #244 — a 0-based imzML lost its first row and column

Three sites subtracted a constant 1 from x and y. On a file numbered from 0
that produces `x = -1`, a legal *negative* numpy index, which `_locate` then
dropped. A 3×3 file at coordinates 0..2 previewed as `grid (2, 2)`, warned that
"5 spectra sat outside the declared 2x2x1 grid", stored 4 rows and **exited 0**.

**Fold a 0 down; do not rebase on the observed minimum** (D14). `_z_base` did
rebase on the minimum and its docstring argues the case well, but that argument
stops at z: **z has no physical origin and x and y do.** An acquisition cropped
to a region of the slide legitimately starts at `x = 5`, and rebasing on the
minimum would slide it to `x = 0` — changing the grid width, every
`obs["spatial_x"]`, the TIC extent and the pixel footprint of a file that
converts correctly today. Nothing in the document distinguishes that crop from
a 0-based export whose first column happens to be empty.

So the rule is `base = min(observed_minimum, 1)`, in one place
(`thyra/utils/imzml_coordinate_base.py`) that the reader and the extractor both
call, because a base they disagree on lands a pixel's peak count on another
pixel's row. z keeps its own rule.

| file | before | after |
|---|---|---|
| 3×3 numbered 0..2 | 4 rows, grid (2, 2), off-grid warning | 9 rows, grid (3, 3), silent |
| 3×3 numbered 1..3 | 9 rows, grid (3, 3) | unchanged |
| 3×3 numbered 5..7 (a crop) | 9 rows at x = 4..6, grid (7, 7) | unchanged |

The third row is the one the rejected alternative would have moved, which is
why it is a fixture rather than a paragraph.

The declared `IMS:1000042`/`IMS:1000043` counts were the third option and stay
unread. `mzpeak_extractor` is the only thing in Thyra that reads them at all,
and it carries a comment about a declared extent disagreeing with the
coordinates shipped beside it.

**The shift is now recorded.** The imzML extractor never set
`coordinate_offsets` — only Bruker, mzPeak and PHI did — so a normalisation it
performed on every file was invisible. It sets it now, and the converter writes
it to `coordinate_systems.global.coordinate_offsets_px`: `(1, 1, …)` for an
ordinary file, `(0, 0, …)` for a 0-based one.

**The warning.** The issue asks for one saying the file is 0-based rather than
blaming a grid it never declared. There is nothing left to warn about on this
path — the file is no longer off-grid — so the out-of-grid warning keeps its
meaning for a reader whose coordinates genuinely disagree with its declared
grid, and the base is reported once at INFO instead.

`coordinate_bounds` deliberately still reports the file's **own** coordinates
(`1..n` on a 1-based file). Nothing places a pixel from it, and normalising it
would move the stored metadata of every imzML that converts correctly today for
no gain; `coordinate_offsets` says exactly what was subtracted.

---

## #246 — `tic_preserving` on a sparse source, with nothing said

The detector has a verdict for every source and `_build_resampling_config`
never consulted it, so an explicit `--resample-method` was applied with nothing
checked and nothing said. On a Bruker TDF, for which the detector chooses
nearest-neighbour, `tic_preserving` interpolates across the gaps of a sparse
centroid list and fills the axis.

Reproduced on `tims_msms_pos_brain1`, and then measured again after the fix:

| | nearest_neighbor (default) | `tic_preserving` | `tic_preserving --resample-gap-tolerance 0.01` |
|---|---|---|---|
| stored non-zeros | 302,106 | **423,386,757** | **4,801,946** |
| wall | 26 s | 57 s | 59 s |
| warning | — | fires, names the flag | fires, reports the tolerance in force |

Per-pixel TIC is identical either way, so the TIC identity masks it; the
siblings break quietly instead (heatmap marginal against the stored mean
spectrum, rel 68, with nothing recorded).

**A warning, not a refusal or an automatic tolerance** (D15).

- *Refusing* would have to fire on "points per spectrum is a small fraction of
  the axis", which is true of **any** centroid source against a fine axis —
  including the ones where `tic_preserving` plus a gap tolerance is exactly
  what the user wants. The threshold would be arbitrary and it would break
  working commands.
- *An automatic gap tolerance* changes stored values on every sparse
  `tic_preserving` conversion, including ones somebody is relying on, and there
  is no principled value: half the widest source gap is per-spectrum and
  data-dependent, so the stored numbers would depend on a heuristic no flag
  records.
- The remedy already has a flag. **No new flag**, per the one-flag-per-concept
  rule, and nothing stored changes.

Worth saying explicitly, because it is why a detector-only fix is not enough:
this is the same bug class as **#168** on PHI ToF-SIMS, which *was* fixed by
adding a detector — and a detector only ever steers `auto`. Every sparse source
was left unguarded against the explicit override.

Batch 3's axis guard (`AXIS_BYTES_PER_BIN`, 200 B/bin) does not fire here and
should not: 599,146 columns is an ordinary axis. What exploded is the matrix,
and `_matrix_size_gb` already reports it — 423,386,757 entries logged after
pass 1, before pass 2 writes anything.

---

## #240 — the PHI preview read the whole file it promised not to read

`preview_msi` promises "No spectra are decoded" and passes
`metadata_only=True`. `PhiReader.__init__` swallowed it through `**kwargs` and
`phi_extractor` called `get_peak_counts_per_pixel()`, which aggregates every
8-byte event in the stream: 0.16 s for a 16 MB file with 2.02 M events, linear
in file size, so a multi-gigabyte SmartSoft acquisition previewed as slowly as
it converted.

**What the preview reports without the aggregate** (D16). The header knows the
tile geometry but not which pixels fired — PHI stores a stream of ion arrivals,
not a list of spectra. `n_spectra` comes back as 0 with a new
`EssentialMetadata.n_spectra_counted = False`, and `MsiPreview.n_pixels` is now
`Optional[int]`, `None` for that case.

Reported as **unknown, not as `n_x * n_y`**: every other reader's `n_spectra`
counts spectra *present*, and cheaply (imzML `len(coords)`, Bruker a SQL
count), so filling this one in with the raster size would make the same field
mean two different things for one format. The raster is already reported, as
`grid_dims`. A flag beside `n_spectra` rather than widening its type, because
the conversion path reads it in half a dozen places where it is always a real
count. `skip_total_peaks` on the Bruker extractor is the existing precedent for
the other half of this.

Everything header-derived is still exact — dimensions, coordinate bounds, m/z
range, pixel size, and **both** detector verdicts. `PhiToFSIMSDetector` matches
on the format flag rather than on peak density, so zeroing the counts does not
cost the preview its nearest-neighbour verdict; losing that would have been a
regression of #168, and there is a test for it. A reader built for conversion
is untouched and still counts every pixel.

---

## Also

`ImzMLReader._z_base` and `ImzMLMetadataExtractor._z_base` are removed: #244
replaced both with `_coordinate_bases`, which measures all three axes in the
one pass, and left the old names with no callers.

---

## Verification

- `pytest`: **2524 passed / 13 skipped / 0 failed** (baseline 2484 / 13; the 40
  new tests are 15 + 11 + 7 + 7).
- `pytest -m integration`: **54 passed / 11 skipped / 0 failed**, unchanged.
- `pre-commit run --all-files`: clean (black through pre-commit, since the repo
  pins 24.4.2).
- **The batch 4 tests that couple to this are green and not weakened.**
  `test_cli_exit_status.py::TestAConversionThatStoresNothing` still pins both
  the all-zero and narrowed-range routes; only the message fragment moved, from
  "target mass axis" to "target mass range", because the numbers in it are no
  longer the axis endpoints. `test_empty_conversion_refused.py` and
  `test_out_of_grid_guard.py` are unchanged apart from one prose reference to
  the removed `_z_base`.
- **#239** is tested at the bound itself on **both** methods, on a real
  linear-TOF axis, plus the shared-axis nearest-neighbour cache (which carries
  its own copy of the keep rule), plus a bin-0 dumping-ground guard, plus an
  end-to-end conversion whose only peaks sit on the declared bounds — which
  before this stored nothing and hit batch 4's empty-store refusal.
- **#244** has a written 0-based fixture in `tests/conftest.py` alongside
  1-based and cropped-1-based siblings, checked on row count, `obs["x"]`/`["y"]`,
  grid dimensions, `coordinate_offsets`, both coordinate routes in the reader,
  and that no out-of-grid warning is logged. Verified to *fail* against the old
  constant base: 5 of 11 fail, and the 6 that pass are exactly the invariance
  tests that must pass either way.
- **#240** counts entries into `iter_event_batches` rather than timing the
  preview, so it cannot flake on a slow machine — and asserts the counter can
  see a real aggregate, so it cannot pass vacuously.
- **#246** is measured, not asserted: the store figures above are from real
  conversions of a registry dataset, before and after.
- Log assertions use the `thyra_logs` fixture, never `caplog`.

## What changes for users

Three behaviour changes no commit subject can carry in full, for the release
notes when a release is cut:

1. **A peak sitting exactly on `--resample-min-mz` / `--resample-max-mz` is now
   kept**, in the first or last bin. On a physics axis (`linear_tof`,
   `reflector_tof`, `tof`, `orbitrap`, `fticr`) that is a stored-value change
   for any spectrum with a peak on a bound — most visibly PHI, whose declared
   range is its first and last detector channel. `constant` axes and
   `--no-resample` are byte-identical. Peaks *outside* the range are still
   dropped, never folded into an edge bin.
2. **Every 0-based imzML changes shape**: it gains back its first row and
   column, so row count, grid dimensions and every `obs` coordinate move, and
   the spurious "spectra sat outside the declared NxNxN grid" warning stops.
   1-based files — including cropped acquisitions that do not start at x = 1 —
   are unchanged. All imzML stores now carry
   `coordinate_systems.global.coordinate_offsets_px`, which they previously
   never did.
3. **`--resample-method` now warns when it contradicts the detector.** Nothing
   stored changes, but a conversion that used to be silent now emits a WARNING;
   a script asserting on empty stderr will see it.

`MsiPreview.n_pixels` is now `Optional[int]` and is `None` for a PHI `.raw`. A
consumer that formats it without a None check needs one — this is the only
API-shaped change in the batch.

Closes #239
Closes #240
Closes #244
Closes #246
