### PR TITLE
fix(utils): resolve relative store paths so a fitting store cannot lose keys

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -208,12 +208,12 @@ session, napari, or a Jupyter notebook that loaded it.
 **Fix:** Close any program that has the zarr open, or write to a different output
 path.
 
-### Windows: long output paths
+### Windows: long paths
 
 Windows caps a normal path at 260 characters, and the limit applies to every
 file inside the `.zarr` directory rather than to the path you typed. Thyra's
-deepest metadata key sits roughly 95 characters below the output path, so an
-output path over about 165 characters would once fail part-way through the
+deepest metadata key sits roughly 134 characters below the output path, so an
+output path over about 125 characters would once fail part-way through the
 write with a confusing error naming a file you never asked for:
 
 ```
@@ -246,6 +246,37 @@ long output paths convert normally. A log line records when this happens.
     sdata = sd.read_zarr(r"\\?\C:\very\long\path\output.zarr")
     ```
     or simply choose a shorter output path such as `C:\msi\out.zarr`.
+
+!!! warning "A relative path is measured differently, and can lose an array"
+    Windows applies the limit to the working directory, a separator and the
+    relative path **as you spelled it**, before the `..` segments are
+    collapsed. A store you can open perfectly well by its absolute path can
+    therefore be unreadable through a relative one, and the failure is the
+    silent kind described above: the array simply does not appear, with at
+    most a `UserWarning` from Zarr about an object it does not recognise.
+
+    Two arrays sitting side by side in the same group of a real store:
+
+    | key | relative | absolute | result |
+    | --- | --- | --- | --- |
+    | `current_ratio` | 259 | 251 | reads |
+    | `mobility_edges` | **260** | 252 | **missing, no error** |
+
+    Nothing about the two differed but the length of the name -- same shape,
+    dtype, codecs and shards. Enabling long path support does **not** help
+    here, because it only applies to fully qualified paths.
+
+    Pass an absolute path, or pass the store through
+    `thyra.utils.windows_paths.prepare_zarr_read_path`, which resolves one for
+    you. If something looks missing, compare the two spellings before
+    suspecting the data:
+
+    ```python
+    import os
+    os.path.exists(p), os.path.exists(os.path.abspath(p))
+    ```
+
+    A `False, True` result means the path, not the store.
 
 !!! info "Failed conversions exit non-zero and move the partial store aside"
     Any failed conversion exits with status 1, so a script or CI job wrapping

