### PR TITLE
Batch 6: repo and CI hygiene

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,7 +47,30 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      # Build what is on main, not what this run was triggered by. The
+      # concurrency group above serialises runs; it does not order them --
+      # GitHub's workflow-syntax documentation says runs are processed by the
+      # time each started waiting and then adds, verbatim, that "ordering is
+      # not guaranteed". An older run admitted second would build its own
+      # older checkout and force-push it over newer docs, with both runs green
+      # and neither log mentioning the other. Pinning the ref makes whichever
+      # run executes last publish current main, so the final gh-pages state is
+      # right regardless of admission order: correct by construction rather
+      # than by timing (issue #223, design decision D17).
+      #
+      # The cost, accepted deliberately: re-running an old docs run now
+      # publishes today's docs instead of reproducing that run's build, and
+      # gh-deploy's "Deployed <sha>" message no longer matches the run's
+      # trigger. For a workflow whose only job is "deploy the site", that is
+      # the behaviour wanted.
+      #
+      # Conditional rather than a hardcoded `main` so a deliberate
+      # workflow_dispatch against another ref still deploys that ref instead
+      # of silently deploying main. release.yml's deploy-docs job dispatches
+      # with `--ref main`, so the release path is identical either way.
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'push' && 'main' || github.ref }}
 
       - uses: actions/setup-python@v6
         with:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,10 +12,14 @@ thyra [OPTIONS] INPUT OUTPUT
 `thyra export-metaspace` -- see [Metadata subcommands](#metadata-subcommands).
 
 !!! tip "Grouped help"
-    `thyra --help` lists every option under a category heading -- Conversion,
-    Logging, Resampling (advanced), Performance, imzML-specific,
-    Bruker-specific, Waters-specific, Other, and a General section holding
-    `--version` and `--help` -- in the same order as the sections on this page.
+    `thyra --help` lists every option under a category heading, in this order:
+    Conversion, Logging, Ion mobility grid (advanced), Resampling (advanced),
+    imzML-specific, Bruker-specific, Waters-specific, Other, and a General
+    section holding `--version` and `--help`. The sections on this page follow
+    the same order. The one page section with no matching help group is
+    [Performance](#performance), which now records only options that were
+    removed or that select nothing -- there is nothing left there for `--help`
+    to list.
 
 ---
 

--- a/docs/coordinate-systems.md
+++ b/docs/coordinate-systems.md
@@ -301,16 +301,17 @@ Two kinds of Thyra output lack the ``coordinate_systems`` attr, and
 the second is more recent than it looks:
 
 - **Anything written before v1.22.0**, which introduced the schema.
-- **Any store written by the streaming path with ``use_csc=True``,
-  up to and including v2.3.1.** That path hand-writes its Zarr root
-  attributes and its copy was short: 7 attrs against the 10 the
-  other three paths produce, missing ``coordinate_systems``,
-  ``format_specific_metadata`` and ``msi_dataset_info``. Fixed in
-  v3.0.0. This is the awkward one, because in those versions the
-  route was chosen by estimated size -- so the biggest datasets are
-  exactly the ones that lost it. (Since v3.1.1 that threshold is
-  gone and PCS is the streaming default, but by then the attr was
-  already being written.)
+- **Anything written between v1.22.0 and v2.3.1 by the streaming
+  route**, which in those releases was one of four converters and
+  hand-wrote its own Zarr root attributes. Its copy was short: 7
+  attrs against the 10 the other three produced, missing
+  ``coordinate_systems``, ``format_specific_metadata`` and
+  ``msi_dataset_info``. Fixed in v3.0.0. This is the awkward one,
+  because that route was chosen by estimated size -- so the biggest
+  datasets are exactly the ones that lost it, and nothing in the
+  store records which route wrote it. There is no live setting to
+  check: the four converters became one in v3.23 (design decision
+  D11) and every store written since v3.0.0 carries the attr.
 
 Either way the store is still readable, but you have to infer the
 convention from element layouts and accept some risk that two

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -879,8 +879,22 @@ decided below: D10 (#219) and D11 (#218).
 
 **Decision.** Every converter writes CSC. `--sparse-format` and the
 `sparse_format` keyword on `convert_msi` and the converters are removed,
-and passing the keyword raises rather than being ignored. A caller who
+and passing the keyword is answered rather than ignored. A caller who
 wants row-major access calls `.tocsr()` on the matrix they read back.
+
+**How it is answered, exactly.** The converter class raises
+`ConversionRefused`. `convert_msi` does not re-raise it: its
+`except ConversionRefused` logs the message once at `ERROR` and returns
+`False`, which is what it does for *every* refusal since issue #234, and
+what the CLI turns into exit 1. This paragraph used to say the keyword
+"raises", full stop, which was true of the class and not of the front
+door most callers use -- the discrepancy is issue #261's first item.
+Both behaviours are pinned by tests
+(`tests/unit/test_api_argument_gaps.py`,
+`tests/unit/converters/test_spatialdata_converter.py`). What the decision
+requires is that the removal is not *silent*; whether the caller learns
+it from an exception or from `False` plus a logged reason is
+`convert_msi`'s convention, not this decision's.
 
 **Why.** After D9 the flag was honoured by the in-memory converters only.
 That made it a flag whose effect depended on a second flag: `csr` did
@@ -900,9 +914,9 @@ half of every parity test, carried for a layout with no requester. The
 conversion it replaces costs one `.tocsr()` in memory on data the caller
 has already read.
 
-**Why the keyword raises instead of being accepted as a no-op.** Unknown
-keyword arguments fall through `**kwargs` into `BaseMSIConverter.options`
-without a word. Dropping `sparse_format` from the signature and stopping
+**Why the keyword is answered instead of being accepted as a no-op.**
+Unknown keyword arguments fall through `**kwargs` into
+`BaseMSIConverter.options` without a word. Dropping `sparse_format` from the signature and stopping
 there would mean `sparse_format="csr"` silently producing CSC -- which is
 exactly the failure D9 found and this decision is meant to end. So the
 base converter names it: the message says the keyword is gone, that CSC is
@@ -1037,7 +1051,10 @@ micrometres while putting its shapes in optical pixels, so the two
 disagreed at `"global"`.
 
 **What went with them.** `--streaming` is a hidden no-op and `streaming=`
-selects nothing: with one route the `auto` estimate has nothing to decide,
+selects nothing (though it is still checked: only `True`, `False` and
+`"auto"` are accepted, because an argument that selects nothing still has
+to say when it was misspelled -- issue #261): with one route the `auto`
+estimate has nothing to decide,
 so the sizing PR #216 landed the day before (`_values_per_spectrum`, the
 profile-versus-centroid rule, `Thresholds.STREAMING_SIZE_GB`) is gone with
 the gate it served. The refusal of a broken file still happens at the
@@ -1345,3 +1362,149 @@ range, pixel size and both detector verdicts, all from the header and the
 block chain. `PhiToFSIMSDetector` matches on the format flag rather than
 on peak density, so zeroing the counts does not cost the preview its
 nearest-neighbour verdict — which would have been a regression of #168.
+
+---
+
+## D17. The docs deploy builds `main`, and the `.ibd` UUID warns rather than refuses
+
+**Status:** Implemented (2026-09-09), issues #223 and #261.
+
+Two independent calls, both of the same shape: a check that could be made
+stricter, and the measurement that says how strict it should be.
+
+### The docs deploy pins its ref
+
+`docs.yml` ends every run in `mkdocs gh-deploy --force`, which force-pushes
+the whole built site over `gh-pages`. Two runs overlapping is a lost-update
+race. #154 removed the duration-dependent half of it with a `pages-deploy`
+concurrency group, and deliberately left a narrower half: GitHub's
+workflow-syntax documentation says runs in a group are processed by the time
+each started waiting, and then adds, verbatim, that **"ordering is not
+guaranteed"**. An older run admitted second builds its own older checkout and
+force-pushes it over newer docs -- both runs green, nothing in either log.
+
+**Decision.** The deploy checks out
+`${{ github.event_name == 'push' && 'main' || github.ref }}`. Whichever run
+executes last then builds current `main`, so the published site is right
+regardless of admission order.
+
+**Why this rather than tighter serialisation.** There is nothing tighter
+available: the group is already unkeyed (one `gh-pages` branch, so a
+`workflow_dispatch` and a push must contend), and `cancel-in-progress: true`
+would reintroduce the race it was added to remove, because cancellation is not
+synchronous and the older run's force-push can still be in flight. The
+ordering guarantee simply is not offered. Not depending on it is the only fix
+that does not depend on it.
+
+**The cost, accepted.** Re-running an old docs run now publishes today's docs
+rather than reproducing that run's build, and `gh-deploy`'s `Deployed <sha>`
+message stops matching the run's trigger. For a workflow whose only job is
+"deploy the site" that is the behaviour wanted; it would be wrong for a
+workflow meant to reproduce a historical build, and this is not one.
+
+**Why conditional rather than a hardcoded `main`.** A hardcoded ref makes a
+deliberate `workflow_dispatch` against another branch silently deploy `main`
+instead -- a dispatch that does the opposite of what it says. The conditional
+keeps that path honest and changes nothing about the release path:
+`release.yml`'s `deploy-docs` job dispatches with `--ref main` already.
+
+**Known limit.** The race is narrowed to nothing for *content*, not for
+*attribution*: if two runs overlap, the gh-pages commit message names
+whichever ref the surviving run checked out, which is now always `main`'s tip
+rather than the merge that triggered it.
+
+### An `.ibd` UUID that disagrees warns
+
+The imzML specification puts the binary file's UUID in the first 16 bytes of
+the `.ibd` and the same value in the XML as `IMS:1000080`. Thyra read the XML
+term for the metadata store and never compared the two (issue #261, item 5).
+Comparing them is the only check that can tell an `.imzML` apart from a
+*different* acquisition's `.ibd` sitting beside it under the right name: every
+other check in `_validate_parser_state` reads the XML's own offsets and
+lengths against the binary's size, which a wrong-but-plausible pairing
+satisfies.
+
+**Decision.** Compare them, and **warn** on a disagreement. Do not refuse.
+
+**Why not refuse, measured on 2026-09-09.** Of the three real files in the
+corpus, two match byte for byte:
+
+| file | writer | declared `IMS:1000080` | first 16 bytes of `.ibd` |
+|---|---|---|---|
+| `pea` | SCiLS | `9069a51f-11a8-4f15-aabb-43624def10d0` | same |
+| Xenium export | SCiLS | `6c176aa6-5cf8-4027-8661-657695f2d400` | same |
+| `bellini` | IONTOF SurfaceLab 7.5 | `{FC37F303-A9C0-4CD3-A28E-1D18E523C269}` | `3ad1bacd-dcc3-4f7b-aea7-f9b375dbf731` |
+
+`bellini`'s first spectrum starts at byte 16, so the header slot is there and
+populated -- the writer simply put two different values in the two places.
+That file passes every other check and converts correctly. A refusal would
+therefore reject data Thyra reads right today, over a disagreement between two
+copies of an identifier that is never used to locate a byte. One real file in
+three is not a rare shape.
+
+**What the warning has to say, then.** Both values and both filenames, and
+that reading continues -- because the likeliest reading is "this vendor fills
+the two fields independently", and the person needs to be able to dismiss it
+without reading the source. The second reading, a genuinely mispaired `.ibd`,
+is the one worth the noise.
+
+**Comparison rule.** The 32 hex digits only. Vendors differ on the registry
+braces (IONTOF writes them, SCiLS does not) and on case, and the hyphens are
+positional rather than data, so a file re-spelling its own UUID in the other
+convention must not read as a disagreement with itself.
+
+**Silent when either side is absent.** A file that declares no UUID, or an
+`.ibd` shorter than its header, has nothing to compare; the extent checks
+already speak for the truncated case.
+
+---
+
+## D18. `main` stays unprotected until a release credential exists
+
+**Status:** Deferred (2026-09-09), issue #224.
+
+**Decision.** Do not turn on required status checks for `main`. Keep the
+existing ruleset, which forbids deletion and non-fast-forward pushes and costs
+nothing.
+
+**Why.** Required status checks and this repository's release flow cannot both
+work with the credentials available. Measured on 2026-08-01 against a
+throwaway branch, and re-confirmed on 2026-09-09:
+
+| configuration | result |
+|---|---|
+| no protection (baseline) | `github-actions[bot]` push **allowed** |
+| ruleset, required checks, bypass = admin role | push **blocked** (`GH013`) |
+| ruleset + GitHub Actions app (id 15368) as bypass actor | **refused by the API**, `HTTP 422` |
+| classic protection, `enforce_admins: false` | push **blocked** (`GH006`) |
+
+`release.yml` runs `semantic-release version`, which pushes the version commit
+to `main` with `secrets.GITHUB_TOKEN`. That push cannot bypass required
+checks, and the Actions app cannot be added as a repo-level bypass actor --
+"must be part of the ruleset source or owner organization". Turning the rule
+on would leave the repository tagged-but-not-bumped on the first releasable
+merge. **A repository that cannot cut a release is worse than one without
+required checks.**
+
+**The obvious wrong assumption, named.** Moving the release trigger off `push`
+(the batched-release change) did **not** fix this. It changes *when*
+semantic-release pushes the version commit, not *what* that push is.
+
+**What has changed since the measurement, and what it means.** The check list
+has grown from seven contexts to eleven -- four `integration (os, py)` jobs
+joined the seven the issue lists -- which makes the rule stricter, not more
+reachable. More to the point, the risk the issue was opened for is already
+closed by a different mechanism: `release.yml` waits for the **Tests**
+workflow on the exact commit it is about to release, and refuses to release
+when that run is absent, incomplete, or not successful. Required checks would
+add "a red PR cannot be merged"; they would not add "a red commit cannot reach
+PyPI", because that is already true. This is why the issue is deferred rather
+than escalated.
+
+**What would reopen it.** Any one of: a repo-admin PAT or GitHub App token in
+`release.yml`'s checkout `token:` (note Ousia went deliberately no-PAT for its
+own release flow, so this is a reversal, not a detail); a deploy key as a
+`DeployKey` bypass actor, pushing over SSH; or an organization-level ruleset,
+where the 422's wording hints the Actions app may be an acceptable actor --
+untested, because it needs `gh auth refresh -s admin:org`, which is
+interactive.

--- a/docs/imzml-parser-notes.md
+++ b/docs/imzml-parser-notes.md
@@ -255,6 +255,34 @@ The behaviour is pinned by
 assertions now state the correct conversion — including the refusal — rather
 than characterise the error.
 
+### `IMS:1000080` is never checked against the `.ibd` header
+
+The imzML specification puts the binary file's UUID in the first 16 bytes of
+the `.ibd` and the same value in the XML as `IMS:1000080`. pyimzml reads
+neither against the other -- it never touches the header bytes at all -- and
+Thyra used to read only the XML term, for the metadata store.
+
+That pair is the only thing that can tell an `.imzML` apart from a *different*
+acquisition's `.ibd` renamed to sit beside it. Every other check Thyra makes
+(`ImzMLReader._validate_parser_state`) reads the XML's own offsets and lengths
+against the binary's size, which a wrong-but-similarly-shaped file satisfies.
+
+Thyra now compares them and **warns**, naming both values and both filenames,
+rather than refusing. That is measured, not cautious: of the three real files
+in the corpus, `pea` and the Xenium export match byte for byte, while
+`bellini` -- an IONTOF SurfaceLab 7.5 export -- declares
+`{FC37F303-A9C0-4CD3-A28E-1D18E523C269}` and begins its `.ibd` with
+`3ad1bacd-dcc3-4f7b-aea7-f9b375dbf731`. Its first spectrum starts at byte 16,
+so the header slot is genuinely populated; the writer just filled the two
+places independently. That file converts correctly, so refusing would reject
+data Thyra reads right today. See design decision D17.
+
+Only the 32 hex digits are compared. IONTOF writes the registry braces and
+SCiLS does not, case varies, and the hyphens are positional rather than data,
+so a file re-spelling its own UUID in the other convention must not read as a
+disagreement with itself. Pinned by
+`tests/unit/readers/test_imzml_parser_state_validation.py::TestIbdUuid`.
+
 ### A typed cvParam with no `value` aborts the metadata parse
 
 `pyimzml.ontology.ontology.convert_xml_value` converts each cvParam value to

--- a/docs/resampling.md
+++ b/docs/resampling.md
@@ -565,6 +565,12 @@ convert_msi(
 It has no effect when resampling is on, which is the default: a resampled axis
 has the bin count you asked for.
 
+The value is a count, so it must be a positive integer or `None`. Anything
+else is refused before the file is opened. It used to be accepted and then
+used: a cap of `-1` or `0` turned every file into a refusal for "exceeding"
+a limit it could not satisfy, in a message that named the caller's own value
+back at them as if the data were at fault.
+
 ---
 
 ## Overriding the automatic choice

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,22 @@ dependencies = [
     "click>=8.1, <9",                 # tested 8.1.8 and 8.4.2
     "defusedxml>=0.7.1",  # Secure XML parsing for the Bruker Rapiflex reader
     "geopandas>=0.9.0",
-    "lxml>=4.6.0",
+    # No `lxml` here, deliberately, and it is the inverse of the `click` case
+    # above rather than an oversight. Nothing under `thyra/` imports it at any
+    # depth, and the one dependency that could -- pyimzML -- imports it inside
+    # `choose_iterparse()` and only when the caller asks for `parse_lib="lxml"`.
+    # Thyra's single ImzMLParser call site passes `parse_lib="ElementTree"` on
+    # purpose (`readers/imzml/imzml_reader.py`, pinned by a test): the
+    # unmaintained upstream prunes each <spectrum> out of the tree under lxml
+    # and misreports the resulting `ERR_NO_MEMORY` as an `xmlSAX2Characters`
+    # failure. pyimzML does not declare lxml either -- its Requires-Dist is
+    # `numpy, wheezy.template` on both 1.4.0 (the floor) and 1.5.5 -- so Thyra
+    # was not covering for a missing upstream declaration; the import is
+    # guarded by ImportError on 1.4.0 and gone from the default path on 1.5.5.
+    # Every other requirer in the resolved set asks for it behind an extra
+    # Thyra does not request (pandas[xml], tifffile[xml], fonttools[lxml], ...),
+    # so this line was the only unconditional one and removing it drops lxml
+    # from the closure.
     "numpy>=2.0.0, <3",
     # pandas 3.0 makes `future.infer_string` the default, which gives the table
     # indices and string columns pandas' `str` dtype. anndata >= 0.13 serializes

--- a/tests/unit/readers/test_imzml_parser_state_validation.py
+++ b/tests/unit/readers/test_imzml_parser_state_validation.py
@@ -15,6 +15,7 @@ hand-authored corpus exists separately.
 import logging
 import os
 import re
+import uuid
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator, List
@@ -546,6 +547,86 @@ class TestPreviewReportsARefusedFile:
         assert preview.n_pixels == 6
 
 
+class TestIbdUuid:
+    """``IMS:1000080`` against the first 16 bytes of the ``.ibd``.
+
+    The pair is the only thing that tells an ``.imzML`` apart from a
+    *different* acquisition's ``.ibd`` renamed to sit beside it: every other
+    check reads the XML's own offsets and lengths against the binary's size,
+    which a wrong-but-similar file satisfies. It warns rather than refuses --
+    see ``ImzMLReader._check_ibd_uuid`` and design decision D17.
+    """
+
+    @staticmethod
+    def _set_declared_uuid(imzml_path: Path, value: str) -> None:
+        """Rewrite the ``IMS:1000080`` value in the file description."""
+        text = imzml_path.read_text(encoding="utf-8")
+        edited, n = re.subn(
+            r'(accession="IMS:1000080"[^>]*?value=")[^"]*(")',
+            rf"\g<1>{value}\g<2>",
+            text,
+        )
+        assert n == 1, f"expected one IMS:1000080 cvParam, rewrote {n}"
+        imzml_path.write_text(edited, encoding="utf-8")
+
+    @staticmethod
+    def _read_warnings(path: Path) -> List[str]:
+        with _capture_module_logs() as records:
+            reader = ImzMLReader(path)
+            reader._ensure_parser_initialized()
+            reader.close()
+        return [r for r in records if "binary-file UUID" in r]
+
+    def test_matching_uuid_is_silent(self, temp_dir):
+        """pyimzml's own writer puts the same UUID in both places."""
+        path = write_imzml(temp_dir)
+        assert self._read_warnings(path) == []
+
+    def test_mismatched_uuid_warns_and_still_reads(self, temp_dir):
+        """The bellini case: two different values, a readable file."""
+        path = write_imzml(temp_dir)
+        self._set_declared_uuid(path, "{FC37F303-A9C0-4CD3-A28E-1D18E523C269}")
+
+        with _capture_module_logs() as records:
+            reader = ImzMLReader(path)
+            reader._ensure_parser_initialized()
+            n = reader.n_spectra
+            reader.close()
+
+        assert n == 6, "the warning must not cost the file its spectra"
+        said = [r for r in records if "binary-file UUID" in r]
+        assert len(said) == 1
+        assert "fc37f303a9c04cd3a28e1d18e523c269" in said[0]
+
+    def test_braces_and_case_are_not_a_mismatch(self, temp_dir):
+        """IONTOF writes the registry braces, SCiLS does not; neither is data.
+
+        The hyphens are positional too. Only the 32 hex digits are compared,
+        so re-spelling the file's own UUID in the other convention must stay
+        silent rather than reporting a disagreement with itself.
+        """
+        path = write_imzml(temp_dir)
+        header = path.with_suffix(".ibd").read_bytes()[:16].hex()
+        plain = uuid.UUID(hex=header)
+        for spelling in (
+            str(plain),
+            str(plain).upper(),
+            "{" + str(plain).upper() + "}",
+            "  {" + str(plain) + "}  ",
+        ):
+            self._set_declared_uuid(path, spelling)
+            assert self._read_warnings(path) == [], f"warned on {spelling!r}"
+
+    def test_a_file_declaring_no_uuid_is_silent(self, temp_dir):
+        """Nothing to compare is not a disagreement."""
+        path = write_imzml(temp_dir)
+        text = path.read_text(encoding="utf-8")
+        edited, n = re.subn(r"\s*<cvParam[^>]*IMS:1000080[^>]*/>", "", text)
+        assert n == 1
+        path.write_text(edited, encoding="utf-8")
+        assert self._read_warnings(path) == []
+
+
 @pytest.mark.skipif(
     not (_REAL_DATA_DIR / "bellini.imzML").exists(),
     reason=f"real MSI corpus not present at {_REAL_DATA_DIR} (test_data/ is gitignored)",
@@ -563,6 +644,21 @@ class TestRealFilesAreStillAccepted:
     here.
     """
 
+    #: What each real file is allowed to say, and nothing else. ``bellini``
+    #: is an IONTOF SurfaceLab export whose ``IMS:1000080`` and ``.ibd``
+    #: header hold two different UUIDs -- measured, not hypothetical: the XML
+    #: says ``{FC37F303-...C269}`` and the binary begins
+    #: ``3ad1bacd...f731``, with the first spectrum at byte 16 so the header
+    #: slot is genuinely populated. Every other check passes and the file
+    #: converts correctly, which is exactly why that check warns instead of
+    #: refusing (issue #261, design decision D17). Listing the warning here
+    #: rather than dropping the assertion keeps the rest of the guarantee:
+    #: any *other* message from these files still fails the test.
+    _ALLOWED_WARNINGS = {
+        "bellini.imzML": ("imzML declares binary-file UUID",),
+        "pea.imzML": (),
+    }
+
     @pytest.mark.parametrize("name", ["bellini.imzML", "pea.imzML"])
     def test_real_file_initialises_with_no_errors_and_no_warnings(self, name):
         path = _REAL_DATA_DIR / name
@@ -575,5 +671,12 @@ class TestRealFilesAreStillAccepted:
             n = reader.n_spectra
             reader.close()
 
+        allowed = self._ALLOWED_WARNINGS[name]
+        unexpected = [r for r in records if not any(r.startswith(a) for a in allowed)]
+
         assert n > 0
-        assert records == [], f"{name} tripped the validator: {records}"
+        assert unexpected == [], f"{name} tripped the validator: {unexpected}"
+        for prefix in allowed:
+            assert any(
+                r.startswith(prefix) for r in records
+            ), f"{name} no longer warns {prefix!r}; the check or the file changed"

--- a/tests/unit/test_api_argument_gaps.py
+++ b/tests/unit/test_api_argument_gaps.py
@@ -1,0 +1,161 @@
+"""What ``convert_msi`` does with arguments nobody meant to pass.
+
+The CLI validates its own options with click, so these gaps were only ever
+reachable through the Python API -- which is how Ousia and every notebook
+call Thyra. Three shapes were found in the 2026-09-08 sweep (issue #261):
+
+- a no-op argument accepted in silence when misspelled (``streaming``);
+- an argument accepted and then used, turning every file into a refusal
+  that named the caller's nonsense value back at them
+  (``max_mass_axis_length``);
+- a removed argument whose refusal reaches the caller as ``False`` rather
+  than as an exception (``sparse_format``), which design decision D10
+  described the other way round.
+
+All three end the same way at the front door, which is the point: one
+``ERROR`` line saying what to do, and ``False``. That is what every other
+refusal does since issue #234, and what the CLI turns into exit 1.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from thyra.convert import _validate_streaming, convert_msi
+from thyra.errors import ConversionRefused
+from thyra.readers.imzml.imzml_reader import _validate_max_mass_axis_length
+
+
+class TestStreaming:
+    """``streaming`` selects nothing, and still has to say when it is wrong.
+
+    Every conversion streams since v3.23 (design decision D11), so the
+    argument is kept only so existing calls keep running. That is not a
+    licence to accept anything: a caller who writes ``streaming="flase"``
+    believes they changed something.
+    """
+
+    @pytest.mark.parametrize("value", [True, False, "auto"])
+    def test_the_three_real_values_are_accepted(self, value):
+        assert _validate_streaming(value) is True
+
+    @pytest.mark.parametrize("value", ["yes", "true", "false", None, 1, 2.0, []])
+    def test_anything_else_is_refused(self, value, thyra_logs):
+        with thyra_logs("thyra.convert", logging.ERROR) as records:
+            assert _validate_streaming(value) is False
+        said = " ".join(r.getMessage() for r in records)
+        assert "streaming must be True, False or 'auto'" in said
+
+    def test_zero_is_refused_rather_than_read_as_false(self, thyra_logs):
+        """The sharpest case, and the reason this check exists.
+
+        ``0 == False`` but ``0 is not False``, so ``streaming=0`` -- which a
+        caller writes meaning ``False`` -- slipped past the ``is False``
+        test that exists precisely to answer that request, and converted in
+        silence.
+        """
+        with thyra_logs("thyra.convert", logging.ERROR) as records:
+            assert _validate_streaming(0) is False
+        assert "got 0" in " ".join(r.getMessage() for r in records)
+
+    def test_it_is_refused_before_the_source_is_opened(self, tmp_path, thyra_logs):
+        """A path that does not exist must not be the complaint.
+
+        The argument check runs in ``_validate_input_parameters``, ahead of
+        every path check and every read, so a typo fails while the caller is
+        still looking at their own arguments rather than after a metadata
+        scan.
+        """
+        with thyra_logs("thyra.convert", logging.ERROR) as records:
+            assert (
+                convert_msi(
+                    tmp_path / "no-such-file.imzML",
+                    tmp_path / "out.zarr",
+                    streaming="yes",
+                )
+                is False
+            )
+        said = " ".join(r.getMessage() for r in records)
+        assert "streaming must be" in said
+        assert "does not exist" not in said
+
+
+class TestMaxMassAxisLength:
+    """The raw-axis cap is a count, so it is a positive integer or nothing."""
+
+    @pytest.mark.parametrize("value", [None, 1, 10_000_000])
+    def test_a_count_or_no_limit_is_accepted(self, value):
+        assert _validate_max_mass_axis_length(value) == value
+
+    @pytest.mark.parametrize("value", [-1, 0, 2.5, "ten", [10]])
+    def test_anything_else_is_refused(self, value):
+        with pytest.raises(ConversionRefused, match="positive integer or None"):
+            _validate_max_mass_axis_length(value)
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_a_bool_is_refused_rather_than_read_as_a_count(self, value):
+        """``bool`` is an ``int`` subclass; ``True`` would mean a cap of one."""
+        with pytest.raises(ConversionRefused, match="positive integer or None"):
+            _validate_max_mass_axis_length(value)
+
+    def test_the_message_does_not_blame_the_file(self):
+        """It used to.
+
+        A cap of ``-1`` was accepted and then compared against a growing
+        axis, so every file was refused for "exceeding -1 unique m/z
+        values" -- a sentence about the data, for a mistake in the call.
+        """
+        with pytest.raises(ConversionRefused) as excinfo:
+            _validate_max_mass_axis_length(-1)
+        assert "exceeded" not in str(excinfo.value)
+        assert "max_mass_axis_length must be" in str(excinfo.value)
+
+
+class TestSparseFormatReachesTheCaller:
+    """``sparse_format`` was removed in v3.22, and the removal still speaks.
+
+    Design decision D10 said passing the keyword "raises". The converter
+    class does raise (pinned in
+    ``tests/unit/converters/test_spatialdata_converter.py``), but nothing
+    called ``convert_msi`` and looked: its ``except ConversionRefused``
+    turns every refusal into one logged ``ERROR`` and ``False``, which is
+    the whole point of that handler (issue #234).
+
+    So the front door reports this the same way it reports a Waters raster
+    whose stage never moved, and D10's sentence was the thing that was
+    wrong, not the code. Pinned here so the two cannot drift apart again:
+    what matters is that the removal is *not silent*, and that the message
+    is the one the caller needs.
+    """
+
+    FIXTURE = (
+        Path(__file__).resolve().parents[1]
+        / "data"
+        / "fixtures"
+        / "iontof_sparse.imzML"
+    )
+
+    def test_it_is_reported_and_returns_false(self, tmp_path, thyra_logs):
+        with thyra_logs("thyra.convert", logging.ERROR) as records:
+            result = convert_msi(
+                self.FIXTURE,
+                tmp_path / "out.zarr",
+                dataset_id="pinned",
+                sparse_format="csr",
+            )
+
+        assert result is False
+        said = " ".join(r.getMessage() for r in records)
+        assert "sparse_format was removed" in said
+        assert "tocsr()" in said, "the message must say what to call instead"
+
+    def test_nothing_is_written(self, tmp_path):
+        out = tmp_path / "out.zarr"
+        assert (
+            convert_msi(self.FIXTURE, out, dataset_id="pinned", sparse_format="csc")
+            is False
+        )
+        assert not out.exists(), "a refused conversion must leave no store"

--- a/thyra/convert.py
+++ b/thyra/convert.py
@@ -117,6 +117,33 @@ def _validate_numeric_parameters(
     return True
 
 
+def _validate_streaming(streaming: Any) -> bool:
+    """Validate the ``streaming`` argument, which selects nothing.
+
+    A no-op argument still has to say when it was misspelled. ``"yes"``,
+    ``None`` and ``1`` were all accepted in silence, and so was ``0`` --
+    which a caller writes meaning ``False``, and which the ``is False``
+    test in ``_create_converter`` misses, because ``0`` and ``False`` are
+    equal but not identical. The one value the code answers was the one a
+    plausible spelling could hide (issue #261).
+
+    Checked here rather than in ``_create_converter`` so it fails while the
+    caller is still looking at their own arguments, before the source is
+    opened -- the same reason ``spectrum_type`` is normalised in
+    ``ImzMLReader.__init__``.
+    """
+    if streaming is True or streaming is False or streaming == "auto":
+        return True
+
+    logger.error(
+        "streaming must be True, False or 'auto', got %r. It selects nothing "
+        "either way -- every conversion streams since v3.23 -- so the "
+        "argument can simply be dropped.",
+        streaming,
+    )
+    return False
+
+
 def _validate_input_parameters(
     input_path: Union[str, Path],
     output_path: Union[str, Path],
@@ -124,12 +151,14 @@ def _validate_input_parameters(
     dataset_id: str,
     pixel_size_um: Optional[float],
     z_spacing_um: Optional[float] = None,
+    streaming: Any = "auto",
 ) -> bool:
     """Validate all input parameters for convert_msi function."""
     return (
         _validate_paths_parameters(input_path, output_path)
         and _validate_string_parameters(format_type, dataset_id)
         and _validate_numeric_parameters(pixel_size_um, z_spacing_um)
+        and _validate_streaming(streaming)
     )
 
 
@@ -295,7 +324,8 @@ def _create_converter(
     streaming one, on request or on an estimated size. There is one
     converter now and it streams (design decision D11), so the argument
     selects nothing; it is accepted so existing calls keep working, and
-    ``False`` is answered with a note rather than silently.
+    ``False`` is answered with a note rather than silently. The value is
+    checked by ``_validate_streaming`` before the reader is opened.
     """
     if streaming is False:
         logger.warning(
@@ -465,17 +495,24 @@ def convert_msi(
             conversion streams -- two passes over the source into
             memory-mapped arrays, the matrix never held in RAM -- since
             the in-memory converter was folded in (v3.23). ``False`` is
-            accepted with a warning.
+            accepted with a warning. Only ``True``, ``False`` and
+            ``"auto"`` are accepted at all: a no-op argument still has to
+            say when it was misspelled, and ``0`` -- which reads as
+            ``False`` but is not it -- used to convert in silence.
         region: For multi-region datasets (e.g. Bruker timsTOF),
             select a specific region. Accepts an int (DB
             RegionNumber) or a str (matched against .mis Area
             Name, falling back to integer parse). None (default)
             converts all regions. Passed to the reader as
             reader_options["region"].
-        **kwargs: Additional keyword arguments
 
     Returns:
-        True if conversion was successful, False otherwise
+        True if the conversion completed and the store was written, False
+        otherwise. Every failure comes back this way, refusals included:
+        a refusal Thyra planned for is logged once at ``ERROR`` with the
+        whole explanation and its traceback kept for ``DEBUG`` (issue
+        #234), so a caller that wants the exception itself has to use the
+        converter classes directly.
     """
     # Validate input parameters
     if not _validate_input_parameters(
@@ -485,6 +522,7 @@ def convert_msi(
         dataset_id,
         pixel_size_um,
         z_spacing_um,
+        streaming,
     ):
         return False
 

--- a/thyra/converters/spatialdata/streaming_converter.py
+++ b/thyra/converters/spatialdata/streaming_converter.py
@@ -813,8 +813,8 @@ class StreamingSpatialDataConverter(BaseSpatialDataConverter):
             n_x, n_y, n_z = self._dimensions
             logger.warning(
                 "%d spectra sat outside the declared %dx%dx%d grid and were "
-                "skipped. Previously they were written to a wrapped-round "
-                "row index, silently overwriting an unrelated pixel.",
+                "skipped: their coordinates fall beyond the raster the source "
+                "declares, so there is no pixel to write them to.",
                 n_out_of_bounds,
                 n_x,
                 n_y,

--- a/thyra/core/base_converter.py
+++ b/thyra/core/base_converter.py
@@ -261,11 +261,14 @@ class BaseMSIConverter(ABC):
     def _is_volume(self) -> bool:
         """True when this conversion writes a real multi-slice volume.
 
-        ``handle_3d`` alone is not enough: it is forced on by
-        ``SpatialData3DConverter.__init__`` regardless of the data, and a
-        single-slice acquisition converted through that class still takes
-        the 2D branch of ``_create_tic_image``. Only the combination has
-        a z axis to space out.
+        ``handle_3d`` alone is not enough: it says the caller asked for a
+        volume, not that the source has one, and a single-slice
+        acquisition converted with ``handle_3d=True`` still takes the 2D
+        branch of ``_create_tic_image``. Only the combination has a z axis
+        to space out. (The flag used to be forced on by
+        ``SpatialData3DConverter.__init__``; that class went when the
+        converters were folded into one, design decision D11, and the
+        caller's own argument is now the only thing that sets it.)
         """
         return bool(self.handle_3d and self._dimensions and self._dimensions[2] > 1)
 

--- a/thyra/metadata/extractors/imzml_extractor.py
+++ b/thyra/metadata/extractors/imzml_extractor.py
@@ -777,6 +777,13 @@ class ImzMLMetadataExtractor(MetadataExtractor):
         braces (IONTOF writes ``{...}``, SCiLS does not); they are stripped
         so the stored field is one shape whatever wrote the file.
 
+        What is stored is what the *XML* declares, which is not always what
+        the ``.ibd`` header carries -- ``ImzMLReader._check_ibd_uuid``
+        compares the two and warns when they disagree (design decision D17).
+        This value is not corrected against the binary: the store records the
+        file's own declaration, and the warning is where the disagreement is
+        reported.
+
         Returns:
             The UUID string, or ``None`` if the file declares none.
         """

--- a/thyra/readers/imzml/imzml_reader.py
+++ b/thyra/readers/imzml/imzml_reader.py
@@ -20,7 +20,7 @@ from ...core.mobility import MobilityAxis, classify_mobility_array
 from ...core.registry import register_reader
 from ...errors import ConversionRefused
 from ...metadata.extractors.imzml_extractor import ImzMLMetadataExtractor
-from ...resampling.constants import normalize_spectrum_type
+from ...resampling.constants import ImzMLAccessions, normalize_spectrum_type
 from ...utils.imzml_coordinate_base import coordinate_bases
 from ...utils.pyimzml_direct import read_spectrum_mzs_only
 from ._pyimzml_compat import ensure_lenient_cv_param_values
@@ -491,6 +491,42 @@ class _MassAxisAccumulator:
         )
 
 
+def _validate_max_mass_axis_length(value: Any) -> Optional[int]:
+    """Check the raw-axis cap, which is a count of unique m/z values.
+
+    Refused here rather than at extraction time, so a bad value fails while
+    the caller is still looking at their own arguments -- the same reason
+    ``spectrum_type`` is normalised in the constructor. Until then ``-1``,
+    ``0`` and ``2.5`` were all accepted and then compared against a growing
+    axis, so every file was refused for "exceeding" a cap it could not
+    possibly satisfy, in a message that named the nonsense value back at the
+    person who set it (issue #261).
+
+    ``bool`` is rejected explicitly: it is an ``int`` subclass, so
+    ``max_mass_axis_length=True`` would otherwise mean a cap of one.
+
+    Args:
+        value: What the caller passed, or the default.
+
+    Returns:
+        The value unchanged, once it is ``None`` or a positive int.
+
+    Raises:
+        ConversionRefused: On anything else.
+    """
+    if value is None or (
+        isinstance(value, int) and not isinstance(value, bool) and value > 0
+    ):
+        return value
+
+    raise ConversionRefused(
+        f"max_mass_axis_length must be a positive integer or None (no limit), "
+        f"got {value!r}. It caps how many unique m/z values a processed-mode "
+        f"raw axis may reach before the build gives up; the default is "
+        f"{DEFAULT_MAX_MASS_AXIS_LENGTH:,}."
+    )
+
+
 @register_reader("imzml")
 class ImzMLReader(BaseMSIReader):
     """Reader for imzML format files with optimizations for performance."""
@@ -529,8 +565,8 @@ class ImzMLReader(BaseMSIReader):
         self.cache_coordinates: bool = cache_coordinates
         # Absent means "use the default"; an explicit None means "unlimited",
         # so this cannot be a bare ``.get(...)`` with a None fallback.
-        self.max_mass_axis_length: Optional[int] = kwargs.get(
-            "max_mass_axis_length", DEFAULT_MAX_MASS_AXIS_LENGTH
+        self.max_mass_axis_length: Optional[int] = _validate_max_mass_axis_length(
+            kwargs.get("max_mass_axis_length", DEFAULT_MAX_MASS_AXIS_LENGTH)
         )
         # Validated here rather than at extraction time, so a bad value fails
         # while the caller is still looking at its own arguments.
@@ -754,12 +790,18 @@ class ImzMLReader(BaseMSIReader):
            arrays declare different numbers of values.
         5. A spectrum whose array ends past the end of the ``.ibd``.
 
-        Warned about but allowed: non-monotonic offsets, a maximum end byte
-        short of the file size, and more than one ``<scanSettings>`` block.
-        All three are legal; the last is mishandled downstream (pyimzml
-        resolves each scan-settings accession by first match anywhere in the
-        list, so a two-block file yields a per-accession chimera), but refusing
-        it belongs with the pixel-size unit work rather than here.
+        Warned about but allowed:
+
+        - non-monotonic offsets, and a maximum end byte short of the file
+          size. Both are legal.
+        - more than one ``<scanSettings>`` block. Also legal, and mishandled
+          downstream -- pyimzml resolves each scan-settings accession by first
+          match anywhere in the list, so a two-block file yields a
+          per-accession chimera -- but refusing it belongs with the pixel-size
+          unit work rather than here.
+        - an ``IMS:1000080`` UUID the ``.ibd`` header does not carry. A
+          warning rather than a refusal on measured evidence; see
+          ``_check_ibd_uuid``.
 
         Limitation: this runs *after* ``ImzMLParser.__fix_offsets``, which
         silently adds 2**32 to every offset from the first positive-to-negative
@@ -784,6 +826,7 @@ class ImzMLReader(BaseMSIReader):
         arrays = _offset_arrays(parser)
         self._validate_offset_arrays(arrays)
         self._validate_ibd_extent(parser, arrays)
+        self._check_ibd_uuid(parser)
 
         # Does every spectrum point at one shared m/z block? True for a
         # well-formed continuous file, and the licence for the fast read in
@@ -1054,6 +1097,80 @@ class ImzMLReader(BaseMSIReader):
                 "document order matches byte order and silently rewrites every "
                 "offset after a sign flip when it does not."
             )
+
+    def _check_ibd_uuid(self, parser: ImzMLParser) -> None:
+        """Say so when the ``.ibd`` header does not carry the declared UUID.
+
+        The imzML specification puts the binary file's UUID in the first 16
+        bytes of the ``.ibd`` and the same value in the XML as
+        ``IMS:1000080``. Matching them is the only check that tells an
+        ``.imzML`` apart from a *different* acquisition's ``.ibd`` sitting
+        beside it under the right name -- every other check here reads the
+        XML's own numbers against the ``.ibd``'s size, which a wrong-but-
+        plausible pairing can satisfy. Thyra read the term for the metadata
+        store and never compared it (issue #261).
+
+        **A warning, not a refusal**, and that is measured rather than
+        cautious. Of the three real files in the corpus, ``pea`` and the
+        Xenium export match byte for byte; ``bellini``, an IONTOF SurfaceLab
+        export, declares ``{FC37F303-A9C0-4CD3-A28E-1D18E523C269}`` while its
+        ``.ibd`` header reads ``3ad1bacd-dcc3-4f7b-aea7-f9b375dbf731``. Its
+        first spectrum starts at byte 16, so the header slot is there and
+        populated -- the writer simply put two different values in the two
+        places. That file converts correctly under every other check, so a
+        refusal here would reject data Thyra reads right today, for a
+        disagreement between two copies of an identifier neither of which is
+        used to locate a byte.
+
+        Silent when either side is absent: a file that declares no UUID, or
+        an ``.ibd`` shorter than its header, has nothing to compare and the
+        extent checks above already speak for the truncated case.
+        """
+        if self.ibd_file is None:
+            return
+
+        declared = None
+        try:
+            param_by_name = parser.metadata.file_description.param_by_name
+            value = param_by_name.get(ImzMLAccessions.UUID_NAME)
+            if isinstance(value, str):
+                # Vendors differ on the registry-format braces (IONTOF writes
+                # them, SCiLS does not) and on case; the hyphens are
+                # positional, not data. Compare the 32 hex digits alone.
+                declared = value.strip().strip("{}").replace("-", "").lower()
+        except AttributeError:
+            return
+        if not declared:
+            return
+
+        try:
+            here = self.ibd_file.tell()
+            self.ibd_file.seek(0)
+            header = self.ibd_file.read(16)
+            self.ibd_file.seek(here)
+        except OSError as e:
+            logger.debug("Could not read the .ibd UUID header: %s", str(e))
+            return
+        if len(header) != 16:
+            return
+
+        found = header.hex()
+        if found == declared:
+            return
+
+        name = self.ibd_path.name if self.ibd_path else ".ibd"
+        logger.warning(
+            "imzML declares binary-file UUID %s (IMS:1000080) but %s begins "
+            "with %s. The two are meant to be the same value, so either the "
+            "writer filled the two places independently, or %s is paired "
+            "with another acquisition's binary file. Reading continues -- the "
+            "offsets, not the UUID, locate the data -- but check the pair if "
+            "the spectra look wrong.",
+            declared,
+            name,
+            found,
+            self.imzml_path.name if self.imzml_path else "this .imzML",
+        )
 
     def _cache_all_coordinates(self) -> None:
         """Cache all coordinates for faster access.

--- a/uv.lock
+++ b/uv.lock
@@ -1782,50 +1782,6 @@ wheels = [
 ]
 
 [[package]]
-name = "lxml"
-version = "6.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ad/a9/970b8fa0ecc4fbf1dfaed0d89bbc1fc1421b25ec26a2038c91e872dc6c8e/lxml-6.1.2.tar.gz", hash = "sha256:1055241852f2b02068af4a625a5d32c087db193c12251928af2562ecd2239f18", size = 4210626, upload-time = "2026-08-19T04:58:15.341Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/a4/55eb54507073089ab27743c5da2113c84f0d0b1715b33175fdd943c9652d/lxml-6.1.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7d506bdba580ecb1a6ad2e2b5c49445e66d3e1f95894885739094393a1aad237", size = 8602111, upload-time = "2026-08-19T04:58:28.017Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/bf/6332f45d78da385bb01d5cac3fe4acda19f025d1307cbc7ad538355fecbb/lxml-6.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:12acd337d2821cb8b9247dfe4b7aa2f2769a3df5ae8511b7e550df42b8f4d3c3", size = 4638376, upload-time = "2026-08-19T04:58:41.181Z" },
-    { url = "https://files.pythonhosted.org/packages/68/e0/21fba0fe74d417fbe976903ae6bc77e92cdce01aae7b636abd87756f4588/lxml-6.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5078ff51e6316c0f75ea8127c2cd24374747fb351f62fb93d1761f8ae5a04a40", size = 4939689, upload-time = "2026-08-19T04:58:48.526Z" },
-    { url = "https://files.pythonhosted.org/packages/de/e5/ce3e885264fdd0bdcb6b49c1ea1842f94281b39e4ff956099e8d57532c60/lxml-6.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9477e14217c212e6023c994a71a1a349db19b0e10fd5bf189666b281ae63b1fd", size = 5105185, upload-time = "2026-08-19T04:59:15.533Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/b6/990a8446c488c70fa25681e150de94b7bf2eaaf387e374d195ab3c8faafb/lxml-6.1.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:261d98065326676d7253882db0198d0aa06748d7ee0443367acf10b148273f99", size = 5011863, upload-time = "2026-08-19T04:59:50.58Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/6a/f70f41363dae27e3bfd6224b128f5ba150874bd32ca4938552930ffa33b0/lxml-6.1.2-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0666943ee1576fa890a6dc6316ef42e8241b5dd56f67bc5475acb2ac298c6ca9", size = 5638234, upload-time = "2026-08-19T05:00:00.802Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/e0/a65b64f34d556925faef2c4f14167d58c571bc15a3e1f2bba71138830562/lxml-6.1.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04cf9e3f4ee9cab9d9ba05401bef8668840fa9620fcd4d8e85a2d2fd0b0fa960", size = 5244532, upload-time = "2026-08-19T05:00:07.516Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/a9/471552e015e954fc9d960aa27c3d67ebf489683d03f033399a790417c67c/lxml-6.1.2-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:9429d2371d406344ed1da5b5686d9412e74137c07b0171278368ff704f470ed5", size = 5358194, upload-time = "2026-08-19T05:00:22.747Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/0f/bc6248fbec2cc416f102b1267f1567e07510f6fa909bbe8cd2a22d6fb78e/lxml-6.1.2-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:eff128ffdc093cc6317955934ad9751105d37ed8dbca3ff4ccd751af6be37185", size = 4704432, upload-time = "2026-08-19T05:00:51.115Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/3f/cec859f50e63f1fa338fab43d2362d7543e1237f2475960d8ab0769de0eb/lxml-6.1.2-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ba58574d710b82ead7cbedea01cac3e110bc3ef82d4731519b74a2c11f7cf5e9", size = 5255038, upload-time = "2026-08-19T05:00:58.895Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/d9/2ced0cf2967115f92a1b8b3ae6bd18763abc3ebef88c98cf25145fda396c/lxml-6.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:52f6d4dff133c9778a24e9a2cfc1608930b15869866171aacc5131b5a418a003", size = 5054481, upload-time = "2026-08-19T05:01:10.096Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/f5/4f07386d3c88673daeec3b8cc09a2a4d39fa01c1fc49009791b0746d97fa/lxml-6.1.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:8807998c1023d1e9d60e02500f90e85a0752dbc0b670989806bba87b82dd5b42", size = 4785535, upload-time = "2026-08-19T05:01:18.909Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/5a/f4fe3ecbc189f48fba2547c5db5c940a10151d3e86b856a60a533a77e816/lxml-6.1.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:2170d0a280c877b6e2dc6738217db947be35dd8cf09ca458b355aa1bab2a9e70", size = 5655337, upload-time = "2026-08-19T05:01:41.324Z" },
-    { url = "https://files.pythonhosted.org/packages/92/c4/f586aa1bf27bfbace2dfdbb704da5c52f0bdece8ee440c8fb4946c940b2e/lxml-6.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c67f3c1278f942e97d8665c2a690324aaea5137de16f056583a21f0ac706177f", size = 5245778, upload-time = "2026-08-19T05:01:45.227Z" },
-    { url = "https://files.pythonhosted.org/packages/18/a1/677494bbaef4d6db5e4633af817414f478865850b55c03ae4bf70fa7b8ca/lxml-6.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:093fbf547d0f3ca02705381f795a050fbb58988be4aac7f79f99f280c4082313", size = 5267274, upload-time = "2026-08-19T05:01:57.687Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/71/b71425b8764d4cb7c92eb970483be7d5610dce2a6316242b5aaae7d260be/lxml-6.1.2-cp312-cp312-win32.whl", hash = "sha256:be365ce8d2d411cf2fb573747684b4fd470fa6224e0094d9d5a21155acc369d3", size = 3602563, upload-time = "2026-08-19T05:02:01.837Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/fb/909584e16d2148c1a252cc2c32dd99fe0e2682459c586d3d7a192e74a0ae/lxml-6.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:b97153ca609b434b712ddfb92cd6af101a7045a7724c542258bd4727a344472f", size = 4005965, upload-time = "2026-08-19T05:02:07.157Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/8d/41207c9212caad0b52749e34739fb9bfab67486729f52a8fe9bd9266fee6/lxml-6.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:7feb72424f19a893ae4f3373c7aae821b1aacb6076b708915c651f0683a97c49", size = 3666641, upload-time = "2026-08-19T05:02:11.3Z" },
-    { url = "https://files.pythonhosted.org/packages/61/2a/e9651f47a31a60b5cae031abc23391ed9aa30c8fc07571d1a38f58d6d770/lxml-6.1.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:351318f5c0eb7fcab5b4fdb507c6f88fb2c4b5e67784c7e5911448c91fffb5d4", size = 8590165, upload-time = "2026-08-19T04:58:40.489Z" },
-    { url = "https://files.pythonhosted.org/packages/61/87/a8098abaf35118767d1703b84c98940a5d833064e0eca39a00ecfe9840ab/lxml-6.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c0edde95e4b4278dcc0175eda06dc8aa2631ad9f83ae5dbdbc4f0925e200b0b0", size = 4632474, upload-time = "2026-08-19T04:58:47.465Z" },
-    { url = "https://files.pythonhosted.org/packages/93/cc/fe74d1def7f4fb967c4a825608a074d4dbdbb871b0d6bd59c6ed07d67868/lxml-6.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a8326e24ae6c3a6bfb03fa8b4793f9a5d804c125228aa067f652b0428e31b87c", size = 4936196, upload-time = "2026-08-19T04:59:03.477Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/ad/b96e6ca926e26726a99aa643602aac7411ecc1731ddb1b25af8cc57edfcd/lxml-6.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7c534ed898413f439b048130011e99a4245ee13d62d431f6b4f7f2484d02a93a", size = 5093290, upload-time = "2026-08-19T04:59:17.498Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/84/616f5d3b7cd086fcfba3e5add6fccda67f976c1c753ae9ed7bbd317cb9be/lxml-6.1.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e37fe49fe2d5aa40a2cb1cc8176673ad7de0d124e6f4a509d9318f5979c7871", size = 4998767, upload-time = "2026-08-19T04:59:28.385Z" },
-    { url = "https://files.pythonhosted.org/packages/80/88/d5b453a8d083483c9442ad7f5ac5c560796022eb5c80d60b65d75e449236/lxml-6.1.2-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9b52ea73a37fc64aa3357ff8607801d46dd170506d3cf8253a91a1d91639d4f9", size = 5626717, upload-time = "2026-08-19T04:59:40.045Z" },
-    { url = "https://files.pythonhosted.org/packages/71/45/31e5aa4d4bae024908ba1d03480c7425cf027a28b7e5c88d1b7202bd80cc/lxml-6.1.2-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8b9a92652e75e7731309ea51db5dee892eef414ce70a6ec3441e5d36bf5189f", size = 5232330, upload-time = "2026-08-19T04:59:46.175Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/5a/2627912420df8b2d31ba3014da5539f15ec85add01d42048864ffefda516/lxml-6.1.2-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:9088da25ecd609965f838d89fda0465a905b48f4dd90331db9845518f2177372", size = 5347054, upload-time = "2026-08-19T04:59:52.762Z" },
-    { url = "https://files.pythonhosted.org/packages/16/86/54ac0f529b22a8f12313726dd49e12961bb46471d9028cc28d2a29408f0b/lxml-6.1.2-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:0349321a0537d4fdbebb2af06dd1b64676132c72e2ae250de8cdb58f8c43019c", size = 4707275, upload-time = "2026-08-19T05:00:04.836Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/42/ffcdc6e4519be90df907cdae7e88409efb25d823ae4de8846f737dae1884/lxml-6.1.2-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b20440e578d269c5e8a722ab602ddd0f0cedb8b080006b3f936da9991a593d3b", size = 5240071, upload-time = "2026-08-19T05:00:19.604Z" },
-    { url = "https://files.pythonhosted.org/packages/68/49/5b1d7ab35f013f1127ec48f3108319f58b65b00d5cb26f215adbe86eadfb/lxml-6.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7766e525282dd38fd89567311323e441996eb958e8e816d16b38f782e3aecd2a", size = 5050356, upload-time = "2026-08-19T05:00:27.968Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/57/1cf049d054189b55c8fe8012269234f6602256949b69cd3ba80608a88219/lxml-6.1.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:9221442682c27417f10fe11184ea4cce174b25ab52465570b1f3ee3f85f320fa", size = 4780394, upload-time = "2026-08-19T05:00:39.047Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/ad/064488a8fa60e639fd773e421a18bf17541d02a95fbf36238ad7c65f69d4/lxml-6.1.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:75530642d8471327e691ab9b0513a5f9c77f38871014ceda40f51bb51765c0a1", size = 5645854, upload-time = "2026-08-19T05:03:42.697Z" },
-    { url = "https://files.pythonhosted.org/packages/85/bb/120e56f3cf1c149bb3b014278fb86d0a6dd552403981081f0ee0a0a57be7/lxml-6.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:678e35f1cbca98f55107511ee21a60568535c950f3c2371819bd64504c980d20", size = 5231132, upload-time = "2026-08-19T05:03:45.466Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/2c/7d49aab893c128671a3276580074cce4c002896145b8dd2893da79633bca/lxml-6.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c2bae42b3a09f977330a08f4a8fe72aec58c4bdb89069d3fe7272a71d885881", size = 5256076, upload-time = "2026-08-19T05:03:48.092Z" },
-    { url = "https://files.pythonhosted.org/packages/72/28/ddea3aa1fa9acfd384fe34d4a2a93eecc07541dd2d922fa9b140c60d8014/lxml-6.1.2-cp313-cp313-win32.whl", hash = "sha256:5848f3de6a8de8a93cff9f068134393ff5fa69ac2a04399f7d49cd67c61c348c", size = 3602177, upload-time = "2026-08-19T05:03:50.571Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/7a/96bac167538748cae2544335855f812fa33e49a9a67bc8b8520dcbd592bd/lxml-6.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:6cb0c87421946030b92b558be416852780a912454e3dcba0998e4497c9c588d5", size = 4004117, upload-time = "2026-08-19T05:03:53.074Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/24/9498fa3c84135956e5ef55ea4d8bd11e999e381f7f210fb6f8c6a980ef03/lxml-6.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:648861c19b775b89ebefa14586f85090b10163367476d77f242c4131c835ce73", size = 3665412, upload-time = "2026-08-19T05:03:55.621Z" },
-]
-
-[[package]]
 name = "markdown"
 version = "3.10.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3836,7 +3792,6 @@ dependencies = [
     { name = "defusedxml" },
     { name = "geopandas" },
     { name = "imagecodecs" },
-    { name = "lxml" },
     { name = "numpy" },
     { name = "ome-zarr" },
     { name = "pandas" },
@@ -3891,7 +3846,6 @@ requires-dist = [
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "geopandas", specifier = ">=0.9.0" },
     { name = "imagecodecs", specifier = ">=2024.1.1" },
-    { name = "lxml", specifier = ">=4.6.0" },
     { name = "numpy", specifier = ">=2.0.0,<3" },
     { name = "ome-zarr", specifier = ">=0.16.0,<0.19" },
     { name = "pandas", specifier = ">=2.0.0,<4" },


### PR DESCRIPTION
Last of the six release batches from the 2026-09-08 robustness sweep. This one is dependency metadata, a deploy race, and a bag of cosmetic leftovers — plus one issue that is **blocked on a credential and has been taken out of the milestone rather than half-configured**.

**Batch 6 closes three issues, not four.** #224 is deferred; see below.

Closes #222
Closes #223
Closes #261

---

## What changes for users

- **`lxml` is no longer installed by `pip install thyra`.** Nothing in Thyra imported it. A fresh `pip install .` drops from 264 to 263 resolved packages; `lxml 6.1.2` is the only removal, nothing was added, no version moved. If your own code imports `lxml` and relied on Thyra to pull it in, declare it yourself.
- **Three Python-API arguments now fail loudly instead of quietly.** All three come back the way every refusal has since #234 — one `ERROR` line saying what to do, `convert_msi` returns `False`, the CLI exits 1:
  - `streaming=` accepts only `True`, `False` and `"auto"`. `"yes"`, `None`, `1` and — the sharp one — `0` used to convert in silence.
  - `max_mass_axis_length=` must be a positive integer or `None`. `-1`, `0` and `2.5` used to be accepted and then refuse every file for "exceeding" a cap it could not satisfy.
  - Neither is a CLI flag; click already validates the CLI. **No new flags** (one flag per concept).
- **An imzML whose `IMS:1000080` disagrees with its `.ibd` header now says so, at `WARNING`.** Reading continues. Nothing is refused and no stored value changes.
- **The docs site deploy builds `main`.** Re-running an old docs run now publishes today's docs rather than reproducing that run's build.

No stored value changes. No exit status changes for any input that worked before.

---

## #222 — `lxml` was a declared runtime dependency that nothing imports

Removed, with a comment in `pyproject.toml` saying why it is *not* there — the inverse of the `click` case #158 fixed.

**The one experiment the issue asked for, run against the installed package rather than the docs:**

| question | answer |
|---|---|
| Does pyimzML import `lxml` at module scope? | **No.** It is imported inside `choose_iterparse()`, and only when the caller passes `parse_lib="lxml"`. |
| …on 1.4.0, the declared floor? | **Also no** — same function, and there the `else` branch is `try: lxml / except ImportError: ElementTree`, so it is guarded even when nobody asks. 1.5.5's `else` goes straight to ElementTree. |
| Does pyimzML declare it? | **No.** `Requires-Dist` is `numpy, wheezy.template` on both versions. So Thyra was *not* covering for a missing upstream declaration. |
| Is it reachable from another dependency's closure? | **No.** Every other requirer wants it behind an extra Thyra does not request — `pandas[xml]`, `tifffile[xml]`, `fonttools[lxml]`, `beautifulsoup4[lxml]`, `networkx[extra]`, `mypy[reports]`. `thyra` was the only unconditional one. |

Thyra's single `ImzMLParser` call site passes `parse_lib="ElementTree"` on purpose and is pinned by a test: the unmaintained upstream prunes each `<spectrum>` out of the tree, and under lxml that misreports `ERR_NO_MEMORY` as an `xmlSAX2Characters` failure.

**Resolved-set diff, regenerated not hand-edited.** `uv.lock` went 264 → 263 packages: `lxml 6.1.2` removed, nothing added, no version changed. `uv` is not installed on this machine, so it was installed into the throwaway worktree venv (`uv 0.12.11`) purely to run `uv lock`; nothing about the machine changed and `uv.lock` was never touched by hand.

**Verified beyond unit tests**, because the failure mode is an XML parser missing at parse time:

- fresh venv, plain `pip install .` → 113 packages, `lxml` neither importable nor in the distribution list, `thyra --version` runs;
- `pytest -m integration` on the real `pea.imzML`.

**Commit type is `fix:`, deliberately.** `build:` is in this repo's `allowed_tags` but in neither `minor_tags` nor `patch_tags`, so it computes no version bump and PyPI would keep serving the old metadata. This `fix:` is also the only releasable commit in the batch — everything else here is `docs:`/`ci:`/`test:`, which are non-releasable.

## #223 — docs.yml serialised deploys without ordering them

`concurrency: pages-deploy` serialises runs, but GitHub's workflow-syntax documentation says, verbatim, that **"ordering is not guaranteed"** — so an older run admitted second would build its own older checkout and force-push stale docs, both runs green, nothing in either log.

The deploy now checks out `${{ github.event_name == 'push' && 'main' || github.ref }}`. Whichever run executes last builds current `main`, so the site is right regardless of admission order: correct by construction rather than by timing.

Conditional rather than a hardcoded `main` so a deliberate `workflow_dispatch` against another ref still deploys that ref instead of silently deploying main. `release.yml`'s `deploy-docs` job dispatches with `--ref main` already, so the release path is identical either way.

Recorded as **D17**, including the accepted cost: re-running an old docs run now publishes today's docs, and `gh-deploy`'s `Deployed <sha>` stops matching the run's trigger.

*(Item A of the original file — whether a release rebuilds the docs — was confirmed done before this branch and is not in scope.)*

## #261 — cosmetic leftovers: five items, not eight

Three of the eight had already been fixed by earlier batches. Re-measured on `main` at batch 5 before writing anything:

| # | state | what happened here |
|---|---|---|
| 1 | **the issue was right, the handoff was wrong** | The keyword is *not* swallowed by `**kwargs`. It reaches the converter, which raises `ConversionRefused`; `convert_msi`'s handler logs it once at `ERROR` and returns `False` — exactly what it does for every refusal. **The code is consistent and D10's wording was the defect**, so D10 is corrected and both behaviours are pinned by tests. Changing `convert_msi` to re-raise for this one keyword would have broken its documented contract. |
| 2 | fixed | The out-of-grid warning no longer ends in changelog prose ("Previously they were written to a wrapped-round row index…"); it says what the skipped spectra are instead. |
| 3 | **already fixed** (#241, batch 3/4) | `non_empty_pixels` is set from `sum(unit.n_rows)`. No change. |
| 4 | fixed | `docs/cli.md`'s "Grouped help" tip listed a `Performance` group that no longer renders and omitted `Ion mobility grid (advanced)`. Rewritten against the nine groups `--help` actually prints today, and it now names the one page section with no matching group. |
| 5 | fixed | See below — the one item with real design content. |
| 6 | fixed | `streaming` and `max_mass_axis_length` validated; see "What changes for users". |
| 7 | fixed | `base_converter.py` no longer names the removed `SpatialData3DConverter` as a live cause; `docs/coordinate-systems.md` no longer tells a reader to check a `use_csc=True` that has not existed since v3.22. Also folded in: `convert_msi`'s docstring documented `**kwargs` twice, once in full and once as a bare stub. |
| 8 | **already fixed** (`423da85`, batch 3) | `pre-commit run --all-files` is clean on `main`. Confirmed. |

### Item 5 — the `.ibd` UUID check, and why it warns

The imzML spec puts the binary file's UUID in the first 16 bytes of the `.ibd` and the same value in the XML as `IMS:1000080`. Thyra read the XML term for the metadata store and never compared them. That pair is the **only** check that can tell an `.imzML` apart from a *different* acquisition's `.ibd` renamed to sit beside it — every other check reads the XML's own offsets against the binary's size, which a wrong-but-plausible pairing satisfies.

It **warns**. It does not refuse, and that is measured:

| file | writer | declared `IMS:1000080` | first 16 bytes of `.ibd` |
|---|---|---|---|
| `pea` | SCiLS | `9069a51f-11a8-4f15-aabb-43624def10d0` | same |
| Xenium export | SCiLS | `6c176aa6-5cf8-4027-8661-657695f2d400` | same |
| `bellini` | IONTOF SurfaceLab 7.5 | `{FC37F303-A9C0-4CD3-A28E-1D18E523C269}` | `3ad1bacd-dcc3-4f7b-aea7-f9b375dbf731` |

`bellini`'s first spectrum starts at byte 16, so the header slot is there and populated — the writer simply put two different values in the two places. That file passes every other check and converts correctly. **One real file in three is not a rare shape**, and a refusal would reject data Thyra reads right today over a disagreement between two copies of an identifier that never locates a byte.

Only the 32 hex digits are compared: IONTOF writes the registry braces, SCiLS does not, case varies, and the hyphens are positional. Silent when either side is absent.

`TestRealFilesAreStillAccepted` now lists `bellini`'s warning by prefix rather than dropping its "no warnings" assertion — any *other* message from a real file still fails.

## #224 — deferred, and taken out of the milestone

Blocked on a credential, which is why this PR closes three issues. Re-measured read-only (nothing created, nothing deleted) and written up as **D18** plus a comment on the issue. In short:

- `release.yml` still pushes with `GITHUB_TOKEN`, so the four cases measured on 2026-08-01 still apply. `main` is still unprotected (404); the one ruleset that exists (`no force-push, no deletion`) does not block a fast-forward push and **must not be deleted** — the issue's cleanup instruction is stale on that point.
- The `gh` token still lacks `admin:org`, so route 3 stays unrunnable non-interactively.
- **The check list is eleven contexts now, not seven** — four `integration (os, py)` jobs joined. The config JSON in the issue is stale.
- **Batching the releases did not fix this.** It changes *when* semantic-release pushes the version commit, not *what* that push is.
- More usefully: the risk this issue was opened for is **already closed by a different mechanism**. `release.yml` waits for the `Tests` run on the exact commit it is about to release and fails closed if it is absent, incomplete or unsuccessful. Required checks would add "a red PR cannot be merged"; they would not add "a red commit cannot reach PyPI".

A repository that cannot cut a release is worse than one without required checks, so nothing was turned on.

---

## Verification

| check | result |
|---|---|
| `pytest` | **2553 passed, 13 skipped, 0 failed** (baseline on `main` re-measured here: 2524/13/0 — +29 is the 29 new tests) |
| `pytest -m integration` | **54 passed, 11 skipped, 0 failed** — identical to the baseline, and it is what exercises `pea.imzML` without `lxml` installed |
| `pre-commit run --all-files` (after `git add -A`) | clean |
| fresh-venv `pip install .` | 113 packages, `lxml` neither importable nor in the distribution list, `thyra --version` runs |
| `uv lock` | 264 → 263 packages; `lxml 6.1.2` removed, nothing added, no version changed |
| radon CC on changed files | `convert_msi` 13 before and after, `_initialize_parser` 12 before and after; threshold is 15 |

Two commits: the `fix:` carries the batch (`ci:` is non-releasable here, so
without it this PR would compute no version bump at all).