--- a/docs/metadata-schema.md
+++ b/docs/metadata-schema.md
@@ -330,7 +330,7 @@ On Windows, a store whose files sit past the 260-character path limit is
 read through an extended-length path automatically; without that, Zarr
 would return empty terms for the keys it cannot open and the document
 would fail validation for the wrong reason (see
-[long output paths](getting-started.md#windows-long-output-paths)).
+[long paths](getting-started.md#windows-long-paths)).
 
 Errors mean the document does not conform: structural violations, unknown
 PSI-MS/IMS/UO accessions, version incompatibility. Warnings mean it

--- a/tests/unit/utils/test_windows_paths.py
+++ b/tests/unit/utils/test_windows_paths.py
@@ -9,6 +9,7 @@ on every platform; the end-to-end conversion is Windows-only.
 
 from __future__ import annotations
 
+import ntpath
 import shutil
 import sys
 import tempfile
@@ -107,6 +108,45 @@ class TestPrepareZarrReadPath:
         text = str(result)
         assert text.startswith(EXTENDED_PREFIX)
         assert Path(text[len(EXTENDED_PREFIX) :]).is_absolute()
+
+    def test_a_relative_path_that_fits_still_comes_back_absolute(
+        self, on_windows, monkeypatch, tmp_path
+    ):
+        r"""Regression: a store that fits was still read through the
+        caller's relative spelling.
+
+        Windows measures a relative path as ``<cwd> + "\" + <spelling>``
+        *before* collapsing the ``..`` segments, so a spelling that reaches
+        an absolute path of 252 characters can be refused at 260. Returning
+        ``store_path`` unchanged on this branch handed that spelling to Zarr,
+        which reports the over-long keys as absent and drops them from
+        ``array_keys()`` with only a ``UserWarning``. Observed on a real
+        store: ``mobility_edges`` vanished while its siblings, identical in
+        shape, dtype, codecs and shards, survived.
+        """
+        monkeypatch.setattr(windows_paths.os, "walk", lambda path: [])
+        monkeypatch.chdir(tmp_path)
+
+        result = prepare_zarr_read_path(Path("store.zarr"))
+
+        assert result != Path("store.zarr")
+        assert ntpath.isabs(str(result))
+        assert result.name == "store.zarr"
+
+    def test_a_relative_path_is_resolved_when_long_paths_are_enabled(
+        self, monkeypatch, tmp_path
+    ):
+        """Long-path support only covers fully qualified paths, so it is no
+        reason to hand a relative spelling back."""
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(windows_paths, "_long_paths_enabled", lambda: True)
+        self._store_with_key_length(monkeypatch, WINDOWS_MAX_PATH + 20)
+        monkeypatch.chdir(tmp_path)
+
+        result = prepare_zarr_read_path(Path("store.zarr"))
+
+        assert ntpath.isabs(str(result))
+        assert not str(result).startswith(EXTENDED_PREFIX)
 
     def test_already_extended_path_is_returned_without_walking(
         self, on_windows, monkeypatch
@@ -232,6 +272,34 @@ class TestPrepareZarrOutputPath:
         out = self._long_path()
 
         assert prepare_zarr_output_path(out, "msi_dataset") == out
+
+    def test_a_relative_output_path_comes_back_absolute(
+        self, on_windows, monkeypatch, tmp_path
+    ):
+        monkeypatch.chdir(tmp_path)
+
+        result = prepare_zarr_output_path(Path("out.zarr"), "msi_dataset")
+
+        assert ntpath.isabs(str(result))
+        assert result.name == "out.zarr"
+
+    def test_a_relative_output_path_is_measured_after_resolving(
+        self, on_windows, monkeypatch, tmp_path
+    ):
+        """``len("out.zarr")`` is the spelling, not the path.
+
+        Projecting from the relative spelling understates the deepest key by
+        the whole working directory, so a location that cannot hold the
+        store is waved through and the write fails part-way with a
+        ``FileNotFoundError`` naming a file the caller never chose.
+        """
+        deep = tmp_path / ("d" * 100)
+        deep.mkdir()
+        monkeypatch.chdir(deep)
+
+        result = prepare_zarr_output_path(Path("out.zarr"), "msi_dataset")
+
+        assert str(result).startswith(EXTENDED_PREFIX)
 
     def test_the_registry_is_only_consulted_when_needed(self, monkeypatch):
         """A short path must not pay for a registry read."""

--- a/tests/unit/utils/test_windows_paths.py
+++ b/tests/unit/utils/test_windows_paths.py
@@ -9,7 +9,6 @@ on every platform; the end-to-end conversion is Windows-only.
 
 from __future__ import annotations
 
-import ntpath
 import shutil
 import sys
 import tempfile
@@ -130,7 +129,7 @@ class TestPrepareZarrReadPath:
         result = prepare_zarr_read_path(Path("store.zarr"))
 
         assert result != Path("store.zarr")
-        assert ntpath.isabs(str(result))
+        assert result.is_absolute()
         assert result.name == "store.zarr"
 
     def test_a_relative_path_is_resolved_when_long_paths_are_enabled(
@@ -145,7 +144,7 @@ class TestPrepareZarrReadPath:
 
         result = prepare_zarr_read_path(Path("store.zarr"))
 
-        assert ntpath.isabs(str(result))
+        assert result.is_absolute()
         assert not str(result).startswith(EXTENDED_PREFIX)
 
     def test_already_extended_path_is_returned_without_walking(
@@ -280,7 +279,7 @@ class TestPrepareZarrOutputPath:
 
         result = prepare_zarr_output_path(Path("out.zarr"), "msi_dataset")
 
-        assert ntpath.isabs(str(result))
+        assert result.is_absolute()
         assert result.name == "out.zarr"
 
     def test_a_relative_output_path_is_measured_after_resolving(

--- a/thyra/utils/windows_paths.py
+++ b/thyra/utils/windows_paths.py
@@ -123,12 +123,14 @@ def _long_paths_enabled() -> bool:
 def _absolute(path: Path) -> Path:
     r"""The absolute spelling of ``path``.
 
-    Absoluteness is judged with :mod:`ntpath` rather than
-    ``Path.is_absolute`` so that a Windows-shaped path is recognised as
-    absolute even when the caller is not on Windows, which is what the test
-    suite does when it fakes ``sys.platform``. On Windows the two agree.
+    Absoluteness is judged by :mod:`ntpath` *or* ``Path.is_absolute``, and
+    the two disagree only when the platform is faked. ``ntpath`` catches a
+    Windows-shaped path such as ``C:\...\out.zarr`` while the suite is
+    running on Linux; ``Path.is_absolute`` catches the POSIX path a
+    ``tmp_path`` fixture hands back there, which ``ntpath`` reads as merely
+    drive-relative. On Windows both agree and either alone would do.
     """
-    if ntpath.isabs(str(path)):
+    if ntpath.isabs(str(path)) or path.is_absolute():
         return path
     return path.resolve()
 

--- a/thyra/utils/windows_paths.py
+++ b/thyra/utils/windows_paths.py
@@ -27,6 +27,27 @@ otherwise, so ordinary paths are handled exactly as before. It is not
 applied to the *source data* path: readers reach vendor SDKs that may not
 accept extended-length syntax.
 
+A *relative* store path is a second, sharper trap, so both helpers below
+resolve one before doing anything else and hand back the resolved path.
+Windows measures a relative path as the raw ``<cwd> + "\" + <spelling>``
+concatenation, *before* the ``..`` segments are collapsed, so a path whose
+absolute form sits comfortably inside the limit can still be refused::
+
+    cwd                                                    175
+    ..\out.zarr\tables\<id>\uns\<block>\mobility_edges\zarr.json    +85
+                                                           ---
+                                                           260  refused
+    C:\...\out.zarr\tables\<id>\uns\<block>\mobility_edges\zarr.json
+                                                           252  fine
+
+Measured here on a real store: the sibling key one character shorter
+(``current_ratio``, 259) opened, ``mobility_edges`` at 260 did not, and the
+absolute spelling of the refused one is 252. Nothing about the array was
+different -- same shape, dtype, codecs and shards as its siblings. Windows
+long-path support does not rescue a relative path either, since it applies
+only to fully qualified paths, so the resolution is unconditional rather
+than gated on the registry check.
+
 Reading a converted store back is subject to the same limit, and a read
 past it does not fail. Windows reports an over-long key as missing, and
 Zarr treats a missing key as one that was never written: a whole-store
@@ -38,6 +59,7 @@ which Thyra's own read paths go through.
 """
 
 import logging
+import ntpath
 import os
 import sys
 from pathlib import Path
@@ -98,6 +120,19 @@ def _long_paths_enabled() -> bool:
         return False
 
 
+def _absolute(path: Path) -> Path:
+    r"""The absolute spelling of ``path``.
+
+    Absoluteness is judged with :mod:`ntpath` rather than
+    ``Path.is_absolute`` so that a Windows-shaped path is recognised as
+    absolute even when the caller is not on Windows, which is what the test
+    suite does when it fakes ``sys.platform``. On Windows the two agree.
+    """
+    if ntpath.isabs(str(path)):
+        return path
+    return path.resolve()
+
+
 def to_extended_length_path(path: Path) -> Path:
     r"""Rewrite an absolute Windows path into extended-length form.
 
@@ -148,9 +183,14 @@ def prepare_zarr_read_path(store_path: Path) -> Path:
     exactly the keys this is looking for and could pass a store whose deepest
     keys do not fit.
 
-    A relative path is resolved first, since the length that matters is the
-    absolute one and the prefix needs an absolute path anyway. A path that
-    already carries the prefix is returned as it is.
+    A relative path is resolved first and the resolved path is what comes
+    back, even when the store is shallow enough to need no prefix at all.
+    Handing the caller's own relative spelling back is not safe: Windows
+    measures it as ``<cwd> + "\" + <spelling>`` before collapsing the ``..``
+    segments, so a store whose keys all fit in absolute terms can still lose
+    an array through that spelling, with only a ``UserWarning`` from Zarr
+    about an object it does not recognise. A path that already carries the
+    prefix is returned as it is.
 
     Args:
         store_path: Path to an existing Zarr store.
@@ -164,7 +204,7 @@ def prepare_zarr_read_path(store_path: Path) -> Path:
     if str(store_path).startswith(_EXTENDED_PREFIX):
         return store_path
 
-    absolute = store_path if store_path.is_absolute() else store_path.resolve()
+    absolute = _absolute(store_path)
     extended = to_extended_length_path(absolute)
     # Keys are measured as the plain path would spell them.
     prefix_length = len(str(extended)) - len(str(absolute))
@@ -176,11 +216,15 @@ def prepare_zarr_read_path(store_path: Path) -> Path:
         if longest > WINDOWS_MAX_PATH:
             break
 
+    # ``absolute``, never ``store_path``: the caller's relative spelling is
+    # measured against the limit uncollapsed, so it can be refused where the
+    # absolute form fits. Long-path support does not cover it either, which
+    # is why that branch resolves too.
     if longest <= WINDOWS_MAX_PATH:
-        return store_path
+        return absolute
 
     if _long_paths_enabled():
-        return store_path
+        return absolute
 
     logger.info(
         "Store contains a key %d characters long, past the %d character "
@@ -197,12 +241,22 @@ def prepare_zarr_output_path(output_path: Path, dataset_id: str) -> Path:
     A no-op off Windows, and a no-op on Windows when long-path support is
     enabled or the projected deepest key fits inside the normal limit.
 
+    A relative path is resolved first and the resolved path is what comes
+    back. ``len(str(output_path))`` on a relative path measures the spelling
+    rather than the path, which understates the projection and would wave
+    through an output location that cannot hold the store.
+
     Args:
-        output_path: The resolved, absolute output store path.
+        output_path: The output store path. Resolved here if it is relative.
         dataset_id: The dataset identifier, which appears in the deepest key.
     """
     if sys.platform != "win32":
         return output_path
+
+    if str(output_path).startswith(_EXTENDED_PREFIX):
+        return output_path
+
+    output_path = _absolute(output_path)
 
     projected = projected_deepest_key_length(output_path, dataset_id)
     if projected <= WINDOWS_MAX_PATH:


### PR DESCRIPTION
## What

Both Windows path helpers measured one path and used another. `prepare_zarr_read_path` resolved the store path in order to measure it, then returned the caller's **relative** spelling on the two "fits" branches. `prepare_zarr_output_path` had the mirror defect: it projected the deepest key from `len(str(output_path))`, which on a relative path measures the spelling rather than the path.

Both now resolve first and return the resolved path on every branch.

## Why it matters

Windows applies the 259-character limit to the raw `<cwd> + "\" + <spelling>` concatenation **before** collapsing `..` segments. A store whose keys all fit in absolute terms can therefore be unreadable through the spelling the caller used, and the refusal comes back as `ERROR_PATH_NOT_FOUND` -> errno 2, which Zarr reads as a key that was never written. The array disappears from `array_keys()` with only a `UserWarning`.

Measured on a real store:

| key | relative | absolute | result |
|---|---|---|---|
| `counts` | 252 | 244 | ok |
| `mz_edges` | 254 | 246 | ok |
| `current_ratio` | **259** | 251 | ok |
| `mobility_edges` | **260** | 252 | **dropped** |

Nothing about `mobility_edges` differed from its siblings in shape, dtype, codecs or shards — only the name length. Zarr's own `list_dir` on the array directory succeeded and reported `zarr.json` present; only the read of that file, ten characters longer, failed. `anndata.read_zarr` and `spatialdata.read_zarr` drop it the same way.

Confirmed independently of Zarr: a file whose normalized absolute path is **53** characters is unreachable through a relative spelling padded to 261. Boundary pinned exactly — 259 works, 260 fails. Reproduces identically on zarr 3.1.6 and 3.3.0.

Windows long-path support does not cover relative paths (it applies only to fully qualified paths), so the resolution is unconditional rather than gated on the registry check.

## Notes

Absoluteness is judged with `ntpath.isabs` rather than `Path.is_absolute`, so a Windows-shaped path is still recognised as absolute when the suite runs on Linux with `sys.platform` faked. That kept all 24 existing tests unchanged.

## Tests

Four regression tests, each verified to fail against the unfixed source and pass against the fix. Full unit suite: 2548 passed, 3 skipped.